### PR TITLE
feat: run dry-run upgrade before release procedure

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,5 @@
 steps:
-  - commands: 
-    - helm template k8s-watcher charts/k8s-watcher -f charts/k8s-watcher/values.yaml --set apiKey="sanity" --set metrics.enabled=true
+  - command: helm template k8s-watcher charts/k8s-watcher -f charts/k8s-watcher/values.yaml --set apiKey="sanity" --set metrics.enabled=true
     agents:
       builder: "dind"
     label: "helm template check for sanity"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,8 +1,16 @@
 steps:
-  - command: helm template k8s-watcher charts/k8s-watcher -f charts/k8s-watcher/values.yaml --set apiKey="sanity" --set metrics.enabled=true
+  - commands: 
+    - helm template k8s-watcher charts/k8s-watcher -f charts/k8s-watcher/values.yaml --set apiKey="sanity" --set metrics.enabled=true
     agents:
       builder: "dind"
     label: "helm template check for sanity"
+    if: build.message !~ /feat\(helm-dashboard\):/i
+  - wait
+
+  - commands: 
+    - komo ctx staging
+    - helm upgrade --install k8s-watcher-production  --reuse-values --dry-run charts/k8s-watcher --set apiKey="test"
+    label: "dry-run installation on staging before version bump"
     if: build.message !~ /feat\(helm-dashboard\):/i
   - wait
 


### PR DESCRIPTION
motivation:
avoid situations where the upgrade would fail after bumping the version and releasing a failed upgrade to github pages