### PR TITLE
CU-860q0eueg: Fix k8s-watcher clusterrole new condition to support older helm versions

### DIFF
--- a/charts/k8s-watcher/Chart.yaml
+++ b/charts/k8s-watcher/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 name: k8s-watcher
 description: Watches and sends kubernetes resource-related events
 icon: https://raw.githubusercontent.com/komodorio/helm-charts/master/k8s-watcher.svg
-version: 1.5.1
+version: 1.6.0
 appVersion: 0.1.175

--- a/charts/k8s-watcher/templates/clusterrole.yaml
+++ b/charts/k8s-watcher/templates/clusterrole.yaml
@@ -430,7 +430,7 @@ rules:
     verbs:     ["get", "watch", "list"]
 {{- end}}
 
-{{- if and .Values.watcher.resources.customReadAPIGroups gt (len .Values.watcher.resources.customReadAPIGroups) 0 }}
+{{- if and .Values.watcher.resources.customReadAPIGroups (gt (len .Values.watcher.resources.customReadAPIGroups) 0) }}
   - apiGroups: {{ .Values.watcher.resources.customReadAPIGroups }}
     resources: ["*"]
     verbs:     ["get", "watch", "list"]


### PR DESCRIPTION
## Motivation
The previous `gt` condition syntax was breaking old helm versions and resulted:
`Error: template: k8s-watcher/templates/clusterrole.yaml:433:57: executing "k8s-watcher/templates/clusterrole.yaml" at <gt>: wrong number of args for gt: want 2 got 0`

This is the fix for that.