### PR TITLE
Add tmp directory as volume in container

### DIFF
--- a/charts/k8s-watcher/kube-install/k8s-watcher/templates/deployment.yaml
+++ b/charts/k8s-watcher/kube-install/k8s-watcher/templates/deployment.yaml
@@ -43,6 +43,8 @@ spec:
           volumeMounts:
             - name: configuration
               mountPath: /etc/komodor
+            - name: tmp
+              mountPath: /tmp
             - name: podinfo
               mountPath: /etc/podinfo
             - name: helm-data
@@ -90,6 +92,9 @@ spec:
             items:
               - key: komodor-k8s-watcher.yaml
                 path: komodor-k8s-watcher.yaml
+        - name: tmp
+          emptyDir:
+            sizeLimit: 100Mi
         - name: podinfo
           downwardAPI:
             items:

--- a/charts/k8s-watcher/templates/deployment.yaml
+++ b/charts/k8s-watcher/templates/deployment.yaml
@@ -45,6 +45,8 @@ spec:
           volumeMounts:
             - name: configuration
               mountPath: /etc/komodor
+            - name: tmp
+              mountPath: /tmp
 {{- if .Values.enableMemLimitChecks }}
             - name: podinfo
               mountPath: /etc/podinfo
@@ -102,6 +104,9 @@ spec:
             items:
               - key: komodor-k8s-watcher.yaml
                 path: komodor-k8s-watcher.yaml
+        - name: tmp
+          emptyDir:
+            sizeLimit: 100Mi
 {{- if .Values.enableMemLimitChecks }}
         - name: podinfo
           downwardAPI:


### PR DESCRIPTION
Done in order to allow for the creation of temporary files on agent, since write permissions were revoked on the agent container for security concerns.