### PR TITLE
Allow Komodor api key to be provided by an existing kubnernetes secret

### DIFF
--- a/charts/k8s-watcher/Chart.yaml
+++ b/charts/k8s-watcher/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 name: k8s-watcher
 description: Watches and send kubernetes resource-related events
 icon: https://raw.githubusercontent.com/komodorio/helm-charts/master/placeholder-logo.png
-version: 0.1.39
+version: 0.1.40
 appVersion: 0.1.33

--- a/charts/k8s-watcher/README.md
+++ b/charts/k8s-watcher/README.md
@@ -35,6 +35,10 @@ The command deploys the Komodor K8S-Watcher on the Kubernetes cluster in the def
 
 > **Tip**: List all releases using `helm list`
 
+## Api Key
+
+The Komodor kubernetes api key can provided in the helm upgrade command or `values.yaml` file or can be taken from an existing kubernetes secret resource.
+When using an existing kubernetes secret resource, specify the secret name in `existingSecret` and store the api key under the name 'apiKey'.
 
 ## Uninstalling the Chart
 
@@ -66,7 +70,8 @@ The following table lists the configurable parameters of the chart and their def
 
 | Parameter                                 | Description                                                              | Default                                    |
 |-------------------------------------------|--------------------------------------------------------------------------|--------------------------------------------|
-| `apiKey`                                  | Komodor kubernetes api key (required)                                    | ``                                         |
+| `apiKey`                                  | Komodor kubernetes api key (required if `existingSecret` not specified)                                    | ``                                         |
+| `existingSecret`                          | Existing kubernetes secret resource containing Komodor kubernetes apiKey (required if `apiKey` not specified)                                    | ``                                         |
 | `watcher.redact`                                  | List of regular expressions. Config values for keys that matches one of these expressions will show up at Komodor as "REDACTED:\<SHA of config value\>" | `[]`
 | `watcher.clusterName`                     | Override auto-discovery of Cluster Name with one of your choosing        | ``                                         |
 | `watcher.watchNamespace`                  | Watch a specific namespace, or all namespaces ("", "all")                | `all`                                      |

--- a/charts/k8s-watcher/README.md
+++ b/charts/k8s-watcher/README.md
@@ -38,7 +38,7 @@ The command deploys the Komodor K8S-Watcher on the Kubernetes cluster in the def
 ## Api Key
 
 The Komodor kubernetes api key can provided in the helm upgrade command or `values.yaml` file or can be taken from an existing kubernetes secret resource.
-When using an existing kubernetes secret resource, specify the secret name in `existingSecret` (and `kialiExistingSecret` is using Kiali) and store the api key under the name 'apiKey' (or 'kialiApiKey' if using Kiali).
+When using an existing kubernetes secret resource, specify the secret name in `existingSecret` (and `kialiExistingSecret` is using Kiali) and store the api key under the name 'apiKey' (or 'kialiApiKey' for the `kialiExistingSecret`).
 
 ## Uninstalling the Chart
 

--- a/charts/k8s-watcher/README.md
+++ b/charts/k8s-watcher/README.md
@@ -38,7 +38,7 @@ The command deploys the Komodor K8S-Watcher on the Kubernetes cluster in the def
 ## Api Key
 
 The Komodor kubernetes api key can provided in the helm upgrade command or `values.yaml` file or can be taken from an existing kubernetes secret resource.
-When using an existing kubernetes secret resource, specify the secret name in `existingSecret` and store the api key under the name 'apiKey'.
+When using an existing kubernetes secret resource, specify the secret name in `existingSecret` (and `kialiExistingSecret` is using Kiali) and store the api key under the name 'apiKey' (or 'kialiApiKey' if using Kiali).
 
 ## Uninstalling the Chart
 
@@ -72,6 +72,7 @@ The following table lists the configurable parameters of the chart and their def
 |-------------------------------------------|--------------------------------------------------------------------------|--------------------------------------------|
 | `apiKey`                                  | Komodor kubernetes api key (required if `existingSecret` not specified)                                    | ``                                         |
 | `existingSecret`                          | Existing kubernetes secret resource containing Komodor kubernetes apiKey (required if `apiKey` not specified)                                    | ``                                         |
+| `kialiExistingSecret`                          | Existing kubernetes secret resource containing Komodor kiali kialiApiKey (required if `kialiApiKey` not specified)                                    | ``                                         |
 | `watcher.redact`                                  | List of regular expressions. Config values for keys that matches one of these expressions will show up at Komodor as "REDACTED:\<SHA of config value\>" | `[]`
 | `watcher.clusterName`                     | Override auto-discovery of Cluster Name with one of your choosing        | ``                                         |
 | `watcher.watchNamespace`                  | Watch a specific namespace, or all namespaces ("", "all")                | `all`                                      |

--- a/charts/k8s-watcher/kube-install/k8s-watcher/templates/deployment.yaml
+++ b/charts/k8s-watcher/kube-install/k8s-watcher/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: k8s-watcher
   namespace: komodor
   labels:
-    helm.sh/chart: k8s-watcher-0.1.39
+    helm.sh/chart: k8s-watcher-0.1.40
     app.kubernetes.io/name: k8s-watcher
     app.kubernetes.io/instance: k8s-watcher
     app.kubernetes.io/version: "0.1.33"

--- a/charts/k8s-watcher/kube-install/k8s-watcher/templates/serviceaccount.yaml
+++ b/charts/k8s-watcher/kube-install/k8s-watcher/templates/serviceaccount.yaml
@@ -4,7 +4,7 @@ metadata:
   name: k8s-watcher
   namespace: komodor
   labels:
-    helm.sh/chart: k8s-watcher-0.1.39
+    helm.sh/chart: k8s-watcher-0.1.40
     app.kubernetes.io/name: k8s-watcher
     app.kubernetes.io/instance: k8s-watcher
     app.kubernetes.io/version: "0.1.33"

--- a/charts/k8s-watcher/templates/deployment.yaml
+++ b/charts/k8s-watcher/templates/deployment.yaml
@@ -43,12 +43,16 @@ spec:
                   name: {{ include "k8s-watcher.name" . }}-secret
                   key: apiKey
 {{- end }}
-{{- if .Values.kialiApiKey }}
+{{- if or .Values.kialiApiKey .Values.kialiExistingSecret }}
             - name: KOMOKW_KIALI_API_KEY
               valueFrom:
-                secretKeyRef:
+{{- if .Values.kialiExistingSecret }}
+                  name: {{ .Values.kialiExistingSecret | required "Existing secret name required!" }}
+                  key: kialiApiKey
+{{- else }}
                   name: {{ include "k8s-watcher.name" . }}-secret
                   key: kialiApiKey
+{{- end }}
 {{- end }}
 {{- include "k8s-watcher.proxy-conf" . }}
           ports:

--- a/charts/k8s-watcher/templates/deployment.yaml
+++ b/charts/k8s-watcher/templates/deployment.yaml
@@ -36,8 +36,13 @@ spec:
             - name: KOMOKW_API_KEY
               valueFrom:
                 secretKeyRef:
+{{- if .Values.existingSecret }}
+                  name: {{ .Values.existingSecret | required "Existing secret name required!" }}
+                  key: apiKey
+{{- else }}
                   name: {{ include "k8s-watcher.name" . }}-secret
                   key: apiKey
+{{- end }}
 {{- if .Values.kialiApiKey }}
             - name: KOMOKW_KIALI_API_KEY
               valueFrom:

--- a/charts/k8s-watcher/templates/secret-credentials.yaml
+++ b/charts/k8s-watcher/templates/secret-credentials.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,4 +11,5 @@ data:
   apiKey: {{ .Values.apiKey | required "apiKey is a required value!" | b64enc }}
 {{- if .Values.kialiApiKey }}
   kialiApiKey: {{ .Values.kialiApiKey | default "" | b64enc}}
+{{- end }}
 {{- end }}

--- a/charts/k8s-watcher/values.yaml
+++ b/charts/k8s-watcher/values.yaml
@@ -28,6 +28,8 @@ resources:
     cpu: 0.25
     memory: 256Mi
 
+existingSecret: ""
+
 apiKey: ""
 kialiApiKey: ""
 


### PR DESCRIPTION
These changes allow using an existing secret resource for the Komodor `apiKey` instead of needing to specify the token for each helm command or hardcoding it into `values.yaml`.

For clusters that utilize external secrets (such as https://github.com/external-secrets/kubernetes-external-secrets), charts that allow providing an existing secret provide the functionality needed to remove all sensitive information from the chart files themselves.

These changes are an attempt to implement similar functionality that bitnami has in many of their charts. For example. the [redis chart](https://github.com/bitnami/charts/blob/master/bitnami/redis/values.yaml#L101)