### PR TITLE
added volume size limit to the helm metadata empty dir

### DIFF
--- a/charts/k8s-watcher/templates/deployment.yaml
+++ b/charts/k8s-watcher/templates/deployment.yaml
@@ -119,5 +119,6 @@ spec:
 {{- end }}
 {{- if ((.Values.helm).enableActions) }}
         - name: helm-data
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: {{ .Values.helm.volumeSizeLimit | default "256Mi" }}
 {{- end }}

--- a/charts/k8s-watcher/values.yaml
+++ b/charts/k8s-watcher/values.yaml
@@ -44,6 +44,7 @@ nodeSelector: {}
 
 helm:
   enableActions: true
+  volumeSizeLimit: "256Mi"
 
 watcher:
   enableAgentTaskExecution: true


### PR DESCRIPTION
related ticket / context: https://app.clickup.com/t/860pzd63e

TLDR: client can't install the helm chart due to missing size limit on the volume

added the size limit + added an option to change it via the values.yaml file

I did not add the value to the readme following the fact that the `helm.enableActions` was not mentioned there

tested locally with no value on the values.yaml + value and made sure all paths work as expected

public: added volume size limit to the helm metadata emptyDir
