### PR TITLE
Komodor agent fix proxy

### DIFF
--- a/.buildkite/tests/helpers/kubernetes_helper.py
+++ b/.buildkite/tests/helpers/kubernetes_helper.py
@@ -136,6 +136,6 @@ def rollout_restart_and_wait(deployment_name, namespace):
 def read_file_from_pod(pod_name, namespace, file_path):
     get_file_content_command = f"kubectl exec {pod_name} -n {namespace} -- cat {file_path}"
 
-    output = cmd(get_file_content_command)
-    return output[0] if output else None
+    output, exit_code = cmd(get_file_content_command)
+    return output if exit_code == 0 else None
 

--- a/.buildkite/tests/helpers/kubernetes_helper.py
+++ b/.buildkite/tests/helpers/kubernetes_helper.py
@@ -132,3 +132,10 @@ def rollout_restart_and_wait(deployment_name, namespace):
     output, exit_code = cmd(f'kubectl rollout status deployment/{deployment_name} -n {namespace}')
     return exit_code == 0
 
+
+def read_file_from_pod(pod_name, namespace, file_path):
+    get_file_content_command = f"kubectl exec {pod_name} -n {namespace} -- cat {file_path}"
+
+    output = cmd(get_file_content_command)
+    return output[0] if output else None
+

--- a/.buildkite/tests/test-data/mitm-proxy.yaml
+++ b/.buildkite/tests/test-data/mitm-proxy.yaml
@@ -4,6 +4,19 @@ metadata:
   name: proxy
 ---
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mitm-script
+  namespace: proxy
+data:
+  log_urls.py: |
+    from mitmproxy import http
+    def response(flow: http.HTTPFlow):
+        with open("/tmp/accessed_urls.log", "a") as log:
+            log.write(flow.request.url + "\n")
+
+---
+apiVersion: v1
 kind: Pod
 metadata:
   name: mitm
@@ -12,10 +25,17 @@ metadata:
     proxy: mitmproxy
 spec:
   containers:
-    - name: mitmweb
-      image: mitmproxy/mitmproxy
-      command: ["mitmweb"]
-      args: ["--web-host","0.0.0.0", "--set", "block_global=false"]
+  - name: mitmweb
+    image: mitmproxy/mitmproxy
+    command: ["mitmweb"]
+    args: ["-s", "/scripts/log_urls.py", "--web-host", "0.0.0.0", "--set", "block_global=false"]
+    volumeMounts:
+    - name: script-volume
+      mountPath: /scripts
+  volumes:
+  - name: script-volume
+    configMap:
+      name: mitm-script
 ---
 apiVersion: v1
 kind: Service

--- a/.buildkite/tests/values_capabilities_proxy_test.py
+++ b/.buildkite/tests/values_capabilities_proxy_test.py
@@ -1,11 +1,22 @@
 import pytest
+import time
 from config import NAMESPACE
 from fixtures import setup_cluster, kube_client, cleanup_agent_from_cluster
 from helpers.utils import cmd, get_filename_as_cluster_name
 from helpers.helm_helper import helm_agent_install
-from helpers.kubernetes_helper import create_namespace,wait_for_pod_ready
+from helpers.kubernetes_helper import create_namespace,wait_for_pod_ready, read_file_from_pod
 
 CLUSTER_NAME = get_filename_as_cluster_name(__file__)
+PROXY_POD_NAME = "mitm"
+PROXY_NAMESPACE = "proxy"
+PROXY_URL = "http://mitm.proxy:8080"
+KOMODOR_SERVICE_URLS = [
+    "https://app.komodor.com/k8s-events",
+    "https://app.komodor.com/k8s-events/event",
+    "https://app.komodor.com/k8s-events/agent",
+    "https://app.komodor.com/metrics-collector",
+    "https://app.komodor.com/agent-task-manager",
+]
 
 
 @pytest.mark.flaky(reruns=3)
@@ -53,9 +64,31 @@ def test_use_proxy_and_custom_ca(setup_cluster, kube_client):
 
     # install with proxy and custom ca
     output, exit_code = helm_agent_install(CLUSTER_NAME, additional_settings=f"--set proxy.enabled=true "
-                                                               f"--set proxy.http=http://mitm.proxy:8080 "
-                                                               f"--set proxy.https=http://mitm.proxy:8080 "
+                                                               f"--set proxy.http={PROXY_URL} "
+                                                               f"--set proxy.https={PROXY_URL} "
                                                                f"--set customCa.enabled=true "
                                                                f"--set customCa.secretName={secret_name} ")
 
     assert exit_code == 0, f"Agent installation failed, output: {output}"
+
+    verify_communication_through_proxy()
+
+
+def verify_communication_through_proxy():
+    attempts = 12
+    success = False
+    for attempt in range(attempts):
+        try:
+            mitm_access_log = read_file_from_pod(PROXY_POD_NAME, PROXY_NAMESPACE, "/tmp/accessed_urls.log")
+            if mitm_access_log:
+                for url in KOMODOR_SERVICE_URLS:
+                    assert url in mitm_access_log, f"Failed to find {url} in proxy access log"
+                success = True
+                break
+        except AssertionError as e:
+            print(f"Attempt {attempt + 1} failed: {e}")
+
+        if attempt < attempts - 1:
+            time.sleep(10)
+
+    assert success, "Failed to read mitmproxy access log or find URLs after 5 attempts"

--- a/.buildkite/tests/values_capabilities_proxy_test.py
+++ b/.buildkite/tests/values_capabilities_proxy_test.py
@@ -47,6 +47,10 @@ def test_use_proxy_and_custom_ca(setup_cluster, kube_client):
     create_namespace(kube_client)
     secret_name = "mitmproxysecret"
     cmd(f"kubectl create secret generic {secret_name}  --from-file={root_ca_path} -n {NAMESPACE}")
+
+    # TODO: Find a way to add networkpolicy to prevent the agent from reaching the internet directly.
+    #  (at the moment it's not possible natively in kind)
+
     # install with proxy and custom ca
     output, exit_code = helm_agent_install(CLUSTER_NAME, additional_settings=f"--set proxy.enabled=true "
                                                                f"--set proxy.http=http://mitm.proxy:8080 "

--- a/.buildkite/tests/values_capabilities_proxy_test.py
+++ b/.buildkite/tests/values_capabilities_proxy_test.py
@@ -91,4 +91,4 @@ def verify_communication_through_proxy():
         if attempt < attempts - 1:
             time.sleep(10)
 
-    assert success, "Failed to read mitmproxy access log or find URLs after 5 attempts"
+    assert success, f"Failed to read mitmproxy access log or find URLs after {attempts} attempts"

--- a/charts/komodor-agent/templates/daemonset.yaml
+++ b/charts/komodor-agent/templates/daemonset.yaml
@@ -37,8 +37,10 @@ spec:
         {{- include "metrics.daemonset.volumes" .        | nindent 8 }}
         {{- include "network_mapper.daemonset.volumes" . | nindent 8 }}
         {{- include "custom-ca.volume" .                 | nindent 8 }}
+        {{- include "custom-ca.trusted-volume" .         | nindent 8 }}
       initContainers:
         {{- include "metrics.daemonset.init.container" . | nindent 8 }}
+        {{- include "ca-init.container" .                | nindent 8 }}
 
 
 {{- end }}

--- a/charts/komodor-agent/templates/metrics/_containers.tpl
+++ b/charts/komodor-agent/templates/metrics/_containers.tpl
@@ -34,6 +34,7 @@
   - name: {{ include "metrics.daemon.config.name" . }}
     mountPath: /etc/telegraf/telegraf.conf
     subPath: telegraf.conf
+  {{- include "custom-ca.trusted-volumeMounts" . | indent 2 }}
   envFrom:
   - configMapRef:
       name:  "k8s-watcher-daemon-env-vars"

--- a/charts/komodor-agent/templates/metrics/configmap-daemon.yaml
+++ b/charts/komodor-agent/templates/metrics/configmap-daemon.yaml
@@ -18,9 +18,9 @@ data:
       timeout = "${OUTPUT_TIMEOUT}"
       content_encoding = "gzip"
       {{- if .Values.proxy.https }}
-      http_proxy_url = "${KOMOKW_HTTPS_PROXY_URL}"
+      http_proxy_url = "${KOMOKW_HTTPS_PROXY}"
       {{- else if .Values.proxy.http }}
-      http_proxy_url = "${KOMOKW_HTTP_PROXY_URL}"
+      http_proxy_url = "${KOMOKW_HTTP_PROXY}"
       {{- end }}
       [outputs.http.headers]
         X-ACCOUNT-ID = "${ACCOUNT_ID}"

--- a/charts/komodor-agent/templates/metrics/configmap.yaml
+++ b/charts/komodor-agent/templates/metrics/configmap.yaml
@@ -20,9 +20,9 @@ data:
       content_encoding = "gzip"
       metric_batch_size= ${BATCH_SIZE}
       {{- if .Values.proxy.https }}
-      http_proxy_url = "${KOMOKW_HTTPS_PROXY_URL}"
+      http_proxy_url = "${KOMOKW_HTTPS_PROXY}"
       {{- else if .Values.proxy.http }}
-      http_proxy_url = "${KOMOKW_HTTP_PROXY_URL}"
+      http_proxy_url = "${KOMOKW_HTTP_PROXY}"
       {{- end }}
       [outputs.http.headers]
         X-ACCOUNT-ID = "${ACCOUNT_ID}"


### PR DESCRIPTION
Add proxy not working for metrics.
* Wrong env var name
* Missing CA trusted store

Update proxy test
* Make sure the connections of the agent and metrics are passing through the proxy

TODO:
* Add `networkpolicy` to block direct internet access from the agent to the internet in the proxy test