### PR TITLE
Komodor agent helm tests update

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -85,6 +85,16 @@ steps:
           parameters:
             API_KEY: /helm-chart-test/production/API_KEY
 
+  - label: ":test_tube: legacy_k8s_versions_test"
+    commands:
+      - cd .buildkite/tests
+      - make legacy_k8s_versions_test
+    agents:
+      builder: "dind"
+    plugins:
+      - zacharymctague/aws-ssm#v1.0.0:
+          parameters:
+            API_KEY: /helm-chart-test/production/API_KEY
   - wait
 
   - label: ":running: LEGACY: dry-run installation on staging before version bump"

--- a/.buildkite/pipeline_scripts/publish_helm_charts.sh
+++ b/.buildkite/pipeline_scripts/publish_helm_charts.sh
@@ -5,7 +5,6 @@ SCRIPT_DIR=$(dirname $(realpath "$0"))
 source "$SCRIPT_DIR/common.sh"
 
 configure_git() {
-  git config user.email
   git config user.email buildkite@users.noreply.github.com
   git config user.name buildkite
   git checkout master

--- a/.buildkite/tests/Makefile
+++ b/.buildkite/tests/Makefile
@@ -53,3 +53,6 @@ values_capabilities_test: setup-venv install-kind cleanup-kind
 
 values_components_test: setup-venv install-kind cleanup-kind
 	$(VENV_ACTIVATE) ; pytest values_components_test.py
+
+legacy_k8s_versions_test: setup-venv install-kind cleanup-kind
+	$(VENV_ACTIVATE) ; pytest legacy_k8s_versions_test.py

--- a/.buildkite/tests/basic_test.py
+++ b/.buildkite/tests/basic_test.py
@@ -4,7 +4,7 @@ from fixtures import setup_cluster, kube_client, cleanup_agent_from_cluster
 from helpers.utils import get_filename_as_cluster_name
 import helpers.kubernetes_helper as kubernetes_helper
 from helpers.komodor_helper import create_komodor_uid, query_backend
-from config import API_KEY, BE_BASE_URL, NAMESPACE
+from config import API_KEY, BE_BASE_URL, NAMESPACE, RELEASE_NAME
 from helpers.helm_helper import helm_agent_install
 
 CLUSTER_NAME = get_filename_as_cluster_name(__file__)
@@ -40,6 +40,10 @@ def test_helm_installation(setup_cluster, kube_client):
             time.sleep(10)
     else:
         assert False, f"Pods are not ready: {last_exception}"
+
+    deployment_name = f"{RELEASE_NAME}-komodor-agent"
+    pod_name = kubernetes_helper.find_pod_name_by_deployment(deployment_name, NAMESPACE)
+    kubernetes_helper.look_for_errors_in_pod_log(pod_name, "k8s-watcher")
 
 
 def test_get_configmap_from_resources_api(setup_cluster):

--- a/.buildkite/tests/fixtures.py
+++ b/.buildkite/tests/fixtures.py
@@ -6,9 +6,14 @@ from config import NAMESPACE
 
 
 @pytest.fixture(scope='module')
-def setup_cluster():
+def setup_cluster(request):
     cluster_name = "test"
-    cmd(f"kind create cluster --name {cluster_name} --wait 5m")
+
+    node = ""
+    if hasattr(request, 'param'):
+        node = f"--image=kindest/node:v{request.param}"
+
+    cmd(f"kind create cluster --name {cluster_name} {node} --wait 5m")
     config.load_kube_config(context=f"kind-{cluster_name}")
     cmd(f"kubectl apply -f ./test-data")
     yield

--- a/.buildkite/tests/helpers/komodor_helper.py
+++ b/.buildkite/tests/helpers/komodor_helper.py
@@ -1,4 +1,5 @@
 import requests
+import time
 from config import API_KEY
 
 
@@ -15,3 +16,16 @@ def query_backend(url):
 
     response = requests.request("GET", url, headers=headers, data=payload)
     return response
+
+
+def query_backend_with_retry(url, retries=3, sleep_time=5, object_to_wait_for=None):
+    for i in range(retries):
+        response = query_backend(url)
+        if (response.status_code == 200 and
+                (not object_to_wait_for or len(response.json().get(object_to_wait_for, [])) > 0)):
+            return response
+
+        time.sleep(sleep_time)
+
+    print(f"Failed to get desired response from backend after {retries} retries,\nresponse: {response}")
+    return  response

--- a/.buildkite/tests/helpers/kubernetes_helper.py
+++ b/.buildkite/tests/helpers/kubernetes_helper.py
@@ -1,5 +1,6 @@
 import time
 import json
+from helpers.utils import cmd
 from kubernetes import client
 from config import NAMESPACE
 
@@ -124,3 +125,10 @@ def look_for_errors_in_pod_log(pod_name, container_name="k8s-watcher"):
         json_log = json.loads(line)
         if "level" in json_log and json_log["level"] == "error":
             assert False, f"Found error in logs of {pod_name}\nLog: {json_log['msg']}"
+
+
+def rollout_restart_and_wait(deployment_name, namespace):
+    cmd(f'kubectl rollout restart deployment/{deployment_name} -n {namespace}')
+    output, exit_code = cmd(f'kubectl rollout status deployment/{deployment_name} -n {namespace}')
+    return exit_code == 0
+

--- a/.buildkite/tests/helpers/kubernetes_helper.py
+++ b/.buildkite/tests/helpers/kubernetes_helper.py
@@ -1,4 +1,5 @@
 import time
+import json
 from kubernetes import client
 from config import NAMESPACE
 
@@ -98,3 +99,28 @@ def find_pod_name_by_deployment(deployment_name, namespace):
     except client.exceptions.ApiException as e:
         print(f"An error occurred: {e}")
         return None
+
+
+def get_pod_logs(namespace, pod_name, container_name=None, tail_lines=100):
+    """
+    Retrieve the logs for a specific pod and container.
+    """
+    v1 = client.CoreV1Api()
+
+    return v1.read_namespaced_pod_log(
+        name=pod_name,
+        namespace=namespace,
+        container=container_name,  # None will get the first container
+        tail_lines=tail_lines
+    )
+
+
+def look_for_errors_in_pod_log(pod_name, container_name="k8s-watcher"):
+    assert pod_name, "Failed to find pod by deployment name"
+    logs = get_pod_logs(NAMESPACE, pod_name, container_name)
+    for line in logs.splitlines():
+        if not line.startswith("{"):
+            continue
+        json_log = json.loads(line)
+        if "level" in json_log and json_log["level"] == "error":
+            assert False, f"Found error in logs of {pod_name}\nLog: {json_log['msg']}"

--- a/.buildkite/tests/helpers/kubernetes_helper.py
+++ b/.buildkite/tests/helpers/kubernetes_helper.py
@@ -117,7 +117,7 @@ def get_pod_logs(namespace, pod_name, container_name=None, tail_lines=100):
 
 
 def look_for_errors_in_pod_log(pod_name, container_name="k8s-watcher"):
-    assert pod_name, "Failed to find pod by deployment name"
+    assert pod_name, "Pod name is required"
     logs = get_pod_logs(NAMESPACE, pod_name, container_name)
     for line in logs.splitlines():
         if not line.startswith("{"):

--- a/.buildkite/tests/legacy_k8s_versions_test.py
+++ b/.buildkite/tests/legacy_k8s_versions_test.py
@@ -1,0 +1,24 @@
+import pytest
+import json
+from config import API_KEY_B64, NAMESPACE, RELEASE_NAME
+from helpers.utils import cmd, get_filename_as_cluster_name
+from helpers.helm_helper import helm_agent_install,  get_yaml_from_helm_template
+from helpers.kubernetes_helper import get_pod_logs, find_pod_name_by_deployment, look_for_errors_in_pod_log
+from fixtures import setup_cluster, kube_client, cleanup_agent_from_cluster
+
+CLUSTER_NAME = get_filename_as_cluster_name(__file__)
+
+
+@pytest.mark.parametrize("setup_cluster", ["1.25.11", "1.23.17"], indirect=True)
+def test_agent_on_legacy_k8s_versions(setup_cluster, kube_client):
+    output, exit_code = helm_agent_install(CLUSTER_NAME)
+    assert exit_code == 0, "helm install failed, output: {}".format(output)
+
+    deployment_name = f"{RELEASE_NAME}-komodor-agent"
+    pod_name = find_pod_name_by_deployment(deployment_name, NAMESPACE)
+
+    look_for_errors_in_pod_log(pod_name, "k8s-watcher")
+
+
+
+

--- a/.buildkite/tests/values_capabilities_events_test.py
+++ b/.buildkite/tests/values_capabilities_events_test.py
@@ -1,6 +1,7 @@
 import time
 import json
 import pytest
+from helpers.kubernetes_helper import rollout_restart_and_wait
 from config import BE_BASE_URL
 from fixtures import setup_cluster, cleanup_agent_from_cluster
 from helpers.utils import cmd, get_filename_as_cluster_name
@@ -10,30 +11,48 @@ from helpers.komodor_helper import create_komodor_uid, query_backend
 CLUSTER_NAME = get_filename_as_cluster_name(__file__)
 
 
-# define events.watchnamespace
-@pytest.mark.flaky(reruns=3)
-def test_events_watch_namespace(setup_cluster):
-    def query_events(namespace, deployment, start_time, end_time):
-        kuid = create_komodor_uid("Deployment", deployment, namespace, CLUSTER_NAME)
-        url = f"{BE_BASE_URL}/resources/api/v1/events/general?fromEpoch={start_time}&toEpoch={end_time}&komodorUids={kuid}"
-        return query_backend(url)
+def query_events(namespace, deployment, start_time, end_time):
+    kuid = create_komodor_uid("Deployment", deployment, namespace, CLUSTER_NAME)
+    url = f"{BE_BASE_URL}/resources/api/v1/events/general?fromEpoch={start_time}&toEpoch={end_time}&komodorUids={kuid}"
+    return query_backend(url)
 
-    watch_namespace = "client-namespace"
-    watch_deployment = "nc-client"
-    un_watch_namespace = "server-namespace"
-    un_watch_deployment = "nc-server"
+
+@pytest.fixture
+def install_agent(setup_cluster):
+    def _install_agent(cluster_name, additional_settings):
+        output, exit_code = helm_agent_install(cluster_name, additional_settings=additional_settings)
+        assert exit_code == 0, f"Agent installation failed, output: {output}"
+    return _install_agent
+
+
+@pytest.fixture
+def restart_deployment():
+    def _restart_deployment(deployment, namespace):
+        assert rollout_restart_and_wait(deployment, namespace), f"Failed to restart deployment {deployment} in namespace {namespace}"
+    return _restart_deployment
+
+
+@pytest.mark.parametrize(
+    "watch_namespace, watch_deployment, un_watch_namespace, un_watch_deployment, additional_settings",
+    [
+        ("client-namespace", "nc-client", "server-namespace", "nc-server", "--set capabilities.events.watchNamespace=client-namespace"),
+        ("server-namespace", "nc-server", "client-namespace", "nc-client", "--set capabilities.events.namespacesDenylist={client-namespace}")
+    ],
+    ids=["watch_namespace", "namespacesDenylist"]
+)
+@pytest.mark.flaky(reruns=3)
+def test_namespace_behavior(
+        setup_cluster, install_agent, restart_deployment,
+        watch_namespace, watch_deployment, un_watch_namespace, un_watch_deployment, additional_settings):
     start_time = int(time.time() * 1000)
     end_time = int(time.time() * 1000) + 120_000  # two minutes from now
 
-    output, exit_code = helm_agent_install(CLUSTER_NAME, additional_settings=f"--set capabilities.events.watchNamespace={watch_namespace}")
-    assert exit_code == 0, f"Agent installation failed, output: {output}"
+    # Install agent
+    install_agent(CLUSTER_NAME, additional_settings)
 
-    # Create deploy event
-    cmd(f'kubectl rollout restart deployment/{watch_deployment} -n {watch_namespace}')
-    cmd(f'kubectl rollout restart deployment/{un_watch_deployment} -n {un_watch_namespace}')
-
-    # Wait for event to be sent
-    time.sleep(10)
+    # Restart deployments
+    restart_deployment(watch_deployment, watch_namespace)
+    restart_deployment(un_watch_deployment, un_watch_namespace)
 
     # Verify events from watched namespace
     response = query_events(watch_namespace, watch_deployment, start_time, end_time)
@@ -43,43 +62,7 @@ def test_events_watch_namespace(setup_cluster):
     # Verify that we dont get events from unwatched namespace
     response = query_events(un_watch_namespace, un_watch_deployment, start_time, end_time)
     assert response.status_code == 200, f"Failed to get configmap from resources api, response: {response}"
-    assert len(response.json()['event_deploy']) == 0, f"Failed to get event_deploy from resources api, response: {response.json()}"
-
-
-# Block namespace and validate that no events are sent
-@pytest.mark.flaky(reruns=3)
-def test_block_namespace(setup_cluster):
-    def query_events(namespace, deployment, start_time, end_time):
-        kuid = create_komodor_uid("Deployment", deployment, namespace, CLUSTER_NAME)
-        url = f"{BE_BASE_URL}/resources/api/v1/events/general?fromEpoch={start_time}&toEpoch={end_time}&komodorUids={kuid}"
-        return query_backend(url)
-
-    un_watch_namespace = "client-namespace"
-    un_watch_deployment = "nc-client"
-    watch_namespace = "server-namespace"
-    watch_deployment = "nc-server"
-    start_time = int(time.time() * 1000)
-    end_time = int(time.time() * 1000) + 120_000  # two minutes from now
-
-    output, exit_code = helm_agent_install(CLUSTER_NAME, additional_settings=f"--set capabilities.events.namespacesDenylist={{{un_watch_namespace}}}")
-    assert exit_code == 0, f"Agent installation failed, output: {output}"
-
-    # Create deploy event
-    cmd(f'kubectl rollout restart deployment/{watch_deployment} -n {watch_namespace}')
-    cmd(f'kubectl rollout restart deployment/{un_watch_deployment} -n {un_watch_namespace}')
-
-    # Wait for event to be sent
-    time.sleep(15)
-
-    # Verify events from watched namespace
-    response = query_events(watch_namespace, watch_deployment, start_time, end_time)
-    assert response.status_code == 200, f"Failed to get configmap from resources api, response: {response}"
-    assert len(response.json()['event_deploy']) > 0, f"Failed to get event_deploy from resources api, response: {response}"
-
-    # Verify that we dont get events from unwatched namespace
-    response = query_events(un_watch_namespace, un_watch_deployment, start_time, end_time)
-    assert response.status_code == 200, f"Failed to get configmap from resources api, response: {response}"
-    assert len(response.json()['event_deploy']) == 0, f"Failed to get event_deploy from resources api, response: {response}"
+    assert len(response.json()['event_deploy']) == 0, f"Found events for un-watched namespace {un_watch_namespace}, response: {response.json()}"
 
 
 @pytest.mark.flaky(reruns=3)
@@ -92,8 +75,7 @@ def test_redact_workload_names(setup_cluster):
     output, exit_code = helm_agent_install(CLUSTER_NAME, additional_settings="--set capabilities.events.redact={TOP_SECRET}")
     assert exit_code == 0, f"Agent installation failed, output: {output}"
 
-    cmd(f'kubectl rollout restart deployment/{deployment} -n {namespace}')
-    time.sleep(10)
+    rollout_restart_and_wait(deployment, namespace)
 
     kuid = create_komodor_uid("Deployment", deployment, namespace, CLUSTER_NAME)
     url = (f"{BE_BASE_URL}/resources/api/v1/deploys/events/search"

--- a/scripts/helm-migration/Makefile
+++ b/scripts/helm-migration/Makefile
@@ -30,4 +30,4 @@ endif
 
 .PHONY: release
 release: all
-	gh release create v$(VERSION) $(DIST_DIR)/* --title "$(APP_NAME) v$(VERSION)" --notes-file release-notes.md --draft
+	gh release create v$(VERSION) $(DIST_DIR)/* --title "$(APP_NAME) v$(VERSION)" --notes-file release-note.md --draft

--- a/scripts/helm-migration/Makefile
+++ b/scripts/helm-migration/Makefile
@@ -2,7 +2,8 @@
 APP_NAME = komodor-helm-migration
 GO = go
 DIST_DIR = ./dist
-LDFLAGS = -ldflags "-X main.version=$(VERSION)"
+COMMIT := $(shell git rev-parse HEAD)
+LDFLAGS = -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT)"
 
 .PHONY: all windows linux darwin clean check-version
 
@@ -26,3 +27,7 @@ check-version:
 ifndef VERSION
 	$(error VERSION is not set. Use make all VERSION=x.y.z to set the version.)
 endif
+
+.PHONY: release
+release: all
+	gh release create v$(VERSION) $(DIST_DIR)/* --title "$(APP_NAME) v$(VERSION)" --notes-file release-notes.md --draft

--- a/scripts/helm-migration/main.go
+++ b/scripts/helm-migration/main.go
@@ -18,6 +18,7 @@ type HelmRelease struct {
 }
 
 var version = "dev"
+var commit = "none"
 
 func main() {
 	var outputFile string
@@ -64,7 +65,7 @@ func printUpdateCommand(releaseName string, outputFile string, namespace string)
 
 func showVersionAndExit(showVersion bool) {
 	if showVersion {
-		fmt.Printf("Version: %s\n", version)
+		fmt.Printf("Version: %s, Commit: %s\n", version, commit)
 		os.Exit(0)
 	}
 }

--- a/scripts/helm-migration/mapping.go
+++ b/scripts/helm-migration/mapping.go
@@ -7,8 +7,8 @@ var mapping = map[string]string{
 	"supervisor.enabled":   "capabilities.supervisor",
 	"enableRWCache":        "capabilities.events.enableRWCache",
 
-	"watcher.actions.basic":       "capabilities.actions.basic",
-	"watcher.actions.advanced":    "capabilities.actions.advanced",
+	"watcher.actions.basic":       "capabilities.actions",
+	"watcher.actions.advanced":    "",
 	"watcher.actions.podExec":     "",
 	"watcher.actions.portforward": "",
 	"watcher.allowReadingPodLogs": "capabilities.logs.enabled",

--- a/scripts/helm-migration/release-note.md
+++ b/scripts/helm-migration/release-note.md
@@ -1,0 +1,25 @@
+We are excited to announce a new release of the Komodor-Helm-Migration tool,
+which facilitates a seamless transition from the old Helm chart, k8s-watcher, to our new and improved Helm chart, komodor-agent.
+
+## Usage
+
+To utilize this tool, execute the following command:
+
+```bash
+komodor-helm-migration_<OS>_<ARCH> [options]
+```
+
+### Options:
+
+- `-o string`: Specify the output values file. Default is `komodor_watcher_values.yaml`.
+- `-r string`: Specify the release name. Default is `k8s-watcher`.
+- `-v`: Show the version of the tool and exit.
+
+## What does the tool do?
+
+Upon execution, this tool will generate a values file that can be used with the new `komodor-agent` Helm chart. 
+Additionally, it provides step-by-step instructions on uninstalling the old `k8s-watcher` chart and installing the new `komodor-agent` chart, ensuring a smooth migration.
+
+## Download
+
+Grab the latest release from the assets section below to get started!


### PR DESCRIPTION
* Update basic test to check for errors in k8s-watcher logs (validated it detects the CSI Storage issue fixed yesterday)
* Add a new test to check for agent logs in old k8s versions (1.23 & 1.25)
* Fix bug in `publish` script
* Fix a bug in the mapping of the migration script
* Add a `release` target in the migration script makefile to create a draft release in case we will need to release more versions.