### PR TITLE
Helm uninstall not working due to lack permissions

### DIFF
--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -182,7 +182,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | allowedResources.persistentVolume | bool | `true` | Enables watching `persistentVolumes` |
 | allowedResources.persistentVolumeClaim | bool | `true` | Enables watching `persistentVolumeClaims` |
 | allowedResources.namespace | bool | `true` | Enables watching `namespaces` |
-| allowedResources.secret | bool | `false` | Enables watching `secrets` |
+| allowedResources.secret | bool | `true` | Enables watching `secrets` |
 | allowedResources.configMap | bool | `true` | Enables watching `configmaps` |
 | allowedResources.ingress | bool | `true` | Enables watching `ingresses` |
 | allowedResources.endpoints | bool | `true` | Enables watching `endpoints` |

--- a/charts/komodor-agent/templates/clusterrole.yaml
+++ b/charts/komodor-agent/templates/clusterrole.yaml
@@ -467,6 +467,11 @@ rules:
       - list
       - get
       - watch
+
+  # Allow to uninstall charts
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["delete", "list", "get"]
 {{- end}}
 
 {{- if .Values.allowedResources.allowReadAll }}

--- a/charts/komodor-agent/templates/configmap.yaml
+++ b/charts/komodor-agent/templates/configmap.yaml
@@ -34,8 +34,15 @@ data:
       enable: {{ .Values.capabilities.networkMapper }}
     resync:
       period: "0"
+
+    {{ with merge (dict "secret" true) .Values.allowedResources }}
     resources:
-      {{ toYaml .Values.allowedResources | trim | nindent 6 }}
+      {{- if $.Values.capabilities.helm -}}
+      {{- toYaml . | nindent 6 }}
+      {{- else -}}
+      {{- toYaml $.Values.allowedResources | nindent 6 }}
+      {{- end -}}
+    {{- end }}
 
   installed-values.yaml: |
-    {{ toYaml .Values | nindent 4 }}   
+    {{ toYaml .Values | nindent 4 }}

--- a/charts/komodor-agent/templates/configmap.yaml
+++ b/charts/komodor-agent/templates/configmap.yaml
@@ -35,14 +35,8 @@ data:
     resync:
       period: "0"
 
-    {{ with merge (dict "secret" true) .Values.allowedResources }}
     resources:
-      {{- if $.Values.capabilities.helm -}}
-      {{- toYaml . | nindent 6 }}
-      {{- else -}}
-      {{- toYaml $.Values.allowedResources | nindent 6 }}
-      {{- end -}}
-    {{- end }}
+      {{- toYaml .Values.allowedResources | nindent 6 }}
 
   installed-values.yaml: |
     {{ toYaml .Values | nindent 4 }}

--- a/charts/komodor-agent/templates/configmap.yaml
+++ b/charts/komodor-agent/templates/configmap.yaml
@@ -36,7 +36,7 @@ data:
       period: "0"
 
     resources:
-      {{- toYaml .Values.allowedResources | nindent 6 }}
+      {{- toYaml .Values.allowedResources | trim | nindent 6 }}
 
   installed-values.yaml: |
     {{ toYaml .Values | nindent 4 }}

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -262,7 +262,7 @@ allowedResources:
   # allowedResources.namespace -- Enables watching `namespaces`
   namespace: true
   # allowedResources.secret -- Enables watching `secrets`
-  secret: false
+  secret: true
   # allowedResources.configMap -- Enables watching `configmaps`
   configMap: true
   # allowedResources.ingress -- Enables watching `ingresses`


### PR DESCRIPTION
Enable secrets by default when helm capability is enabled.
Allow deleting all resources when helm capability is enabled (Allow * delete in cluster role). 
Do not bump k8s-watcher chart version if not needed.