### PR TITLE
CU-85zt5jfu0 - added wildcard toleration for metrics daemon set

### DIFF
--- a/charts/k8s-watcher/values.yaml
+++ b/charts/k8s-watcher/values.yaml
@@ -63,7 +63,8 @@ supervisor:
 metrics:
   enabled: false
 daemon:
-  tolerations: []
+  tolerations:
+    - operator: "Exists"
   resources:
     limits:
       cpu: 1


### PR DESCRIPTION
motivation:
currently the metrics daemonset is not running on nodes that have taints since the default toleration we set is empty

this PR adds a wildcard toleration on the daemonsset that will allow the pods to be scheduled on all cluster nodes

public: 
added a toleration on the daemonset to allow metrics daemon set pods to be scheduled on all nodes