### PR TITLE
feat: pin version to v0.1.17 on public-ecr

### DIFF
--- a/charts/k8s-watcher/charts/network-mapper/values.yaml
+++ b/charts/k8s-watcher/charts/network-mapper/values.yaml
@@ -1,8 +1,8 @@
 # Local configuration for network mapper chart
 mapper:
-  repository: otterize
+  repository: public.ecr.aws/g8r5w0b5
   image: network-mapper
-  tag: latest
+  tag: v0.1.17
   pullPolicy:
 
   resources: { }
@@ -19,9 +19,9 @@ mapper:
 
 
 sniffer:
-  repository: otterize
+  repository: public.ecr.aws/g8r5w0b5
   image: network-mapper-sniffer
-  tag: latest
+  tag: v0.1.17
   pullPolicy:
   resources: { }
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
# Description
network mapper images for both deployment and daemonset were hosted on docker-hub which is causing issues to some of our customers reaching dockerhub limits.
also, the latest default tag in their chart could potentially cause breaking changes.

# manual testing
i uploaded the images to ECR and checked on production that deployment\daemonset are working and validated that we get rows in `event_networkmap_changes` @shaicantor - is there anything else i should do to check that we're still working?