### PR TITLE
Add http(s) proxy support

### DIFF
--- a/charts/k8s-watcher/Chart.yaml
+++ b/charts/k8s-watcher/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 name: k8s-watcher
 description: Watches and send kubernetes resource-related events
 icon: https://raw.githubusercontent.com/komodorio/helm-charts/master/placeholder-logo.png
-version: 0.1.18
+version: 0.1.19
 appVersion: 0.1.10

--- a/charts/k8s-watcher/README.md
+++ b/charts/k8s-watcher/README.md
@@ -98,6 +98,10 @@ The following table lists the configurable parameters of the chart and their def
 | `image.pullPolicy`                        | Image pull policy                                                        | `Always`                                   |
 | `serviceAccount.create`                   | Creates a service account                                                | `true`                                     |
 | `serviceAccount.name`                     | Optional name for the service account                                    | `{RELEASE_FULLNAME}`                       |
+| `proxy.enabled`                           | Configure proxy for watcher                                              | `true`                                     |
+| `proxy.http`                              | Configure Proxy setting (HTTP_PROXY)                                     | ``                                         |
+| `proxy.https`                             | Configure Proxy setting (HTTPS_PROXY)                                    | ``                                         |
+| `proxy.no-proxy`                          | Configure Proxy setting (NO_PROXY)                                       | ``                                         |
 
 
 

--- a/charts/k8s-watcher/README.md
+++ b/charts/k8s-watcher/README.md
@@ -101,7 +101,7 @@ The following table lists the configurable parameters of the chart and their def
 | `proxy.enabled`                           | Configure proxy for watcher                                              | `true`                                     |
 | `proxy.http`                              | Configure Proxy setting (HTTP_PROXY)                                     | ``                                         |
 | `proxy.https`                             | Configure Proxy setting (HTTPS_PROXY)                                    | ``                                         |
-| `proxy.no-proxy`                          | Configure Proxy setting (NO_PROXY)                                       | ``                                         |
+| `proxy.no_proxy`                          | Configure Proxy setting (NO_PROXY)                                       | ``                                         |
 
 
 

--- a/charts/k8s-watcher/templates/_proxy_conf.tpl
+++ b/charts/k8s-watcher/templates/_proxy_conf.tpl
@@ -1,0 +1,15 @@
+{{- define "k8s-watcher.proxy-conf" -}}
+{{- if .Values.proxy.enabled }}
+{{- if .Values.proxy.http }}
+            - name: HTTP_PROXY
+              value: {{ .Values.proxy.http }}
+{{- end }}
+{{- if .Values.proxy.https }}
+            - name: HTTPS_PROXY
+              value: {{ .Values.proxy.https }}
+{{- end }}
+{{- if .Values.proxy.no_proxy }}
+            - name: NO_PROXY
+              value: {{ .Values.proxy.no_proxy }}
+{{- end }}
+{{- end }}{{- end }}

--- a/charts/k8s-watcher/templates/deployment.yaml
+++ b/charts/k8s-watcher/templates/deployment.yaml
@@ -45,20 +45,7 @@ spec:
                   name: {{ include "k8s-watcher.name" . }}-secret
                   key: kialiApiKey
 {{- end }}
-{{- if .Values.proxy.enabled }}
-{{- if .Values.proxy.http }}
-            - name: HTTP_PROXY
-              value: {{ .Values.proxy.http }}
-{{- end }}
-{{- if .Values.proxy.https }}
-            - name: HTTPS_PROXY
-              value: {{ .Values.proxy.https }}
-{{- end }}
-{{- if .Values.proxy.no_proxy }}
-            - name: NO_PROXY
-              value: {{ .Values.proxy.no_proxy }}
-{{- end }}
-{{- end }}
+{{- include "k8s-watcher.proxy-conf" . }}
           ports:
             - name: http-healthz
               containerPort: {{ .Values.watcher.servers.healthCheck.port | default 8090 }}

--- a/charts/k8s-watcher/templates/deployment.yaml
+++ b/charts/k8s-watcher/templates/deployment.yaml
@@ -47,15 +47,15 @@ spec:
 {{- end }}
 {{- if .Values.proxy.enabled }}
 {{- if .Values.proxy.http }}
-            - name: http_proxy
+            - name: HTTP_PROXY
               value: {{ .Values.proxy.http }}
 {{- end }}
 {{- if .Values.proxy.https }}
-            - name: https_proxy
+            - name: HTTPS_PROXY
               value: {{ .Values.proxy.https }}
 {{- end }}
 {{- if .Values.proxy.no_proxy }}
-            - name: no_proxy
+            - name: NO_PROXY
               value: {{ .Values.proxy.no_proxy }}
 {{- end }}
 {{- end }}

--- a/charts/k8s-watcher/templates/deployment.yaml
+++ b/charts/k8s-watcher/templates/deployment.yaml
@@ -54,9 +54,9 @@ spec:
             - name: https_proxy
               value: {{ .Values.proxy.https }}
 {{- end }}
-{{- if .Values.proxy.no-proxy }}
+{{- if .Values.proxy.no_proxy }}
             - name: no_proxy
-              value: {{ .Values.proxy.no-proxy }}
+              value: {{ .Values.proxy.no_proxy }}
 {{- end }}
 {{- end }}
           ports:

--- a/charts/k8s-watcher/templates/deployment.yaml
+++ b/charts/k8s-watcher/templates/deployment.yaml
@@ -45,6 +45,20 @@ spec:
                   name: {{ include "k8s-watcher.name" . }}-secret
                   key: kialiApiKey
 {{- end }}
+{{- if .Values.proxy.enabled }}
+{{- if .Values.proxy.http }}
+            - name: http_proxy
+              value: {{ .Values.proxy.http }}
+{{- end }}
+{{- if .Values.proxy.https }}
+            - name: https_proxy
+              value: {{ .Values.proxy.https }}
+{{- end }}
+{{- if .Values.proxy.no-proxy }}
+            - name: no_proxy
+              value: {{ .Values.proxy.no-proxy }}
+{{- end }}
+{{- end }}
           ports:
             - name: http-healthz
               containerPort: {{ .Values.watcher.servers.healthCheck.port | default 8090 }}

--- a/charts/k8s-watcher/values.yaml
+++ b/charts/k8s-watcher/values.yaml
@@ -13,6 +13,12 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   # name: ""
 
+proxy:
+  enabled: false
+  http: ""
+  https: ""
+  no-proxy: ""
+
 resources:
   limits:
     cpu: 500m

--- a/charts/k8s-watcher/values.yaml
+++ b/charts/k8s-watcher/values.yaml
@@ -17,7 +17,7 @@ proxy:
   enabled: false
   http: ""
   https: ""
-  no-proxy: ""
+  no_proxy: ""
 
 resources:
   limits:


### PR DESCRIPTION
Tested:
`helm template . --set apiKey=test --set proxy.enabled=false --set proxy.https=https://test.com --set proxy.http=http://aaa.com`
`helm template . --set apiKey=test --set proxy.enabled=true --set proxy.https=https://test.com --set proxy.http=http://aaa.com`
`helm template . --set apiKey=test --set proxy.enabled=true --set proxy.https=https://test.com`
`helm template . --set apiKey=test --set proxy.enabled=true  --set proxy.http=http://aaa.com`
`helm template . --set apiKey=test --set proxy.enabled=true  --set proxy.https=https://aaa.com --set proxy.no_proxy=*aaa.io`