### PR TITLE
CU-85ztknh8x - fix error when daemon cant translate mode dns

### DIFF
--- a/charts/k8s-watcher/templates/metrics/configmap-daemon.yaml
+++ b/charts/k8s-watcher/templates/metrics/configmap-daemon.yaml
@@ -29,7 +29,7 @@ data:
         X-ACCOUNT-ID = "${ACCOUNT_ID}"
 
     [[inputs.kubernetes]]
-      url = "https://$NODE_NAME:10250"
+      url = "https://$NODE_IP:10250"
       bearer_token = "/run/secrets/kubernetes.io/serviceaccount/token"
       insecure_skip_verify = true
       fieldpass = ["memory_usage_bytes","cpu_usage_nanocores"]

--- a/charts/k8s-watcher/templates/metrics/daemonset.yaml
+++ b/charts/k8s-watcher/templates/metrics/daemonset.yaml
@@ -17,6 +17,10 @@
     valueFrom:
       fieldRef:
         fieldPath: spec.nodeName
+  - name: NODE_IP
+    valueFrom:
+      fieldRef:
+        fieldPath: status.hostIP
   {{- if .Values.proxy.http }}
   - name: KOMOKW_HTTP_PROXY_URL
     value: {{ .Values.proxy.http }}


### PR DESCRIPTION
The user experienced an error in the daemon logs : 
` Error in plugin: error making HTTP request to "https://${NODE_NAME}:10250/stats/summary": Get "https://${NODE_NAME}:10250/stats/summary": dial tcp: lookup ${NODE_NAME} on 172.20.0.10:53: no such host`
From what I saw online the solution is not trying to use the DNS server to resolve the node name but to use the internal node IP instead 

public: fix error with node DNS translation 