### PR TITLE
[skip ci] fix(vulnerability scan): Error when no vuln detected

### DIFF
--- a/.buildkite/vulnerability-scan/exclude.yaml
+++ b/.buildkite/vulnerability-scan/exclude.yaml
@@ -6,8 +6,8 @@ exclusions: # []
       - CVE-2023-29404
       - CVE-2023-29405
       - CVE-2023-39323
-    Reason: "pluto uses a go lang version 1.20.4, GitHub issue: https://github.com/FairwindsOps/pluto/issues/510"
-    MuteUntil: 2023-11-30
+    Reason: "pluto uses a go lang version 1.20.4, Expected to be fixed in Pluto version > 5.19.0"
+    MuteUntil: 2024-01-30
 
   - SystemPath: /usr/local/bin/kubectl
     CVEs:

--- a/.buildkite/vulnerability-scan/main.py
+++ b/.buildkite/vulnerability-scan/main.py
@@ -113,12 +113,12 @@ def scan(image_url, max_retries=3, retry_interval=5, timeout=30):
                 continue
 
             if process.returncode != 0:
-                print(f"Error scanning image {image_url}, ({retry + 1}/{max_retries})\n\toutput: {output}, \n\terror: {e}")
+                print(f"Error scanning image {image_url}, ({retry + 1}/{max_retries})\n\toutput: {output}, \n\terror: {err}")
 
             output = json.loads(output)
             return process_results(output)
         except Exception as e:
-            print(f"Error scanning image {image_url}: {e} ({retry + 1}/{max_retries}) Error details: {err}")
+            print(f"Error scanning image {image_url}: {e} ({retry + 1}/{max_retries}) Error details: {e}")
 
     print(f"Max retries reached for image {image_url}")
     return 1, [Vulnerability({'target': image_url, 'type': 'scan error', 'vulnerabilities': []})]

--- a/.buildkite/vulnerability-scan/main.py
+++ b/.buildkite/vulnerability-scan/main.py
@@ -81,6 +81,13 @@ def filter_out_excluded_cves(vulnerabilities):
 def process_results(results):
     v_count = 0
     vulnerabilities = []
+    if 'securityFindings' not in results:
+        print("No securityFindings were found")
+        return v_count, vulnerabilities
+    if 'vulnerabilities' not in results['securityFindings']:
+        print("No vulnerabilities were found")
+        return v_count, vulnerabilities
+
     for v in results['securityFindings']['vulnerabilities']:
         vulnerabilities_with_fix = [item for item in v['vulnerabilities'] if 'FixedVersion' in item]
         vulnerabilities_to_report = filter_out_excluded_cves(vulnerabilities_with_fix)
@@ -111,7 +118,7 @@ def scan(image_url, max_retries=3, retry_interval=5, timeout=30):
             output = json.loads(output)
             return process_results(output)
         except Exception as e:
-            print(f"Error scanning image {image_url}: {e} ({retry + 1}/{max_retries})")
+            print(f"Error scanning image {image_url}: {e} ({retry + 1}/{max_retries}) Error details: {err}")
 
     print(f"Max retries reached for image {image_url}")
     return 1, [Vulnerability({'target': image_url, 'type': 'scan error', 'vulnerabilities': []})]
@@ -127,7 +134,7 @@ if __name__ == "__main__":
     scan_result = {}
     total_vulnerabilities = 0
 
-    for image in images:
+    for image in set(images):
         print(f"Scanning image {image}")
         full_image_url = f'{image_repo}/{image}'
         count, results = scan(full_image_url)

--- a/.buildkite/vulnerability-scan/main.py
+++ b/.buildkite/vulnerability-scan/main.py
@@ -113,7 +113,7 @@ def scan(image_url, max_retries=3, retry_interval=5, timeout=30):
                 continue
 
             if process.returncode != 0:
-                print(f"Error scanning image {image_url}, ({retry + 1}/{max_retries})\n\toutput: {output}, \n\terror: {err}")
+                print(f"Error scanning image {image_url}, ({retry + 1}/{max_retries})\n\toutput: {output}, \n\terror: {e}")
 
             output = json.loads(output)
             return process_results(output)


### PR DESCRIPTION
There was a change in the return data from Mend cli,
Previously we have every time the key `securityFindings.vulnerabilities` however now in case there are no vulnerabilities this key not exist in the returned data.

In addition, I've extended the exclusion of Pluto till next month.