### PR TITLE
Update network-mapper name and values

### DIFF
--- a/charts/k8s-watcher/templates/network-mapper/_helpers.tpl
+++ b/charts/k8s-watcher/templates/network-mapper/_helpers.tpl
@@ -1,9 +1,9 @@
-{{- define "otterize.sniffer.fullName" -}}
-otterize-network-sniffer
+{{- define "network.sniffer.fullName" -}}
+network-sniffer
 {{- end -}}
-{{- define "otterize.mapper.fullName" -}}
-otterize-network-mapper
+{{- define "network.mapper.fullName" -}}
+network-mapper
 {{- end -}}
-{{- define "otterize.mapper.configMapName" -}}
-otterize-network-mapper-store
+{{- define "network.mapper.configMapName" -}}
+network-mapper-store
 {{- end -}}

--- a/charts/k8s-watcher/templates/network-mapper/cluster-role.yaml
+++ b/charts/k8s-watcher/templates/network-mapper/cluster-role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "otterize.mapper.fullName" . }}
+  name: {{ template "network.mapper.fullName" . }}
 rules:
   - apiGroups:
       - ''

--- a/charts/k8s-watcher/templates/network-mapper/configmap.yaml
+++ b/charts/k8s-watcher/templates/network-mapper/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "otterize.mapper.configMapName" . }}
+  name: {{ template "network.mapper.configMapName" . }}
   {{- if hasKey .Values "namespace" }}
   namespace: {{ .Values.namespace }}
   {{- end }}

--- a/charts/k8s-watcher/templates/network-mapper/daemonset.yaml
+++ b/charts/k8s-watcher/templates/network-mapper/daemonset.yaml
@@ -1,6 +1,6 @@
 {{- define "network_mapper.daemonset.container" }}
 {{- if and .Values.network_mapper ((.Values.watcher.networkMapper).enable | default false) }}
-- name: {{ template "otterize.sniffer.fullName" . }}
+- name: {{ template "network.sniffer.fullName" . }}
   image: "{{ .Values.network_mapper.sniffer.repository }}/{{ .Values.network_mapper.sniffer.image }}:{{ .Values.network_mapper.sniffer.tag }}"
   {{ if .Values.network_mapper.sniffer.pullPolicy }}
   imagePullPolicy: {{ .Values.network_mapper.sniffer.pullPolicy }}
@@ -9,9 +9,9 @@
     {{- toYaml .Values.network_mapper.sniffer.resources | nindent 10 }}
   env:
     - name: OTTERIZE_MAPPER_API_URL
-      value: http://{{ template "otterize.mapper.fullName" . }}:9090/query
+      value: http://{{ template "network.mapper.fullName" . }}:9090/query
     - name: OTTERIZE_DEBUG
-      value: {{ .Values.debug | quote }}
+      value: {{ .Values.network_mapper.debug | quote }}
   volumeMounts:
     - mountPath: /hostproc
       name: proc

--- a/charts/k8s-watcher/templates/network-mapper/deployment.yaml
+++ b/charts/k8s-watcher/templates/network-mapper/deployment.yaml
@@ -1,6 +1,6 @@
 {{- define "network_mapper.deployment.container" }}
 {{- if and .Values.network_mapper ((.Values.watcher.networkMapper).enable | default false) }}
-- name: {{ template "otterize.mapper.fullName" . }}
+- name: {{ template "network.mapper.fullName" . }}
   image: "{{ .Values.network_mapper.mapper.repository }}/{{ .Values.network_mapper.mapper.image }}:{{ .Values.network_mapper.mapper.tag }}"
   {{ if .Values.network_mapper.mapper.pullPolicy }}
   imagePullPolicy: {{ .Values.network_mapper.mapper.pullPolicy }}
@@ -9,16 +9,16 @@
   {{- toYaml .Values.network_mapper.mapper.resources | nindent 4 }}
   env:
   - name: OTTERIZE_DEBUG
-    value: {{ .Values.debug | quote }}
-  {{ if .Values.network_mapper.global.otterizeCloud.apiAddress }}
+    value: {{ .Values.network_mapper.debug | quote }}
+  {{ if (((.Values.network_mapper).global).otterizeCloud).apiAddress }}
   - name: OTTERIZE_API_ADDRESS
     value: "{{ .Values.network_mapper.global.otterizeCloud.apiAddress }}"
   {{ end }}
-  {{ if .Values.network_mapper.global.otterizeCloud.credentials.clientId }}
+  {{ if ((((.Values.network_mapper).global).otterizeCloud).credentials).clientId }}
   - name: OTTERIZE_CLIENT_ID
     value: "{{ .Values.network_mapper.global.otterizeCloud.credentials.clientId }}"
   {{ end }}
-  {{ if .Values.network_mapper.global.otterizeCloud.credentials.clientSecret }}
+  {{ if ((((.Values.network_mapper).global).otterizeCloud).credentials).clientSecret }}
   - name: OTTERIZE_CLIENT_SECRET
     value: "{{ .Values.network_mapper.global.otterizeCloud.credentials.clientSecret }}"
   {{ end }}

--- a/charts/k8s-watcher/templates/network-mapper/role.yaml
+++ b/charts/k8s-watcher/templates/network-mapper/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ template "otterize.mapper.fullName" . }}
+  name: {{ template "network.mapper.fullName" . }}
   {{- if hasKey .Values "namespace" }}
   namespace: {{ .Values.namespace }}
   {{- end }}
@@ -12,7 +12,7 @@ rules:
     resources:
       - 'configmaps'
     resourceNames:
-      - {{ template "otterize.mapper.configMapName" . }}
+      - {{ template "network.mapper.configMapName" . }}
     verbs:
       - 'get'
       - 'update'

--- a/charts/k8s-watcher/templates/network-mapper/roles-binding.yaml
+++ b/charts/k8s-watcher/templates/network-mapper/roles-binding.yaml
@@ -3,11 +3,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "otterize.mapper.fullName" . }}
+  name: {{ template "network.mapper.fullName" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "otterize.mapper.fullName" . }}
+  name: {{ template "network.mapper.fullName" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "k8s-watcher.serviceAccountName" . }}
@@ -18,14 +18,14 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "otterize.mapper.fullName" . }}
+  name: {{ template "network.mapper.fullName" . }}
   {{- if hasKey .Values "namespace" }}
   namespace: {{ .Values.namespace }}
   {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "otterize.mapper.fullName" . }}
+  name: {{ template "network.mapper.fullName" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "k8s-watcher.serviceAccountName" . }}

--- a/charts/k8s-watcher/templates/network-mapper/service.yaml
+++ b/charts/k8s-watcher/templates/network-mapper/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "otterize.mapper.fullName" . }}
+  name: {{ template "network.mapper.fullName" . }}
   {{- if hasKey .Values "namespace" }}
   namespace: {{ .Values.namespace }}
   {{- end }}

--- a/charts/k8s-watcher/values.yaml
+++ b/charts/k8s-watcher/values.yaml
@@ -90,11 +90,6 @@ network_mapper:
   global:
     # If defined overrides `allowGetAllResources`
     allowGetAllResources:
-    otterizeCloud:
-      credentials:
-        # fill clientId and clientSecret in order to connect to Otterize Cloud
-        clientId:
-        clientSecret:
 
   mapper:
     repository: public.ecr.aws/komodor-public
@@ -114,7 +109,7 @@ network_mapper:
     #   memory: 128Mi
 
   sniffer:
-    repository: public.ecr.aws/g8r5w0b5
+    repository: public.ecr.aws/komodor-public
     image: network-mapper-sniffer
     tag: v0.1.17
     pullPolicy: IfNotPresent


### PR DESCRIPTION
## Changelog
* Rename `otterize-network-mapper` to `network-mapper`
![image](https://github.com/komodorio/helm-charts/assets/123294681/efd0d0a8-b30d-4d5a-bf58-33d4f48419c8)
![image](https://github.com/komodorio/helm-charts/assets/123294681/392ce6f8-7c5f-4948-88f6-beb7ee31a1c9)

* Remove unused mapper cloud values
* Update sniffer registry URL

## Validation
* Validated on gke-playground cluster

CU-860r74xw6