### PR TITLE
expose network mapper based on variable

### DIFF
--- a/charts/k8s-watcher/templates/network-mapper/service.yaml
+++ b/charts/k8s-watcher/templates/network-mapper/service.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.network_mapper ((.Values.watcher.networkMapper).enable | default false) }}
+{{- if (.Values.network_mapper.mapper).exposeService | default false }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -14,4 +15,5 @@ spec:
       port: 9090
       name: http
       targetPort: 9090
+{{- end }}
 {{- end }}

--- a/charts/k8s-watcher/values.yaml
+++ b/charts/k8s-watcher/values.yaml
@@ -101,6 +101,7 @@ network_mapper:
     image: network-mapper
     tag: v0.1.17
     pullPolicy: IfNotPresent
+    exposeService: false
     resources: { }
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
@@ -159,6 +160,7 @@ watcher:
     enable: true
   networkMapper:
     enable: false
+    host: http://localhost:9090/query
   monitoringFQDN: ""
   resources:
     event: true


### PR DESCRIPTION
Once we moved the network mapper to be part of the agent pod, there is no need to expose the network mapper with a service.