### PR TITLE
added restarts total to metrics collector inventory plugin

### DIFF
--- a/charts/komodor-agent/templates/metrics/configmap-daemon.yaml
+++ b/charts/komodor-agent/templates/metrics/configmap-daemon.yaml
@@ -45,7 +45,7 @@ data:
       interval = "${INTERVAL_INVENTORY}"
       flush_interval = "${FLUSH_INTERVAL_INVENTORY}"
       node_name = "${NODE_NAME}"
-      fieldpass = ["resource_requests_millicpu_units","resource_limits_millicpu_units","resource_requests_memory_bytes","resource_limits_memory_bytes", "capacity_cpu_cores", "capacity_millicpu_cores", "capacity_memory_bytes"]
+      fieldpass = ["resource_requests_millicpu_units","resource_limits_millicpu_units","resource_requests_memory_bytes","resource_limits_memory_bytes", "capacity_cpu_cores", "capacity_millicpu_cores", "capacity_memory_bytes", "restarts_total"]
       [inputs.kube_inventory.tags]
         measure_type = "inventory"
 


### PR DESCRIPTION
we need the restarts total for each container to support the reliability check
cantor found out this field exists in the kube inventory plugin
![image](https://github.com/komodorio/helm-charts/assets/813024/f7daa904-6ce4-42a8-b7d1-a33aa8d4b2ce)

we tested on staging - changed the configmap and restarted the daemon set  -> we saw restarts_count is added to the staging timestream DB
