### PR TITLE
feat(komodor-agent): Support custom labels

### DIFF
--- a/.buildkite/tests/values_components_test.py
+++ b/.buildkite/tests/values_components_test.py
@@ -19,6 +19,22 @@ def test_override_deployment_pod_annotations():
     assert pod_annotations == value, f"Expected {value} in pod annotations {pod_annotations}"
 
 
+def run_label_test(set_path, value, deployment_name, resource_type):
+    set_command = f"{set_path}={value}"
+    results = get_yaml_from_helm_template(set_command, resource_type, deployment_name, "spec.template.metadata.labels.test")
+    assert results == value, f"Expected {value} in pod labels {results}"
+
+
+# Parameterized test function
+@pytest.mark.parametrize("set_path, value, deployment_name, resource_type", [
+    ("components.komodorAgent.labels.test", "test_value", f"{RELEASE_NAME}-komodor-agent", "Deployment"),
+    ("components.komodorDaemon.labels.test", "test_value", f"{RELEASE_NAME}-komodor-agent-daemon", "DaemonSet"),
+    ("components.komodorDaemonWindows.labels.test", "test_value", f"{RELEASE_NAME}-komodor-agent-daemon-windows", "DaemonSet"),
+])
+def test_user_labels(set_path, value, deployment_name, resource_type):
+    run_label_test(set_path, value, deployment_name, resource_type)
+
+
 def test_override_deployment_tolerations():
     values_file = """
     components:

--- a/.buildkite/tests/values_components_test.py
+++ b/.buildkite/tests/values_components_test.py
@@ -25,7 +25,6 @@ def run_label_test(set_path, value, deployment_name, resource_type):
     assert results == value, f"Expected {value} in pod labels {results}"
 
 
-# Parameterized test function
 @pytest.mark.parametrize("set_path, value, deployment_name, resource_type", [
     ("components.komodorAgent.labels.test", "test_value", f"{RELEASE_NAME}-komodor-agent", "Deployment"),
     ("components.komodorDaemon.labels.test", "test_value", f"{RELEASE_NAME}-komodor-agent-daemon", "DaemonSet"),

--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -137,6 +137,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorAgent | object | See sub-values | Configure the komodor agent components |
 | components.komodorAgent.affinity | object | `{}` | Set node affinity for the komodor agent deployment |
 | components.komodorAgent.annotations | object | `{}` | Set annotations for the komodor agent deployment |
+| components.komodorAgent.labels | object | `{}` | Set custom labels |
 | components.komodorAgent.nodeSelector | object | `{}` | Set node selectors for the komodor agent deployment |
 | components.komodorAgent.tolerations | list | `[]` | Set tolerations for the komodor agent deployment |
 | components.komodorAgent.podAnnotations | object | `{}` | Set pod annotations for the komodor agent deployment |
@@ -154,7 +155,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorAgent.networkMapper.resources | object | `{}` | Set custom resources to the komodor agent network mapper container |
 | components.komodorDaemon | object | See sub-values | Configure the komodor agent components |
 | components.komodorDaemon.affinity | object | `{}` | Set node affinity for the komodor agent daemon |
-| components.komodorDaemon.annotations | object | `{}` | Adds custom annotations - Example: `--set podAnnotations."app\.komodor\.com/app"="komodor-agent"` |
+| components.komodorDaemon.annotations | object | `{}` | Adds custom annotations - Example: `--set annotations."app\.komodor\.com/app"="komodor-agent"` |
+| components.komodorDaemon.labels | object | `{}` | Adds custom labels |
 | components.komodorDaemon.nodeSelector | object | `{}` | Set node selectors for the komodor agent daemon |
 | components.komodorDaemon.tolerations | list | `[]` | Add tolerations to the komodor agent daemon |
 | components.komodorDaemon.podAnnotations | object | `{}` | # Add annotations to the komodor agent watcher pod |
@@ -175,7 +177,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorDaemon.nodeEnricher.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemonWindows | object | See sub-values | Configure the komodor agent components |
 | components.komodorDaemonWindows.affinity | object | `{}` | Set node affinity for the komodor agent daemon |
-| components.komodorDaemonWindows.annotations | object | `{}` | Adds custom annotations - Example: `--set podAnnotations."app\.komodor\.com/app"="komodor-agent"` |
+| components.komodorDaemonWindows.annotations | object | `{}` | Adds custom annotations - Example: `--set annotations."app\.komodor\.com/app"="komodor-agent"` |
+| components.komodorDaemonWindows.labels | object | `{}` | Adds custom labels |
 | components.komodorDaemonWindows.nodeSelector | object | `{}` | Set node selectors for the komodor agent daemon |
 | components.komodorDaemonWindows.tolerations | list | `[]` | Add tolerations to the komodor agent daemon |
 | components.komodorDaemonWindows.podAnnotations | object | `{}` | # Add annotations to the komodor agent watcher pod |

--- a/charts/komodor-agent/templates/_helpers.tpl
+++ b/charts/komodor-agent/templates/_helpers.tpl
@@ -77,3 +77,20 @@ app.kubernetes.io/name: {{ include "komodorAgent.name" . }}-daemon-windows
 app.kubernetes.io/instance: {{ .Release.Name }}-daemon-windows
 {{- end }}
 
+{{- define "KomodorDaemon.user.labels" -}}
+{{- if not (empty (((.Values.components).komodorDaemon).labels)) }}
+{{ toYaml .Values.components.komodorDaemon.labels }}
+{{- end }}
+{{- end}}
+
+{{- define "komodorAgent.user.labels" -}}
+{{- if not (empty (((.Values.components).komodorAgent).labels)) }}
+{{ toYaml .Values.components.komodorAgent.labels }}
+{{- end }}
+{{- end}}
+
+{{- define "komodorDaemonWindows.user.labels" -}}
+{{- if not (empty (((.Values.components).komodorDaemonWindows).labels)) }}
+{{ toYaml .Values.components.komodorDaemonWindows.labels }}
+{{- end }}
+{{- end}}

--- a/charts/komodor-agent/templates/daemonset.yaml
+++ b/charts/komodor-agent/templates/daemonset.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "komodorAgent.fullname" . }}-daemon
   labels:
     {{- include "komodorAgentDaemon.labels" . | nindent 4 }}
+    {{- include "KomodorDaemon.user.labels" . | nindent 4 }}
+
   {{- if not (empty ((.Values.components).komodorDaemon).annotations) }}
   annotations: {{ toYaml ((.Values.components).komodorDaemon).annotations | nindent 4 }}
   {{- end }}
@@ -18,7 +20,9 @@ spec:
         {{- if not (empty (((.Values.components).komodorDaemon).podAnnotations)) }}
         {{- toYaml .Values.components.komodorDaemon.podAnnotations | trim | nindent 8 }}
         {{- end }}
-      labels: {{- include "komodorAgentDaemon.selectorLabels" . | nindent 8 }}
+      labels:
+        {{- include "komodorAgentDaemon.selectorLabels" . | nindent 8 }}
+        {{- include "KomodorDaemon.user.labels" . | nindent 8 }}
     spec:
       {{- include "network_mapper.daemonset.network" .   | nindent 6 }}
 

--- a/charts/komodor-agent/templates/daemonset_windows.yaml
+++ b/charts/komodor-agent/templates/daemonset_windows.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "komodorAgent.fullname" . }}-daemon-windows
   labels:
     {{- include "komodorAgentDaemonWindows.labels" . | nindent 4 }}
+    {{- include "komodorDaemonWindows.user.labels" . | nindent 4 }}
   {{- if not (empty ((.Values.components).komodorDaemonWindows).annotations) }}
   annotations: {{ toYaml ((.Values.components).komodorDaemonWindows).annotations | nindent 4 }}
   {{- end }}
@@ -18,7 +19,9 @@ spec:
         {{- if not (empty (((.Values.components).komodorDaemonWindows).podAnnotations)) }}
         {{- toYaml .Values.components.komodorDaemonWindows.podAnnotations | trim | nindent 8 }}
         {{- end }}
-      labels: {{- include "komodorAgentDaemonWindows.selectorLabels" . | nindent 8 }}
+      labels:
+        {{- include "komodorAgentDaemonWindows.selectorLabels" . | nindent 8 }}
+        {{- include "komodorDaemonWindows.user.labels" . | nindent 8 }}
     spec:
       terminationGracePeriodSeconds: 0
       priorityClassName: {{ .Release.Name }}-daemon-high-priority

--- a/charts/komodor-agent/templates/deployment.yaml
+++ b/charts/komodor-agent/templates/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "komodorAgent.fullname" . }}
   labels:
     {{- include "komodorAgent.labels" . | nindent 4 }}
+    {{- include "komodorAgent.user.labels" . | nindent 4 }}
   annotations:
     {{ toYaml .Values.components.komodorAgent.annotations | nindent 4 }}
 spec:
@@ -24,6 +25,7 @@ spec:
         {{- end }}
       labels:
         {{- include "komodorAgent.selectorLabels" . | nindent 8 }}
+        {{- include "komodorAgent.user.labels" . | nindent 8 }}
     spec:
       priorityClassName: {{ .Release.Name }}-agent-high-priority
       serviceAccountName: {{ include "komodorAgent.serviceAccountName" . }}

--- a/charts/komodor-agent/templates/serviceaccount.yaml
+++ b/charts/komodor-agent/templates/serviceaccount.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "komodorAgent.serviceAccountName" . }}
   labels:
     {{- include "komodorAgent.labels" . | nindent 4 }}
+    {{- include "komodorAgent.user.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.components.komodorAgent.annotations | nindent 4 }}
 {{- end }}

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -108,6 +108,8 @@ components:
     affinity: {}
     # components.komodorAgent.annotations -- Set annotations for the komodor agent deployment
     annotations: {}
+    # components.komodorAgent.labels -- Set custom labels
+    labels: {}
     # components.komodorAgent.nodeSelector -- Set node selectors for the komodor agent deployment
     nodeSelector: {}
     # components.komodorAgent.tolerations -- Set tolerations for the komodor agent deployment
@@ -169,8 +171,10 @@ components:
   komodorDaemon:
     # components.komodorDaemon.affinity -- Set node affinity for the komodor agent daemon
     affinity: {}
-    # components.komodorDaemon.annotations -- Adds custom annotations - Example: `--set podAnnotations."app\.komodor\.com/app"="komodor-agent"`
+    # components.komodorDaemon.annotations -- Adds custom annotations - Example: `--set annotations."app\.komodor\.com/app"="komodor-agent"`
     annotations: {}
+    # components.komodorDaemon.labels -- Adds custom labels
+    labels: {}
     # components.komodorDaemon.nodeSelector -- Set node selectors for the komodor agent daemon
     nodeSelector: {}
     # components.komodorDaemon.tolerations -- Add tolerations to the komodor agent daemon
@@ -241,8 +245,10 @@ components:
   komodorDaemonWindows:
     # components.komodorDaemonWindows.affinity -- Set node affinity for the komodor agent daemon
     affinity: { }
-    # components.komodorDaemonWindows.annotations -- Adds custom annotations - Example: `--set podAnnotations."app\.komodor\.com/app"="komodor-agent"`
+    # components.komodorDaemonWindows.annotations -- Adds custom annotations - Example: `--set annotations."app\.komodor\.com/app"="komodor-agent"`
     annotations: { }
+    # components.komodorDaemonWindows.labels -- Adds custom labels
+    labels: { }
     # components.komodorDaemonWindows.nodeSelector -- Set node selectors for the komodor agent daemon
     nodeSelector: { }
     # components.komodorDaemonWindows.tolerations -- Add tolerations to the komodor agent daemon


### PR DESCRIPTION
This PR introduces support for custom labels in the komodor-agent Helm chart. Users can now provide custom labels for various resources, including Deployment, DaemonSet, and DaemonSet-Windows.

Changes:
* Deployment: Added support for custom labels.
* DaemonSet: Added support for custom labels.
* DaemonSet-Windows: Added support for custom labels.

Changelog:

* Added labels to values.yaml.
* Created a helper function for label management.
* Included the custom labels in each resource template.
* Added tests to verify the correct application of custom labels.
