### PR TITLE
🎨 Remove Superfluous Rule from helm-dashboard ClusterRole

### DIFF
--- a/charts/helm-dashboard/templates/serviceaccount.yaml
+++ b/charts/helm-dashboard/templates/serviceaccount.yaml
@@ -19,11 +19,10 @@ metadata:
 rules:
   - apiGroups: ["*"]
     resources: ["*"]
-    verbs: ["get", "list", "watch"]
   {{- if .Values.dashboard.allowWriteActions }}
-  - apiGroups: ["*"]
-    resources: ["*"]
     verbs: ["get", "list", "watch", "create", "delete", "patch", "update"]
+  {{- else }}
+    verbs: ["get", "list", "watch"]
   {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
A superfluous rule is added to the ClusterRole upon creation, when the dashboard.allowWriteActions value is set to true. This commit will ensure that only a single rule is created within the ClusterRole, regardless of whether the dashboard.allowWriteActions value is enabled or not. The verbs within this rule will update accordingly.