### PR TITLE
CU-867985xym - Generate GitHub release from GH issue messages

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -193,6 +193,18 @@ steps:
     agents:
       builder: "dind"
     if: build.message !~ /feat\(OSS.+\):/i && build.branch == "master"
+
+  - label: Create GitHub release
+    commands:
+      - ./.buildkite/pipeline_scripts/create_gh_pre_release.sh
+    plugins:
+      - zacharymctague/aws-ssm#v1.0.0:
+          parameters:
+            GH_TOKEN: /komo-cli/github/search-token
+
+    agents:
+      builder: "non-docker"
+    if: build.message !~ /feat\(OSS.+\):/i && build.branch == "master"
   - wait
 
   - label: ":eyeglasses: LEGACY: validate helm chart version updated"

--- a/.buildkite/pipeline_scripts/bump_version.sh
+++ b/.buildkite/pipeline_scripts/bump_version.sh
@@ -26,12 +26,14 @@ generate_next_version() {
     local tags=$(git tag -l 'komodor-agent/*' | awk -F'/' '{print $NF}')
     local latest_tag=$(printf "%s\n" "${tags[@]}" | sort -V | tail -n 1 | tr '[:lower:]' '[:upper:]')
 
+    local latest_ga_version=${latest_tag%+RC*}
+    buildkite-agent meta-data set "komodor-agent-ga-version" "$latest_ga_version"
+
     if [[ ${increment_type} == "rc" ]]; then
         if [[ ${latest_tag} == *"+RC"* ]]; then
-            local base_version=${latest_tag%+RC*}
             local rc_part=${latest_tag##*+RC}
             local next_rc_number=$(( rc_part + 1 ))
-            echo "${base_version}+RC${next_rc_number}"
+            echo "${latest_ga_version}+RC${next_rc_number}"
         else
             echo "${latest_tag}+RC1"
         fi

--- a/.buildkite/pipeline_scripts/create_gh_pre_release.sh
+++ b/.buildkite/pipeline_scripts/create_gh_pre_release.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Script to generate release notes from PR comments for Helm Chart and Agent repositories
+
+# General Configuration
+REPO_OWNER="komodorio"
+
+# Helm-chart Repository Configuration
+HELM_CHART_REPO="helm-charts"
+CHART="komodor-agent"
+
+# Helm Chart Version Information
+HELM_CHART_REPO_TAG1="${CHART}/$(buildkite-agent meta-data get ${CHART}-ga-version)"
+HELM_CHART_REPO_TAG2="${CHART}/$(buildkite-agent meta-data get ${CHART}-version)"
+AGENT_VERSION=$(buildkite-agent meta-data get "agent-version")
+
+# Agent Repository Configuration
+AGENT_REPO="komodor-agent"
+# Fetch the last two tags from the additional repository
+AGENT_REPO_TAGS=($(gh api repos/"$REPO_OWNER"/"$AGENT_REPO"/tags --jq '.[].name' | head -n 2))
+AGENT_REPO_TAG1=${AGENT_REPO_TAGS[1]} # Second last tag
+AGENT_REPO_TAG2=${AGENT_REPO_TAGS[0]} # Last tag
+
+
+collect_comments() {
+    local repo=$1
+    local pr_number=$2
+    echo "Processing PR #$pr_number from $repo"
+
+    local comments
+    comments=$(gh api repos/"$REPO_OWNER"/"$repo"/issues/"$pr_number"/comments | jq -r '.[] | select(.body | startswith("public: ")) | .body')
+
+    # Format and append each comment
+    echo "$comments" | while read -r comment; do
+        if [[ -n $comment ]]; then
+            echo "${comment#public: }" | sed 's/^/* /' >> release_notes.txt
+        fi
+    done
+}
+
+process_repository() {
+    local repo=$1
+    local tag1=$2
+    local tag2=$3
+    local section_title=$4
+
+    echo -e "\n## ${section_title}" >> release_notes.txt
+
+    # Collect comments from PRs between the two tags
+    local commit_messages
+    commit_messages=$(gh api repos/"$REPO_OWNER"/"$repo"/compare/"$tag1"..."$tag2" --jq '.commits[].commit.message')
+
+    for msg in $commit_messages; do
+        # Extract PR number from commit message e.g. "(#123)"
+        if [[ $msg =~ \(\#([0-9]+)\) ]]; then
+            local pr_number=${BASH_REMATCH[1]}
+            collect_comments "$repo" "$pr_number"
+        fi
+    done
+}
+
+########################
+# Main Execution Block #
+########################
+
+# Initialize release notes file
+echo "## Helm Chart Updates" > release_notes.txt
+echo "\`${HELM_CHART_REPO_TAG1}\` -> \`${HELM_CHART_REPO_TAG2}\`" >> release_notes.txt
+
+# Process Helm Chart Repository
+process_repository "$HELM_CHART_REPO" "$HELM_CHART_REPO_TAG1" "$HELM_CHART_REPO_TAG2" "Helm Chart Updates"
+
+# Process Agent Repository
+process_repository "$AGENT_REPO" "$AGENT_REPO_TAG1" "$AGENT_REPO_TAG2" "Agent Updates (${AGENT_VERSION})"
+
+# Create a pre-release on GitHub with the collected comments
+gh release create "$HELM_CHART_REPO_TAG2" --title "${HELM_CHART_REPO_TAG2}" --notes-file release_notes.txt --prerelease

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 charts/**/templates-test/
 __pycache__/
 .pytest_cache/
+release_notes.txt


### PR DESCRIPTION
Generate GitHub release for the RC version as `pre-release`

The new script looks for `public: ` messages in the repo between the last GA version and the current RC version.
In addition, it also looks for all `public: ` messages in the `komodor-agent` repo between the last and (last - 1) tag and adds the message to the release.