### PR TITLE
Add ability to set annotations on deployment.

### DIFF
--- a/charts/k8s-watcher/templates/deployment.yaml
+++ b/charts/k8s-watcher/templates/deployment.yaml
@@ -7,6 +7,10 @@ metadata:
   {{- end }}
   labels:
     {{- include "k8s-watcher.labels" . | nindent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy:


### PR DESCRIPTION
Adds ability to set annotations on k8s-watcher deployment. Required for using Komodor GitHub integration.