### PR TITLE
Use .Release.Namespace instead of .Values.namespace in k8s-watcher Helm chart

### DIFF
--- a/charts/k8s-watcher/templates/clusterrole.yaml
+++ b/charts/k8s-watcher/templates/clusterrole.yaml
@@ -3,9 +3,7 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "k8s-watcher.serviceAccountName" . }}
-  {{- if hasKey .Values "namespace" }}
-  namespace: {{ .Values.namespace }}
-  {{- end }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
 rules:
   - apiGroups:
     - ""
@@ -492,6 +490,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "k8s-watcher.serviceAccountName" . }}
-    {{- if hasKey .Values "namespace" }}
-    namespace: {{ .Values.namespace }}
-    {{- end }}
+    namespace: {{ default .Release.Namespace .Values.namespace }}

--- a/charts/k8s-watcher/templates/configmap-daemon.yaml
+++ b/charts/k8s-watcher/templates/configmap-daemon.yaml
@@ -3,9 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "k8s-watcher.name" . }}-daemon-config
-  {{- if hasKey .Values "namespace" }}
-  namespace: {{ .Values.namespace }}
-  {{- end }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
 data:
   telegraf.conf: |
     [global_tags]

--- a/charts/k8s-watcher/templates/configmap.yaml
+++ b/charts/k8s-watcher/templates/configmap.yaml
@@ -2,9 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "k8s-watcher.name" . }}-config
-  {{- if hasKey .Values "namespace" }}
-  namespace: {{ .Values.namespace }}
-  {{- end }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
 data:
   komodor-k8s-watcher.yaml: |
 {{- include "watcher.values" . | nindent 4 }}

--- a/charts/k8s-watcher/templates/daemonset.yaml
+++ b/charts/k8s-watcher/templates/daemonset.yaml
@@ -3,9 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "k8s-watcher.fullname" . }}-daemon
-  {{- if hasKey .Values "namespace" }}
-  namespace: {{ .Values.namespace }}
-  {{- end }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
   labels:
     {{- include "daemon.labels" . | nindent 4 }}
   {{- with .Values.deploymentAnnotations }}
@@ -35,10 +33,10 @@ spec:
             - name: configuration
               mountPath: /etc/komodor
           env:
-            {{- if hasKey .Values "namespace" }}
             - name: NAMESPACE
-              value: {{ .Values.namespace }}
-            {{- end }}
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: KOMOKW_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/k8s-watcher/templates/deployment.yaml
+++ b/charts/k8s-watcher/templates/deployment.yaml
@@ -2,9 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "k8s-watcher.fullname" . }}
-  {{- if hasKey .Values "namespace" }}
-  namespace: {{ .Values.namespace }}
-  {{- end }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
   labels:
     {{- include "k8s-watcher.labels" . | nindent 4 }}
   {{- with .Values.deploymentAnnotations }}

--- a/charts/k8s-watcher/templates/namespace.yaml
+++ b/charts/k8s-watcher/templates/namespace.yaml
@@ -1,8 +1,6 @@
-{{- if hasKey .Values "namespace" }}
 {{- if .Values.createNamespace }}
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{ .Values.namespace }}
-{{- end }}
+  name: {{ default .Release.Namespace .Values.namespace }}
 {{- end }}

--- a/charts/k8s-watcher/templates/resourcequota.yaml
+++ b/charts/k8s-watcher/templates/resourcequota.yaml
@@ -4,9 +4,7 @@ metadata:
   labels:
     app: komodor
   name: komodor-critical-pods
-  {{- if hasKey .Values "namespace" }}
-  namespace: {{ .Values.namespace }}
-  {{- end}}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
 spec:
   hard:
     pods: 2

--- a/charts/k8s-watcher/templates/secret-credentials.yaml
+++ b/charts/k8s-watcher/templates/secret-credentials.yaml
@@ -3,9 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "k8s-watcher.name" . }}-secret
-  {{- if hasKey .Values "namespace" }}
-  namespace: {{ .Values.namespace }}
-  {{- end }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
 type: Opaque
 data:
   apiKey: {{ .Values.apiKey | required "apiKey is a required value!" | b64enc }}

--- a/charts/k8s-watcher/templates/serviceaccount.yaml
+++ b/charts/k8s-watcher/templates/serviceaccount.yaml
@@ -3,9 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "k8s-watcher.serviceAccountName" . }}
-  {{- if hasKey .Values "namespace" }}
-  namespace: {{ .Values.namespace }}
-  {{- end }}
+  namespace: {{ default .Release.Namespace .Values.namespace }}
   labels:
     {{- include "k8s-watcher.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/k8s-watcher/values.yaml
+++ b/charts/k8s-watcher/values.yaml
@@ -4,7 +4,8 @@ image:
   repository: public.ecr.aws/komodor-public/k8s-watcher
   pullPolicy: IfNotPresent
 
-namespace: komodor
+# Preferred over Helm .Release.Namespace for backwards compatibility, if set.
+#namespace: komodor
 createNamespace: true
 
 # enableMemLimitChecks will use downward API to tell the pod what is the allocated memory


### PR DESCRIPTION
Use .Release.Namespace to set namespace.
.Values.namespace is now an override for .Release.Namespace, for backwards compatibility with users who might have set this using --set namespace=[...] - used instead of .Release.Namespace if specified.

Encountered this while deploying k8s-watcher. Took me a while to figure out the Helm --namespace flag was being ignored.