### PR TITLE
fix(chart/komodor-agent): daemonset not starting when configuring proxy

### DIFF
--- a/.buildkite/tests/values_capabilities_proxy_test.py
+++ b/.buildkite/tests/values_capabilities_proxy_test.py
@@ -2,10 +2,18 @@ import time
 
 import pytest
 
-from config import NAMESPACE
-from fixtures import setup_cluster, kube_client, cleanup_agent_from_cluster  # noqa # pylint: disable=unused-import
-from helpers.helm_helper import helm_agent_install
-from helpers.kubernetes_helper import create_namespace, wait_for_pod_ready, read_file_from_pod
+from config import NAMESPACE, RELEASE_NAME
+from fixtures import (
+    setup_cluster,
+    kube_client,
+    cleanup_agent_from_cluster,
+)  # noqa # pylint: disable=unused-import
+from helpers.helm_helper import helm_agent_install, get_yaml_from_helm_template
+from helpers.kubernetes_helper import (
+    create_namespace,
+    wait_for_pod_ready,
+    read_file_from_pod,
+)
 from helpers.utils import cmd, get_filename_as_cluster_name
 
 CLUSTER_NAME = get_filename_as_cluster_name(__file__)
@@ -25,21 +33,23 @@ KOMODOR_SERVICE_URLS = [
 @pytest.mark.flaky(reruns=3)
 def test_use_proxy_and_custom_ca(setup_cluster, kube_client):
     def extract_root_ca(pem_file_path, output_file_path):
-        with open(pem_file_path, 'r') as file:
+        with open(pem_file_path, "r") as file:
             pem_data = file.read()
 
-        certificates = pem_data.split('-----END RSA PRIVATE KEY-----')
+        certificates = pem_data.split("-----END RSA PRIVATE KEY-----")
         # Get the last certificate, ignoring any trailing whitespace or empty strings
-        root_ca_certificate = next((cert for cert in reversed(certificates) if cert.strip()), None)
+        root_ca_certificate = next(
+            (cert for cert in reversed(certificates) if cert.strip()), None
+        )
 
         if root_ca_certificate:
             root_ca_certificate = root_ca_certificate.strip() + "\n"
-            with open(output_file_path, 'w') as file:
+            with open(output_file_path, "w") as file:
                 file.write(root_ca_certificate)
-            print(f'Root CA certificate extracted to {output_file_path}')
+            print(f"Root CA certificate extracted to {output_file_path}")
             return True
 
-        print('No certificate found')
+        print("No certificate found")
         return False
 
     #################
@@ -49,7 +59,9 @@ def test_use_proxy_and_custom_ca(setup_cluster, kube_client):
     assert proxy_ready, "Failed to wait for mitmproxy pod to be ready"
 
     root_ca_pem = "/tmp/mitmproxy-ca.pem"
-    output, exit_code = cmd(f"kubectl cp -n proxy  mitm:root/.mitmproxy/mitmproxy-ca.pem  {root_ca_pem}")
+    output, exit_code = cmd(
+        f"kubectl cp -n proxy  mitm:root/.mitmproxy/mitmproxy-ca.pem  {root_ca_pem}"
+    )
     assert exit_code == 0, f"Failed to copy ca from mitmproxy pod, output: {output}"
 
     # Extract ca from pem file
@@ -60,17 +72,22 @@ def test_use_proxy_and_custom_ca(setup_cluster, kube_client):
     # create ns and secret
     create_namespace(kube_client)
     secret_name = "mitmproxysecret"
-    cmd(f"kubectl create secret generic {secret_name}  --from-file={root_ca_path} -n {NAMESPACE}")
+    cmd(
+        f"kubectl create secret generic {secret_name}  --from-file={root_ca_path} -n {NAMESPACE}"
+    )
 
     # TODO: Find a way to add networkpolicy to prevent the agent from reaching the internet directly.
     #  (at the moment it's not possible natively in kind)
 
     # install with proxy and custom ca
-    output, exit_code = helm_agent_install(CLUSTER_NAME, additional_settings=f"--set proxy.enabled=true "
-                                                                             f"--set proxy.http={PROXY_URL} "
-                                                                             f"--set proxy.https={PROXY_URL} "
-                                                                             f"--set customCa.enabled=true "
-                                                                             f"--set customCa.secretName={secret_name} ")
+    output, exit_code = helm_agent_install(
+        CLUSTER_NAME,
+        additional_settings=f"--set proxy.enabled=true "
+        f"--set proxy.http={PROXY_URL} "
+        f"--set proxy.https={PROXY_URL} "
+        f"--set customCa.enabled=true "
+        f"--set customCa.secretName={secret_name} ",
+    )
 
     assert exit_code == 0, f"Agent installation failed, output: {output}"
 
@@ -82,10 +99,14 @@ def verify_communication_through_proxy():
     success = False
     for attempt in range(attempts):
         try:
-            mitm_access_log = read_file_from_pod(PROXY_POD_NAME, PROXY_NAMESPACE, "/tmp/accessed_urls.log")
+            mitm_access_log = read_file_from_pod(
+                PROXY_POD_NAME, PROXY_NAMESPACE, "/tmp/accessed_urls.log"
+            )
             if mitm_access_log:
                 for url in KOMODOR_SERVICE_URLS:
-                    assert url in mitm_access_log, f"Failed to find {url} in proxy access log"
+                    assert (
+                        url in mitm_access_log
+                    ), f"Failed to find {url} in proxy access log"
                 success = True
                 break
         except AssertionError as e:
@@ -94,4 +115,61 @@ def verify_communication_through_proxy():
         if attempt < attempts - 1:
             time.sleep(10)
 
-    assert success, f"Failed to read mitmproxy access log or find URLs after {attempts} attempts"
+    assert (
+        success
+    ), f"Failed to read mitmproxy access log or find URLs after {attempts} attempts"
+
+
+@pytest.fixture(scope="module")
+def proxy_values():
+    return """
+    proxy:
+      enabled: true
+      http: "http://mitm.proxy:8080"
+      https: "https://mitm.proxy:8080"
+    """
+
+
+@pytest.mark.parametrize(
+    "deployment_suffix, resource_kind, container_path",
+    [
+        ("-komodor-agent", "Deployment", "spec.template.spec.containers"),
+        ("-komodor-agent-daemon", "DaemonSet", "spec.template.spec.containers"),
+        ("-komodor-agent-daemon", "DaemonSet", "spec.template.spec.initContainers"),
+    ],
+)
+def test_proxy_envroinment_vars_are_set(
+    deployment_suffix, resource_kind, container_path, proxy_values
+):
+    deployment_name = f"{RELEASE_NAME}{deployment_suffix}"
+    exclude_containers = ["network-mapper", "network-sniffer-test-template"]
+    expected_env_vars = {
+        "KOMOKW_HTTP_PROXY": "http://mitm.proxy:8080",
+        "KOMOKW_HTTPS_PROXY": "https://mitm.proxy:8080",
+    }
+
+    result = get_yaml_from_helm_template(
+        "test=test",
+        resource_kind,
+        deployment_name,
+        container_path,
+        values_file=proxy_values,
+    )
+
+    for container in result:
+        if container["name"] in exclude_containers:
+            continue
+
+        env_vars = {
+            env["name"]: env["value"]
+            for env in container.get("env", [])
+            if "value" in env
+        }
+
+        for env_name, expected_value in expected_env_vars.items():
+            assert (
+                env_name in env_vars
+            ), f"Expected {env_name} in container {container['name']}"
+            assert (
+                env_vars[env_name] == expected_value
+            ), f"Expected {env_name} to be {expected_value} in container {container['name']}"

--- a/.buildkite/vulnerability-scan/exclude.yaml
+++ b/.buildkite/vulnerability-scan/exclude.yaml
@@ -7,16 +7,4 @@ exclusions: # []
       - CVE-2023-29405
       - CVE-2023-39323
     Reason: "pluto uses a go lang version 1.20.4, Expected to be fixed in Pluto version > 5.19.0"
-    MuteUntil: 2024-01-30
-
-  - SystemPath: /usr/local/bin/kubectl
-    CVEs:
-      - CVE-2023-39323
-    Reason: "waiting for new version"
-    MuteUntil: 2023-11-30
-
-  - SystemPath: /usr/bin/helm
-    CVEs:
-      - CVE-2023-39323
-    Reason: "waiting for new version"
-    MuteUntil: 2023-11-30
+    MuteUntil: 2024-03-01

--- a/charts/komodor-agent/templates/metrics/_containers.tpl
+++ b/charts/komodor-agent/templates/metrics/_containers.tpl
@@ -45,6 +45,7 @@
     mountPath: /etc/komodor
   {{- include "custom-ca.volumeMounts" . | nindent 2 }}
   env:
+  {{- include "komodorAgent.proxy-conf" . | indent 2 }}
   - name: NAMESPACE
     value: {{ .Release.Namespace }}
   - name: KOMOKW_API_KEY


### PR DESCRIPTION
* Add proxy variables to daemonset init-container in case proxy is enabled.
* Update proxy tests.
* Extend `pluto` vulnerability exclusion

CU-86bxd3jq5