### PR TITLE
Add sidecar to monitor agent container

### DIFF
--- a/charts/k8s-watcher/Chart.yaml
+++ b/charts/k8s-watcher/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 name: k8s-watcher
 description: Watches and sends kubernetes resource-related events
 icon: https://raw.githubusercontent.com/komodorio/helm-charts/master/k8s-watcher.svg
-version: 1.11.21
+version: 1.12.0
 appVersion: 0.2.10

--- a/charts/k8s-watcher/README.md
+++ b/charts/k8s-watcher/README.md
@@ -190,6 +190,8 @@ The following table lists the configurable parameters of the chart and their def
 | `helm.volumeSizeLimit`                             | The size limit for the mounted volume holding helm metadata                                                                                                                                                                  | `256Mi`                             |
 | `metrics.enabled`                                  | Enables metrics collection (CPU & Memory)                                                                                                                                                                                    | `false`                             |
 | `daemon.tolerations`                               | Tolerations for daemonset pod assignment - Example:   --set 'daemon.tolerations[0].key=my-key' --set 'daemon.tolerations[0].operator=Equal' --set 'daemon.tolerations[0].value=my-value' --set 'daemon.tolerations[0].effect=NoSchedule'                                                                                                                                                                         | `[]`                                |
+| `supervisor.enabled`                                  | Enables supervisor sidecar (monitoring the agent)                                                                                                                                                                                    | `false`                             |
+
 
 
 The above parameters map to a yaml configuration file used by the watcher.

--- a/charts/k8s-watcher/templates/deployment.yaml
+++ b/charts/k8s-watcher/templates/deployment.yaml
@@ -82,13 +82,6 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
             successThreshold: 1
-          volumes:
-            - name: configuration
-              configMap:
-                name: {{ include "k8s-watcher.name" . }}-config
-                items:
-                  - key: komodor-k8s-watcher.yaml
-                    path: komodor-k8s-watcher.yaml
 {{- end }}
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/k8s-watcher/templates/deployment.yaml
+++ b/charts/k8s-watcher/templates/deployment.yaml
@@ -57,6 +57,10 @@ spec:
                   name: {{ include "k8s-watcher.name" . }}-secret
                   key: apiKey
 {{- end }}
+{{- if ((((((.Values.supervisor)).servers)).healthCheck)).port }}
+            - name: KOMOKW_SERVERS_HEALTHCHECK_PORT
+              value: "{{ .Values.supervisor.servers.healthCheck.port }}"
+{{- end }}
 {{- include "k8s-watcher.proxy-conf" . }}
           securityContext:
             readOnlyRootFilesystem: true
@@ -65,7 +69,7 @@ spec:
             allowPrivilegeEscalation: false
           ports:
             - name: http-healthz
-              containerPort: {{ .Values.watcher.servers.healthCheck.port | default 8090 }}
+              containerPort: {{ .Values.supervisor.servers.healthCheck.port | default 8089 }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/k8s-watcher/templates/deployment.yaml
+++ b/charts/k8s-watcher/templates/deployment.yaml
@@ -83,12 +83,12 @@ spec:
             failureThreshold: 3
             successThreshold: 1
           volumes:
-        - name: configuration
-          configMap:
-            name: {{ include "k8s-watcher.name" . }}-config
-            items:
-              - key: komodor-k8s-watcher.yaml
-                path: komodor-k8s-watcher.yaml
+            - name: configuration
+              configMap:
+                name: {{ include "k8s-watcher.name" . }}-config
+                items:
+                  - key: komodor-k8s-watcher.yaml
+                    path: komodor-k8s-watcher.yaml
 {{- end }}
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/k8s-watcher/templates/deployment.yaml
+++ b/charts/k8s-watcher/templates/deployment.yaml
@@ -82,7 +82,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
             successThreshold: 1
-      volumes:
+          volumes:
         - name: configuration
           configMap:
             name: {{ include "k8s-watcher.name" . }}-config

--- a/charts/k8s-watcher/templates/deployment.yaml
+++ b/charts/k8s-watcher/templates/deployment.yaml
@@ -37,6 +37,59 @@ spec:
       {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
       containers:
+{{- if ((.Values.supervisor)).enabled }}
+        - name: "supervisor"
+          image: "{{ .Values.supervisor.image.repository }}:{{ .Values.supervisor.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.supervisor.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.supervisor.resources | nindent 12 }}
+          volumeMounts:
+            - name: configuration
+              mountPath: /etc/komodor
+          env:
+            - name: KOMOKW_API_KEY
+              valueFrom:
+                secretKeyRef:
+{{- if .Values.existingSecret }}
+                  name: {{ .Values.existingSecret | required "Existing secret name required!" }}
+                  key: apiKey
+{{- else }}
+                  name: {{ include "k8s-watcher.name" . }}-secret
+                  key: apiKey
+{{- end }}
+{{- include "k8s-watcher.proxy-conf" . }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            allowPrivilegeEscalation: false
+          ports:
+            - name: http-healthz
+              containerPort: {{ .Values.watcher.servers.healthCheck.port | default 8090 }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http-healthz
+            periodSeconds: 60
+            initialDelaySeconds: 15
+            failureThreshold: 10
+            successThreshold: 1
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http-healthz
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 3
+            successThreshold: 1
+      volumes:
+        - name: configuration
+          configMap:
+            name: {{ include "k8s-watcher.name" . }}-config
+            items:
+              - key: komodor-k8s-watcher.yaml
+                path: komodor-k8s-watcher.yaml
+{{- end }}
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/k8s-watcher/values.yaml
+++ b/charts/k8s-watcher/values.yaml
@@ -57,6 +57,9 @@ supervisor:
     requests:
       cpu: 0.1
       memory: 256Mi
+  servers:
+    healthCheck:
+      port: 8089
 metrics:
   enabled: false
 daemon:

--- a/charts/k8s-watcher/values.yaml
+++ b/charts/k8s-watcher/values.yaml
@@ -48,6 +48,15 @@ helm:
   enableActions: true
   volumeSizeLimit: "256Mi"
 
+supervisor:
+  enabled: false
+  image:
+    repository: public.ecr.aws/g8r5w0b5/supervisor
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 0.1
+      memory: 256Mi
 metrics:
   enabled: false
 daemon:


### PR DESCRIPTION
public: add sidecar container (supervisor) to monitor the komodor agent container in case of crashes - disabled by default

CU-860qt1vpe