### PR TITLE
CU-860quknkk - Support configured cluster name

### DIFF
--- a/charts/k8s-watcher/templates/daemonset.yaml
+++ b/charts/k8s-watcher/templates/daemonset.yaml
@@ -75,6 +75,10 @@ spec:
             - name: KOMOKW_HTTPS_PROXY_URL
               value: {{ .Values.proxy.https }}
             {{- end }}
+            {{- if .Values.watcher.clusterName }}
+            - name: CLUSTER_NAME
+              value: {{ .Values.watcher.clusterName }}
+            {{- end }}
       {{- with .Values.daemon.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
public: add support in metrics agent to receive cluster name from configuration 