### PR TITLE
CU-85ztcd9pw - fix missing clustername in generate kube templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ generate-kube:
 	--set watcher.resources.secret=false \
 	--set watcher.actions.basic=false \
 	--set watcher.actions.advanced=false \
+	--set watcher.clusterName=YOUR_CLUSTER_NAME \
 	--set apiKey="YOUR_APIKEY_AS_BASE_64" \
 	> generated.yaml
 	cat generated.yaml | ./charts/k8s-watcher/helm-fan-out.sh charts/k8s-watcher/kube-install

--- a/charts/k8s-watcher/README.md
+++ b/charts/k8s-watcher/README.md
@@ -84,7 +84,9 @@ To install the chart directly with kubectl, use the manifests located in `./kube
 
 1. Make sure to set the apiKey (as base 64) secret value in `./kube-install/k8s-watcher/templates/secret-credentials.yaml`
    - `KOMOKW_APIKEY=YOUR_APIKEY sed -i "s/YOUR_APIKEY_AS_BASE_64/$(echo $KOMOKW_APIKEY | base64)/g" kube-install/k8s-watcher/templates/secret-credentials.yaml`
-2. Then just apply everything in order:
+2. Make sure to set the cluster name in `./kube-install/k8s-watcher/templates/*.yaml`
+   - `CLUSTER_NAME=YOUR_CLUSTER_NAME1 sed -i "s/YOUR_CLUSTER_NAME/$CLUSTER_NAME/g" kube-install/k8s-watcher/templates/*.yaml`
+3. Then just apply everything in order:
    - `kubectl apply -f ./kube-install/k8s-watcher/templates/namespace.yaml`
    - `kubectl apply -f ./kube-install/k8s-watcher/templates`
 

--- a/charts/k8s-watcher/README.md
+++ b/charts/k8s-watcher/README.md
@@ -85,7 +85,7 @@ To install the chart directly with kubectl, use the manifests located in `./kube
 1. Make sure to set the apiKey (as base 64) secret value in `./kube-install/k8s-watcher/templates/secret-credentials.yaml`
    - `KOMOKW_APIKEY=YOUR_APIKEY sed -i "s/YOUR_APIKEY_AS_BASE_64/$(echo $KOMOKW_APIKEY | base64)/g" kube-install/k8s-watcher/templates/secret-credentials.yaml`
 2. Make sure to set the cluster name in `./kube-install/k8s-watcher/templates/*.yaml`
-   - `CLUSTER_NAME=YOUR_CLUSTER_NAME1 sed -i "s/YOUR_CLUSTER_NAME/$CLUSTER_NAME/g" kube-install/k8s-watcher/templates/*.yaml`
+   - `CLUSTER_NAME=YOUR_CLUSTER_NAME sed -i "s/YOUR_CLUSTER_NAME/$CLUSTER_NAME/g" kube-install/k8s-watcher/templates/*.yaml`
 3. Then just apply everything in order:
    - `kubectl apply -f ./kube-install/k8s-watcher/templates/namespace.yaml`
    - `kubectl apply -f ./kube-install/k8s-watcher/templates`


### PR DESCRIPTION
* Add to generate-kube the cluster name
* Update the readme file.