### PR TITLE
CU-86c081bq5 - Fix formatting of Tags when passed as helm values as string or as map

### DIFF
--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -95,7 +95,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | apiKey | guid | `nil` | **(*required*)** To be obtained from komodor app during onboarding |
 | apiKeySecret | string | `nil` | Secret name containing Komodor agent api key |
 | createNamespace | bool | `true` | Creates the namespace |
-| tags | dict | `{}` | Tags the agent in order to identify it based on `key:value` properties separated by semicolon (`;`) example: `--set tags="env:staging;team:product-a"` --- Can also be set in the values under `tags` as a dictionary of key:value strings |
+| tags | dict | `{}` | Tags the agent in order to identify it based on `key:value` properties separated by semicolon (`;`) example: `--set tags.env=staging,tags.team=payments` --- Can also be set in the values under `tags` as a dictionary of key:value strings |
 | clusterName | string | `nil` | **(*required*)** Name to be displayed in the Komodor web application |
 | telegrafImageVersion | string | `"1.31.3-alpine-v1"` | Telegraf version to be used |
 | telegrafWindowsImageVersion | string | `"1.31.0-v1"` | Telegraf version to be used for windows |

--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -95,7 +95,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | apiKey | guid | `nil` | **(*required*)** To be obtained from komodor app during onboarding |
 | apiKeySecret | string | `nil` | Secret name containing Komodor agent api key |
 | createNamespace | bool | `true` | Creates the namespace |
-| tags | dict | `""` | Tags the agent in order to identify it based on `key:value` properties separated by semicolon (`;`) example: `--set tags="env:staging;team:product-a"` --- Can also be set in the values under `tags` as a dictionary of key:value strings |
+| tags | dict | `{}` | Tags the agent in order to identify it based on `key:value` properties separated by semicolon (`;`) example: `--set tags="env:staging;team:product-a"` --- Can also be set in the values under `tags` as a dictionary of key:value strings |
 | clusterName | string | `nil` | **(*required*)** Name to be displayed in the Komodor web application |
 | telegrafImageVersion | string | `"1.31.3-alpine-v1"` | Telegraf version to be used |
 | telegrafWindowsImageVersion | string | `"1.31.0-v1"` | Telegraf version to be used for windows |

--- a/charts/komodor-agent/templates/configmap.yaml
+++ b/charts/komodor-agent/templates/configmap.yaml
@@ -39,5 +39,21 @@ data:
     resources:
       {{- toYaml .Values.allowedResources | trim | nindent 6 }}
 
+    {{- if .Values.tags }}
+    {{- if and .Values.tags (kindIs "map" .Values.tags) }}
+    tags: {{ .Values.tags | nindent 6 }}
+    {{- else if and .Values.tags (kindIs "string" .Values.tags) }}
+    {{ $tags := .Values.tags | splitList ";" }}
+    {{ $tagMap := dict }}
+    {{ range $tags }}
+      {{ $pair := splitList ":" . }}
+      {{ $key := index $pair 0 }}
+      {{ $value := index $pair 1 }}
+      {{ $_ := set $tagMap $key $value }}
+    {{ end }}
+    tags: {{ $tagMap | toYaml | nindent 6 }}
+    {{- end }}
+    {{- end }}
+
   installed-values.yaml: |
     {{ toYaml .Values | nindent 4 }}

--- a/charts/komodor-agent/templates/configmap.yaml
+++ b/charts/komodor-agent/templates/configmap.yaml
@@ -47,13 +47,16 @@ data:
     {{ $tagMap := dict }}
     {{ range $tags }}
       {{ $pair := splitList ":" . }}
-      {{ $key := index $pair 0 }}
-      {{ $value := index $pair 1 }}
-      {{ $_ := set $tagMap $key $value }}
+      {{ if eq (len $pair) 2 }}
+        {{ $key := index $pair 0 }}
+        {{ $value := index $pair 1 }}
+        {{ $_ := set $tagMap $key $value }}
+      {{ end }}
     {{ end }}
     tags: {{ $tagMap | toYaml | nindent 6 }}
+    {{- else }}
+      {{ fail "Invalid type for .Values.tags. Expected map or string." }}
     {{- end }}
     {{- end }}
-
   installed-values.yaml: |
     {{ toYaml .Values | nindent 4 }}

--- a/charts/komodor-agent/templates/configmap.yaml
+++ b/charts/komodor-agent/templates/configmap.yaml
@@ -41,7 +41,7 @@ data:
 
     {{- if .Values.tags }}
     {{- if and .Values.tags (kindIs "map" .Values.tags) }}
-    tags: {{ .Values.tags | nindent 6 }}
+    tags: {{ .Values.tags | toYaml | nindent 6 }}
     {{- else if and .Values.tags (kindIs "string" .Values.tags) }}
     {{ $tags := .Values.tags | splitList ";" }}
     {{ $tagMap := dict }}

--- a/charts/komodor-agent/templates/watcher/_containers.tpl
+++ b/charts/komodor-agent/templates/watcher/_containers.tpl
@@ -37,10 +37,6 @@
         {{- end }}
   - name: KOMOKW_CLUSTER_NAME
     value: {{ .Values.clusterName }}
-  {{- if not (empty .Values.tags) }}
-  - name: KOMOKW_TAGS
-    value: {{ .Values.tags | default "" | quote }}
-  {{- end }}
   - name: HELM_CACHE_HOME
     value: /opt/watcher/helm/cache
   - name: HELM_CONFIG_HOME

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -5,7 +5,7 @@ apiKeySecret:
 # createNamespace -- Creates the namespace
 createNamespace: true
 # tags -- (dict) Tags the agent in order to identify it based on `key:value` properties separated by semicolon (`;`)
-# example: `--set tags="env:staging;team:product-a"` --- Can also be set in the values under `tags` as a dictionary of key:value strings
+# example: `--set tags.env=staging,tags.team=payments` --- Can also be set in the values under `tags` as a dictionary of key:value strings
 tags: {}
 # clusterName -- **(*required*)** Name to be displayed in the Komodor web application
 clusterName:

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -6,7 +6,7 @@ apiKeySecret:
 createNamespace: true
 # tags -- (dict) Tags the agent in order to identify it based on `key:value` properties separated by semicolon (`;`)
 # example: `--set tags="env:staging;team:product-a"` --- Can also be set in the values under `tags` as a dictionary of key:value strings
-tags: ""
+tags: {}
 # clusterName -- **(*required*)** Name to be displayed in the Komodor web application
 clusterName:
 


### PR DESCRIPTION
## Changelog

* Pass `tags` configuration in the config file instead of environment variable
* Fix parsing of tags when provided as a string with semicolon delimiter