### PR TITLE
[skip ci] Unified komodor-agent image

### DIFF
--- a/charts/k8s-watcher/Chart.yaml
+++ b/charts/k8s-watcher/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 name: k8s-watcher
 description: Watches and sends kubernetes resource-related events
 icon: https://raw.githubusercontent.com/komodorio/helm-charts/master/k8s-watcher.svg
-version: 1.17.20
+version: 1.18.0
 appVersion: 0.2.68

--- a/charts/k8s-watcher/templates/deployment.yaml
+++ b/charts/k8s-watcher/templates/deployment.yaml
@@ -63,9 +63,8 @@ spec:
           volumeMounts:
             - name: agent-configuration
               mountPath: /etc/komodor
+          command: ["supervisor"]
           env:
-            - name: AGENT_ENTRY
-              value: "supervisor"
             - name: KOMOKW_API_KEY
               valueFrom:
                 secretKeyRef:
@@ -109,6 +108,7 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["watcher"]
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
@@ -130,8 +130,6 @@ spec:
 {{- end }}
 {{- include "custom-ca.trusted-volumeMounts" . | nindent 12 }}
           env:
-            - name: AGENT_ENTRY
-              value: "watcher"
             - name: KOMOKW_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/k8s-watcher/templates/deployment.yaml
+++ b/charts/k8s-watcher/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
 {{- if ne (default false (.Values.customCa).enabled) false }}
       initContainers:
         - name: init-cert
-          image: "{{ ((.Values.supervisor.image)).repository | default "public.ecr.aws/komodor-public/supervisor" }}:{{ ((.Values.supervisor.image)).tag | default .Chart.AppVersion }}"
+          image: "{{ ((.Values.supervisor.image)).repository | default "public.ecr.aws/komodor-public/komodor-agent" }}:{{ ((.Values.supervisor.image)).tag | default .Chart.AppVersion }}"
           command: 
             - sh
             - -c
@@ -56,7 +56,7 @@ spec:
         
 {{- if ((.Values.supervisor)).enabled }}
         - name: "supervisor"
-          image: "{{ ((.Values.supervisor.image)).repository | default "public.ecr.aws/komodor-public/supervisor" }}:{{ ((.Values.supervisor.image)).tag | default .Chart.AppVersion }}"
+          image: "{{ ((.Values.supervisor.image)).repository | default "public.ecr.aws/komodor-public/komodor-agent" }}:{{ ((.Values.supervisor.image)).tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ ((.Values.supervisor.image)).pullPolicy | default "IfNotPresent" }}
           resources:
             {{- toYaml .Values.supervisor.resources | nindent 12 }}
@@ -64,6 +64,8 @@ spec:
             - name: agent-configuration
               mountPath: /etc/komodor
           env:
+            - name: AGENT_ENTRY
+              value: "supervisor"
             - name: KOMOKW_API_KEY
               valueFrom:
                 secretKeyRef:
@@ -128,6 +130,8 @@ spec:
 {{- end }}
 {{- include "custom-ca.trusted-volumeMounts" . | nindent 12 }}
           env:
+            - name: AGENT_ENTRY
+              value: "watcher"
             - name: KOMOKW_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/k8s-watcher/templates/metrics/init-container.yaml
+++ b/charts/k8s-watcher/templates/metrics/init-container.yaml
@@ -27,8 +27,6 @@
   {{- toYaml .Values.daemon.init.resources | nindent 4 }}
   {{- end }}
   env:
-  - name: AGENT_ENTRY
-    value: "daemon"
   {{- if hasKey .Values "namespace" }}
   - name: NAMESPACE
     value: {{ .Values.namespace }}

--- a/charts/k8s-watcher/templates/metrics/init-container.yaml
+++ b/charts/k8s-watcher/templates/metrics/init-container.yaml
@@ -1,7 +1,7 @@
 {{- define "metrics.init" }}
 {{- if ne (.Values.metrics).enabled false }}
 - name: init-daemon
-  image: '{{ (((.Values.daemon).init).image).repository | default "public.ecr.aws/komodor-public/init-daemon-agent" }}:{{ .Values.image.tag | default .Chart.AppVersion }}'
+  image: '{{ (((.Values.daemon).init).image).repository | default "public.ecr.aws/komodor-public/komodor-agent" }}:{{ .Values.image.tag | default .Chart.AppVersion }}'
   imagePullPolicy: {{ (((.Values.daemon).init).image).pullPolicy | default "IfNotPresent" }}
   {{- if ne (default false (.Values.customCa).enabled) false }}
   command:
@@ -27,6 +27,8 @@
   {{- toYaml .Values.daemon.init.resources | nindent 4 }}
   {{- end }}
   env:
+  - name: AGENT_ENTRY
+    value: "daemon"
   {{- if hasKey .Values "namespace" }}
   - name: NAMESPACE
     value: {{ .Values.namespace }}

--- a/charts/k8s-watcher/values.yaml
+++ b/charts/k8s-watcher/values.yaml
@@ -1,7 +1,7 @@
 # ReplicaCount should always be 1 - We do not properly support syncing state (yet) so it will cause the same events to be sent and overload the server.
 replicaCount: 1
 image:
-  repository: public.ecr.aws/komodor-public/k8s-watcher
+  repository: public.ecr.aws/komodor-public/komodor-agent
   pullPolicy: IfNotPresent
 
 namespace: komodor
@@ -56,7 +56,7 @@ helm:
 supervisor:
   enabled: true
   image:
-    repository: public.ecr.aws/komodor-public/supervisor
+    repository: public.ecr.aws/komodor-public/komodor-agent
     pullPolicy: IfNotPresent
   resources:
     requests:
@@ -75,7 +75,7 @@ daemon:
     pullPolicy: IfNotPresent
   init:
     image:
-      repository: public.ecr.aws/komodor-public/init-daemon-agent
+      repository: public.ecr.aws/komodor-public/komodor-agent
       pullPolicy: IfNotPresent
       resources: {}
   resources: {}

--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -168,7 +168,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorDaemon.networkSniffer.image | object | `{"name":"network-mapper-sniffer","tag":"v1.0.3"}` | Override the komodor agent network sniffer image name or tag. |
 | components.komodorDaemon.networkSniffer.resources | object | `{}` | Set custom resources to the komodor agent network sniffer container |
 | components.komodorDaemon.nodeEnricher | object | See sub-values | Configure the komodor daemon node enricher components |
-| components.komodorDaemon.nodeEnricher.image | object | `{"name":"node_enricher","tag":null}` | Override the komodor agent node enricher image name or tag. |
+| components.komodorDaemon.nodeEnricher.image | object | `{"name":"komodor-agent","tag":null}` | Override the komodor agent node enricher image name or tag. |
 | components.komodorDaemon.nodeEnricher.resources | object | `{}` | Set custom resources to the komodor agent node enricher container |
 | components.komodorDaemon.nodeEnricher.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | allowedResources.event | bool | `true` | Enables watching `event` |

--- a/charts/komodor-agent/templates/metrics/_containers.tpl
+++ b/charts/komodor-agent/templates/metrics/_containers.tpl
@@ -44,6 +44,8 @@
     mountPath: /etc/komodor
   {{- include "custom-ca.volumeMounts" . | nindent 2 }}
   env:
+  - name: AGENT_ENTRY
+    value: daemon
   - name: NAMESPACE
     value: {{ .Release.Namespace }}
   - name: KOMOKW_API_KEY

--- a/charts/komodor-agent/templates/metrics/_containers.tpl
+++ b/charts/komodor-agent/templates/metrics/_containers.tpl
@@ -36,6 +36,7 @@
 - name: init-daemon
   image: {{ .Values.imageRepo }}/{{ .Values.components.komodorDaemon.metricsInit.image.name}}:{{ .Values.components.komodorDaemon.metricsInit.image.tag | default .Chart.AppVersion }}
   imagePullPolicy: {{ .Values.pullPolicy }}
+  command: ["daemon"]
   resources:
     {{ toYaml .Values.components.komodorDaemon.metricsInit.resources | trim | nindent 4 }}
   {{ include "custom-ca.trusted-init-container.command" . | indent 2 }}
@@ -44,8 +45,6 @@
     mountPath: /etc/komodor
   {{- include "custom-ca.volumeMounts" . | nindent 2 }}
   env:
-  - name: AGENT_ENTRY
-    value: daemon
   - name: NAMESPACE
     value: {{ .Release.Namespace }}
   - name: KOMOKW_API_KEY

--- a/charts/komodor-agent/templates/node-enricher/_containers.tpl
+++ b/charts/komodor-agent/templates/node-enricher/_containers.tpl
@@ -3,6 +3,7 @@
 - name: node-enricher
   image: {{ .Values.imageRepo }}/{{ .Values.components.komodorDaemon.nodeEnricher.image.name}}:{{ .Values.components.komodorDaemon.nodeEnricher.image.tag | default .Chart.AppVersion }}
   imagePullPolicy: {{ .Values.pullPolicy }}
+  command: ["node_enricher"]
   resources:
     {{ toYaml .Values.components.komodorDaemon.nodeEnricher.resources | trim | nindent 4 }}
   volumeMounts:
@@ -10,8 +11,6 @@
     mountPath: /etc/komodor
   env:
   {{- include "komodorAgent.proxy-conf" . | indent 2 }}
-  - name: AGENT_ENTRY
-    value: "node_enricher"
   - name: KOMOKW_API_KEY
     valueFrom:
       secretKeyRef:

--- a/charts/komodor-agent/templates/node-enricher/_containers.tpl
+++ b/charts/komodor-agent/templates/node-enricher/_containers.tpl
@@ -10,6 +10,8 @@
     mountPath: /etc/komodor
   env:
   {{- include "komodorAgent.proxy-conf" . | indent 2 }}
+  - name: AGENT_ENTRY
+    value: "node_enricher"
   - name: KOMOKW_API_KEY
     valueFrom:
       secretKeyRef:

--- a/charts/komodor-agent/templates/watcher/_containers.tpl
+++ b/charts/komodor-agent/templates/watcher/_containers.tpl
@@ -3,6 +3,7 @@
 - name: "k8s-watcher"
   image: {{ .Values.imageRepo }}/{{ .Values.components.komodorAgent.watcher.image.name}}:{{ .Values.components.komodorAgent.watcher.image.tag | default .Chart.AppVersion }}
   imagePullPolicy: {{ .Values.pullPolicy }}
+  command: ["watcher"]
   resources:
     {{ toYaml .Values.components.komodorAgent.watcher.resources | trim | nindent 4 }}
   volumeMounts:
@@ -24,8 +25,6 @@
   {{- end }}
   {{- include "custom-ca.trusted-volumeMounts" .  |  nindent 2 }}
   env:
-  - name: AGENT_ENTRY
-    value: "watcher"
   - name: KOMOKW_API_KEY
     valueFrom:
       secretKeyRef:

--- a/charts/komodor-agent/templates/watcher/_containers.tpl
+++ b/charts/komodor-agent/templates/watcher/_containers.tpl
@@ -79,12 +79,11 @@
   image: {{ .Values.imageRepo }}/{{ .Values.components.komodorAgent.supervisor.image.name}}:{{ .Values.components.komodorAgent.supervisor.image.tag | default .Chart.AppVersion }}
   imagePullPolicy: {{ .Values.pullPolicy }}
   resources: {{ toYaml .Values.components.komodorAgent.watcher.resources | trim | nindent 4 }}
+  command: ["supervisor"]
   volumeMounts:
     - name: agent-configuration
       mountPath: /etc/komodor
   env:
-    - name: AGENT_ENTRY
-      value: "supervisor"
     - name: KOMOKW_CLUSTER_NAME
       value: {{ .Values.clusterName }}
     - name: KOMOKW_API_KEY

--- a/charts/komodor-agent/templates/watcher/_containers.tpl
+++ b/charts/komodor-agent/templates/watcher/_containers.tpl
@@ -24,6 +24,8 @@
   {{- end }}
   {{- include "custom-ca.trusted-volumeMounts" .  |  nindent 2 }}
   env:
+  - name: AGENT_ENTRY
+    value: "watcher"
   - name: KOMOKW_API_KEY
     valueFrom:
       secretKeyRef:
@@ -82,6 +84,8 @@
     - name: agent-configuration
       mountPath: /etc/komodor
   env:
+    - name: AGENT_ENTRY
+      value: "supervisor"
     - name: KOMOKW_CLUSTER_NAME
       value: {{ .Values.clusterName }}
     - name: KOMOKW_API_KEY

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -117,7 +117,7 @@ components:
       # components.komodorAgent.watcher.image -- Override the komodor agent watcher image name or tag.
       # @default -- `{ "name": "k8s-watcher", "tag": .Chart.AppVersion }`
       image:
-        name: k8s-watcher
+        name: komodor-agent
         tag:
       # components.komodorAgent.watcher.resources -- Set custom resources to the komodor agent watcher container
       resources:
@@ -139,7 +139,7 @@ components:
       # @default -- `{ "name": "supervisor", "tag": .Chart.AppVersion }`
       image:
         # @ignored
-        name: supervisor
+        name: komodor-agent
         # @ignored
         tag:
       # components.komodorAgent.supervisor.resources -- Set custom resources to the komodor agent supervisor container
@@ -181,7 +181,7 @@ components:
       # components.komodorDaemon.metricsInit.image -- Override the komodor agent metrics init image name or tag.
       # @default -- `{ "name": "init-daemon-agent", "tag": .Chart.AppVersion }`
       image:
-        name: init-daemon-agent
+        name: komodor-agent
         tag:
       # components.komodorDaemon.metricsInit.resources -- Set custom resources to the komodor agent metrics init container
       resources: {}
@@ -219,7 +219,7 @@ components:
     nodeEnricher:
       # components.komodorDaemon.nodeEnricher.image -- Override the komodor agent node enricher image name or tag.
       image:
-        name: node_enricher
+        name: komodor-agent
         tag:
       # components.komodorDaemon.nodeEnricher.resources -- Set custom resources to the komodor agent node enricher container
       resources: {}


### PR DESCRIPTION
Move to `komodor-agent` unified image instead of `watcher`, `daemon`, `supervisor` and `node_enricher` images

CU-860t38uyf