### PR TITLE
CU-86bx2d9ge - chore(ci): Add list of images to the release-note and fix pipeline generation

### DIFF
--- a/.buildkite/release_checks/pipeline/generate.py
+++ b/.buildkite/release_checks/pipeline/generate.py
@@ -28,18 +28,17 @@ def get_tags():
 
 def find_latest_ga_tag(tags):
     for tag in reversed(tags):
-        if '+rc' not in tag.lower():
+        if '-rc' not in tag.lower():
             return tag
     return None
 
 
 def find_rc_versions_after_last_ga(tags, last_ga):
     rc_versions = []
-    found_last_ga = False
-    for tag in tags:
+    for tag in reversed(tags):
         if tag == last_ga:
-            found_last_ga = True
-        elif found_last_ga and '+rc' in tag.lower():
+            break
+        elif '-rc' in tag.lower():
             rc_versions.append(tag)
     return rc_versions
 


### PR DESCRIPTION
* Add the list of images used in the charts to be part of the RN. This request came from CS to assist customers who need to transfer our images into a local repo.
* Fix a bug in the pipeline generation due to the change of `+RC` to `-RC`