### PR TITLE
bump network-mapper 0.1.32 > 1.0.3

### DIFF
--- a/charts/k8s-watcher/templates/network-mapper/daemonset.yaml
+++ b/charts/k8s-watcher/templates/network-mapper/daemonset.yaml
@@ -1,7 +1,7 @@
 {{- define "network_mapper.daemonset.container" }}
 {{- if ne (.Values.watcher.networkMapper).enable false }}
 - name: {{ template "network.sniffer.fullName" . }}
-  image: '{{ ((.Values.network_mapper).sniffer).repository | default "public.ecr.aws/komodor-public" }}/{{ ((.Values.network_mapper).sniffer).image | default "network-mapper-sniffer" }}:{{ ((.Values.network_mapper).sniffer).tag | default "v0.1.32" }}'
+  image: '{{ ((.Values.network_mapper).sniffer).repository | default "public.ecr.aws/komodor-public" }}/{{ ((.Values.network_mapper).sniffer).image | default "network-mapper-sniffer" }}:{{ ((.Values.network_mapper).sniffer).tag | default "v1.0.3" }}'
   imagePullPolicy: {{ ((.Values.network_mapper).sniffer).pullPolicy | default "IfNotPresent" }}
   resources:
     {{- toYaml ((.Values.network_mapper).sniffer).resources | nindent 10 }}

--- a/charts/k8s-watcher/templates/network-mapper/deployment.yaml
+++ b/charts/k8s-watcher/templates/network-mapper/deployment.yaml
@@ -1,7 +1,7 @@
 {{- define "network_mapper.deployment.container" }}
 {{- if ne (.Values.watcher.networkMapper).enable false }}
 - name: {{ template "network.mapper.fullName" . }}
-  image: '{{ ((.Values.network_mapper).mapper).repository | default "public.ecr.aws/komodor-public" }}/{{ ((.Values.network_mapper).mapper).image | default "network-mapper" }}:{{ ((.Values.network_mapper).mapper).tag | default "v0.1.32" }}'
+  image: '{{ ((.Values.network_mapper).mapper).repository | default "public.ecr.aws/komodor-public" }}/{{ ((.Values.network_mapper).mapper).image | default "network-mapper" }}:{{ ((.Values.network_mapper).mapper).tag | default "v1.0.3" }}'
   imagePullPolicy: {{ ((.Values.network_mapper).mapper).pullPolicy | default "IfNotPresent" }}
   resources:
     {{- toYaml ((.Values.network_mapper).mapper).resources | nindent 4 }}

--- a/charts/k8s-watcher/values.yaml
+++ b/charts/k8s-watcher/values.yaml
@@ -95,7 +95,7 @@ network_mapper:
   mapper:
     repository: public.ecr.aws/komodor-public
     image: network-mapper
-    tag: v0.1.32
+    tag: v1.0.3
     pullPolicy: IfNotPresent
     resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
@@ -112,7 +112,7 @@ network_mapper:
   sniffer:
     repository: public.ecr.aws/komodor-public
     image: network-mapper-sniffer
-    tag: v0.1.32
+    tag: v1.0.3
     pullPolicy: IfNotPresent
     resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Fixes the following critical vulnerabilities in network-mapper-sniffer:v1.0.2

GO /main
| VulnerabilityID | Severity | InstalledVersion | FixedVersion |
|-----------------|----------|------------------|--------------|
| [CVE-2023-24538](https://www.mend.io/vulnerability-database/CVE-2023-24538) | CRITICAL | 1.19.13 | 1.20.3-r0 |
| [CVE-2023-24540](https://www.mend.io/vulnerability-database/CVE-2023-24540) | CRITICAL | 1.19.13 | 1.20.4-r0 |
| [CVE-2023-29402](https://www.mend.io/vulnerability-database/CVE-2023-29402) | CRITICAL | 1.19.13 | 1.20.5-r0 |
| [CVE-2023-29404](https://www.mend.io/vulnerability-database/CVE-2023-29404) | CRITICAL | 1.19.13 | 1.20.5-r0 |
| [CVE-2023-29405](https://www.mend.io/vulnerability-database/CVE-2023-29405) | CRITICAL | 1.19.13 | 1.20.5-r0 |

