### PR TITLE
chore: address opa violations

### DIFF
--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -112,6 +112,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | customCa | object | See sub-values | Configure custom CA for the agent |
 | customCa.enabled | bool | `false` | Enable custom CA certificate for the agent |
 | customCa.secretName | string | `nil` | Name of the secret containing the CA |
+| customCa.resources | dict | `{"limits":{"cpu":"10m","memory":"100Mi"},"requests":{"cpu":"1m","memory":"10Mi"}}` | Set custom resources to the custom CA container |
 | imageRepo | string | `"public.ecr.aws/komodor-public"` | Override the komodor agent image repository. |
 | pullPolicy | string | `"IfNotPresent"` | Default Image pull policy for the komodor agent image exceptable values <ifNotPresent\Always\Never>. |
 | imagePullSecret | string | `nil` | Set the image pull secret for the komodor agent |
@@ -184,7 +185,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorDaemon.podAnnotations | object | `{}` | # Add annotations to the komodor agent watcher pod |
 | components.komodorDaemon.metricsInit | object | See sub-values | Configure the komodor daemon metrics init container |
 | components.komodorDaemon.metricsInit.image | object | `{ "name": "init-daemon-agent", "tag": .Chart.AppVersion }` | Override the komodor agent metrics init image name or tag. |
-| components.komodorDaemon.metricsInit.resources | object | `{}` | Set custom resources to the komodor agent metrics init container |
+| components.komodorDaemon.metricsInit.resources | object | `{"limits":{"cpu":1,"memory":"100Mi"},"requests":{"cpu":0.1,"memory":"50Mi"}}` | Set custom resources to the komodor agent metrics init container |
 | components.komodorDaemon.metricsInit.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemon.metrics | object | `{"extraEnvVars":[],"image":{"name":"telegraf","tag":"1.31.3-alpine-v1"},"resources":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}}` | Configure the komodor daemon metrics components |
 | components.komodorDaemon.metrics.image | object | `{"name":"telegraf","tag":"1.31.3-alpine-v1"}` | Override the komodor agent metrics image name or tag. |

--- a/charts/komodor-agent/templates/deployment.yaml
+++ b/charts/komodor-agent/templates/deployment.yaml
@@ -51,4 +51,3 @@ spec:
         {{- include "agent.deploy.volumes" .                | trim | nindent 8 }}
         {{- include "custom-ca.volume" .                    | trim | nindent 8 }}
         {{- include "custom-ca.trusted-volume" .            | trim | nindent 8 }}
-      {{- include "komodorAgent.securityContext" . | nindent 6}}

--- a/charts/komodor-agent/templates/deployment.yaml
+++ b/charts/komodor-agent/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         {{- include "komodorAgent.selectorLabels" . | nindent 8 }}
         {{- include "komodorAgent.user.labels" . | nindent 8 }}
     spec:
-    {{- if not .Values.capabilities.networkMapper.enabled }}
+    {{- if (.Values.capabilities).networkMapper -}}
       securityContext:
         runAsUser: 0
         runAsGroup: 0

--- a/charts/komodor-agent/templates/deployment.yaml
+++ b/charts/komodor-agent/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         {{- include "komodorAgent.selectorLabels" . | nindent 8 }}
         {{- include "komodorAgent.user.labels" . | nindent 8 }}
     spec:
-      {{- if (.Values.capabilities.networkMapper) }}
+      {{- if not (.Values.capabilities.networkMapper) }}
       securityContext:
         runAsUser: 0
         runAsGroup: 0

--- a/charts/komodor-agent/templates/deployment.yaml
+++ b/charts/komodor-agent/templates/deployment.yaml
@@ -27,9 +27,6 @@ spec:
         {{- include "komodorAgent.selectorLabels" . | nindent 8 }}
         {{- include "komodorAgent.user.labels" . | nindent 8 }}
     spec:
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 3000
       priorityClassName: {{ .Release.Name }}-agent-high-priority
       serviceAccountName: {{ include "komodorAgent.serviceAccountName" . }}
       affinity:

--- a/charts/komodor-agent/templates/deployment.yaml
+++ b/charts/komodor-agent/templates/deployment.yaml
@@ -30,8 +30,6 @@ spec:
       securityContext:
         runAsUser: 1000
         runAsGroup: 3000
-        fsGroup: 2000
-        runAsNonRoot: true
       priorityClassName: {{ .Release.Name }}-agent-high-priority
       serviceAccountName: {{ include "komodorAgent.serviceAccountName" . }}
       affinity:

--- a/charts/komodor-agent/templates/deployment.yaml
+++ b/charts/komodor-agent/templates/deployment.yaml
@@ -27,9 +27,11 @@ spec:
         {{- include "komodorAgent.selectorLabels" . | nindent 8 }}
         {{- include "komodorAgent.user.labels" . | nindent 8 }}
     spec:
+    {{- if not .Values.capabilities.networkMapper.enabled }}
       securityContext:
         runAsUser: 0
         runAsGroup: 0
+    {{- end }}
       priorityClassName: {{ .Release.Name }}-agent-high-priority
       serviceAccountName: {{ include "komodorAgent.serviceAccountName" . }}
       affinity:

--- a/charts/komodor-agent/templates/deployment.yaml
+++ b/charts/komodor-agent/templates/deployment.yaml
@@ -28,8 +28,8 @@ spec:
         {{- include "komodorAgent.user.labels" . | nindent 8 }}
     spec:
       securityContext:
-        runAsUser: 1
-        runAsGroup: 1
+        runAsUser: 0
+        runAsGroup: 0
       priorityClassName: {{ .Release.Name }}-agent-high-priority
       serviceAccountName: {{ include "komodorAgent.serviceAccountName" . }}
       affinity:

--- a/charts/komodor-agent/templates/deployment.yaml
+++ b/charts/komodor-agent/templates/deployment.yaml
@@ -27,6 +27,9 @@ spec:
         {{- include "komodorAgent.selectorLabels" . | nindent 8 }}
         {{- include "komodorAgent.user.labels" . | nindent 8 }}
     spec:
+      securityContext:
+        runAsUser: 1
+        runAsGroup: 1
       priorityClassName: {{ .Release.Name }}-agent-high-priority
       serviceAccountName: {{ include "komodorAgent.serviceAccountName" . }}
       affinity:

--- a/charts/komodor-agent/templates/deployment.yaml
+++ b/charts/komodor-agent/templates/deployment.yaml
@@ -27,6 +27,11 @@ spec:
         {{- include "komodorAgent.selectorLabels" . | nindent 8 }}
         {{- include "komodorAgent.user.labels" . | nindent 8 }}
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 3000
+        fsGroup: 2000
+        runAsNonRoot: true
       priorityClassName: {{ .Release.Name }}-agent-high-priority
       serviceAccountName: {{ include "komodorAgent.serviceAccountName" . }}
       affinity:

--- a/charts/komodor-agent/templates/deployment.yaml
+++ b/charts/komodor-agent/templates/deployment.yaml
@@ -51,3 +51,4 @@ spec:
         {{- include "agent.deploy.volumes" .                | trim | nindent 8 }}
         {{- include "custom-ca.volume" .                    | trim | nindent 8 }}
         {{- include "custom-ca.trusted-volume" .            | trim | nindent 8 }}
+      {{- include "komodorAgent.securityContext" . | nindent 6}}

--- a/charts/komodor-agent/templates/deployment.yaml
+++ b/charts/komodor-agent/templates/deployment.yaml
@@ -27,11 +27,11 @@ spec:
         {{- include "komodorAgent.selectorLabels" . | nindent 8 }}
         {{- include "komodorAgent.user.labels" . | nindent 8 }}
     spec:
-    {{- if (.Values.capabilities).networkMapper -}}
+      {{- if (.Values.capabilities.networkMapper) }}
       securityContext:
         runAsUser: 0
         runAsGroup: 0
-    {{- end }}
+      {{- end }}
       priorityClassName: {{ .Release.Name }}-agent-high-priority
       serviceAccountName: {{ include "komodorAgent.serviceAccountName" . }}
       affinity:

--- a/charts/komodor-agent/templates/node-enricher/_containers.tpl
+++ b/charts/komodor-agent/templates/node-enricher/_containers.tpl
@@ -12,7 +12,7 @@
   livenessProbe:
     httpGet:
       path: /healthz
-      port: http-healthz
+      port: 8090
     periodSeconds: 60
     initialDelaySeconds: 15
     failureThreshold: 10
@@ -20,7 +20,7 @@
   readinessProbe:
     httpGet:
       path: /healthz
-      port: http-healthz
+      port: 8090
     initialDelaySeconds: 5
     periodSeconds: 5
     failureThreshold: 3

--- a/charts/komodor-agent/templates/node-enricher/_containers.tpl
+++ b/charts/komodor-agent/templates/node-enricher/_containers.tpl
@@ -9,6 +9,22 @@
   volumeMounts:
   - name: configuration
     mountPath: /etc/komodor
+  livenessProbe:
+    httpGet:
+      path: /healthz
+      port: http-healthz
+    periodSeconds: 60
+    initialDelaySeconds: 15
+    failureThreshold: 10
+    successThreshold: 1
+  readinessProbe:
+    httpGet:
+      path: /healthz
+      port: http-healthz
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    failureThreshold: 3
+    successThreshold: 1
   env:
   {{- include "komodorAgent.proxy-conf" . | indent 2 }}
   - name: KOMOKW_API_KEY

--- a/charts/komodor-agent/templates/watcher/_containers.tpl
+++ b/charts/komodor-agent/templates/watcher/_containers.tpl
@@ -134,5 +134,7 @@
   volumeMounts:
     {{- include "custom-ca.trusted-volumeMounts-init" .    | nindent 4 }}
     {{- include "custom-ca.volumeMounts" .                 | nindent 4 }}
+resources:
+    {{ toYaml .Values.customCa.caInitResources | trim | nindent 4 }}
 {{- end }}
 {{- end -}}

--- a/charts/komodor-agent/templates/watcher/_containers.tpl
+++ b/charts/komodor-agent/templates/watcher/_containers.tpl
@@ -136,5 +136,9 @@
     {{- include "custom-ca.volumeMounts" .                 | nindent 4 }}
   resources:
       {{ toYaml .Values.customCa.resources | trim | nindent 6 }}
+  securityContext:
+    runAsUser: 1
+    runAsGroup: 1
+    allowPrivilegeEscalation: true
 {{- end }}
 {{- end -}}

--- a/charts/komodor-agent/templates/watcher/_containers.tpl
+++ b/charts/komodor-agent/templates/watcher/_containers.tpl
@@ -135,6 +135,6 @@
     {{- include "custom-ca.trusted-volumeMounts-init" .    | nindent 4 }}
     {{- include "custom-ca.volumeMounts" .                 | nindent 4 }}
 resources:
-    {{ toYaml .Values.customCa.caInitResources | trim | nindent 4 }}
+    {{ toYaml .Values.customCa.resources | trim | nindent 4 }}
 {{- end }}
 {{- end -}}

--- a/charts/komodor-agent/templates/watcher/_containers.tpl
+++ b/charts/komodor-agent/templates/watcher/_containers.tpl
@@ -136,9 +136,5 @@
     {{- include "custom-ca.volumeMounts" .                 | nindent 4 }}
   resources:
       {{ toYaml .Values.customCa.resources | trim | nindent 6 }}
-  securityContext:
-    runAsUser: 1
-    runAsGroup: 1
-    allowPrivilegeEscalation: true
 {{- end }}
 {{- end -}}

--- a/charts/komodor-agent/templates/watcher/_containers.tpl
+++ b/charts/komodor-agent/templates/watcher/_containers.tpl
@@ -134,7 +134,7 @@
   volumeMounts:
     {{- include "custom-ca.trusted-volumeMounts-init" .    | nindent 4 }}
     {{- include "custom-ca.volumeMounts" .                 | nindent 4 }}
-resources:
-    {{ toYaml .Values.customCa.resources | trim | nindent 4 }}
+  resources:
+      {{ toYaml .Values.customCa.resources | trim | nindent 6 }}
 {{- end }}
 {{- end -}}

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -6,7 +6,7 @@ apiKeySecret:
 createNamespace: true
 # tags -- (dict) Tags the agent in order to identify it based on `key:value` properties separated by semicolon (`;`)
 # example: `--set tags.env=staging,tags.team=payments` --- Can also be set in the values under `tags` as a dictionary of key:value strings
-tags: {}
+tags: { }
 # clusterName -- **(*required*)** Name to be displayed in the Komodor web application
 clusterName:
 
@@ -24,8 +24,8 @@ serviceAccount:
   create: true
   # serviceAccount.name -- (string) Name of the service account, Required if `serviceAccount.create` is false
   name:
-    # serviceAccount.annotations -- Add annotations to the service account
-  annotations: {}
+  # serviceAccount.annotations -- Add annotations to the service account
+  annotations: { }
 
 proxy:
   # proxy.enabled -- Enable proxy for the agent
@@ -46,6 +46,14 @@ customCa:
   enabled: false
   # customCa.secretName -- (string) Name of the secret containing the CA
   secretName:
+  # customCa.caInitResources -- (dict) Resources for the CA init container
+  caInitResources:
+    limits:
+      cpu: 10m
+      memory: 100Mi
+    requests:
+      cpu: 1m
+      memory: 10Mi
 
 # imageRepo -- (string) Override the komodor agent image repository.
 imageRepo: public.ecr.aws/komodor-public
@@ -77,9 +85,9 @@ capabilities:
     # @default -- all
     watchNamespace: all
     # capabilities.events.namespacesDenylist -- (array of strings) Do not watch events from these namespaces. eg. `["kube-system", "kube-public"]`
-    namespacesDenylist: []
+    namespacesDenylist: [ ]
     # capabilities.events.redact -- (list) Redact workload names from the komodor events. eg. `["password", "token"]`
-    redact: []
+    redact: [ ]
     # capabilities.events.enableRWCache -- (bool) Mounts a ReadWrite cache volume for the kubernetes api cache
     enableRWCache: true
 
@@ -89,13 +97,13 @@ capabilities:
     # capabilities.logs.enabled -- (bool) Fetch pod logs from komodor backend
     enabled: true
     # capabilities.logs.logsNamespacesDenylist -- (list) Do not fetch logs from these namespaces. eg. `["kube-system", "kube-public"]`
-    logsNamespacesDenylist: []
+    logsNamespacesDenylist: [ ]
     # capabilities.logs.logsNamespacesAllowlist -- (list) Only fetch logs from these namespaces. eg. `["kube-system", "kube-public"]`
-    logsNamespacesAllowlist: []
+    logsNamespacesAllowlist: [ ]
     # capabilities.logs.nameDenylist -- (list) Do not fetch logs from these workloads. eg. `["supersecret-workload", "password-manager"]`
-    nameDenylist: []
+    nameDenylist: [ ]
     # capabilities.logs.redact -- (list) Redact logs from the komodor logs. eg. `["password", "token"]`
-    redact: []
+    redact: [ ]
 
   # capabilities.redaction -- Configure the agent data redaction capabilities
   # @default -- See sub-values
@@ -122,17 +130,17 @@ components:
     # components.komodorAgent.PriorityClassValue -- Set the priority class value for the komodor agent deployment
     PriorityClassValue: 10000000
     # components.komodorAgent.affinity -- Set node affinity for the komodor agent deployment
-    affinity: {}
+    affinity: { }
     # components.komodorAgent.annotations -- Set annotations for the komodor agent deployment
-    annotations: {}
+    annotations: { }
     # components.komodorAgent.labels -- Set custom labels
-    labels: {}
+    labels: { }
     # components.komodorAgent.nodeSelector -- Set node selectors for the komodor agent deployment
-    nodeSelector: {}
+    nodeSelector: { }
     # components.komodorAgent.tolerations -- Set tolerations for the komodor agent deployment
-    tolerations: []
+    tolerations: [ ]
     # components.komodorAgent.podAnnotations -- Set pod annotations for the komodor agent deployment
-    podAnnotations: {}
+    podAnnotations: { }
 
     watcher:
       # components.komodorAgent.watcher.image -- Override the komodor agent watcher image name or tag.
@@ -153,7 +161,7 @@ components:
         # components.komodorAgent.watcher.ports.healthCheck -- Override the health check port of the komodor agent watcher
         healthCheck: 8090
       # components.komodorAgent.watcher.extraEnvVars -- List of additional environment variables, Each entry is a key-value pair
-      extraEnvVars: []
+      extraEnvVars: [ ]
 
     supervisor:
       # components.komodorAgent.supervisor.image -- Override the komodor agent supervisor image name or tag.
@@ -173,7 +181,7 @@ components:
         # components.komodorAgent.supervisor.ports.healthCheck -- Override the health check port of the komodor agent supervisor
         healthCheck: 8089
       # components.komodorAgent.supervisor.extraEnvVars -- List of additional environment variables, Each entry is a key-value pair
-      extraEnvVars: []
+      extraEnvVars: [ ]
 
     networkMapper:
       # components.komodorAgent.networkMapper.image -- Override the komodor agent network mapper image name or tag.
@@ -181,7 +189,7 @@ components:
         name: network-mapper
         tag: *networkMapperVersion
       # components.komodorAgent.networkMapper.resources -- Set custom resources to the komodor agent network mapper container
-      resources: {}
+      resources: { }
 
   komodorMetrics:
     # components.komodorMetrics.PriorityClassValue -- Set the priority class value for the komodor metrics agent deployment
@@ -234,17 +242,17 @@ components:
     # components.komodorDaemon.PriorityClassValue -- Set the priority class value for the komodor daemon deployment
     PriorityClassValue: 10000000
     # components.komodorDaemon.affinity -- Set node affinity for the komodor agent daemon
-    affinity: {}
+    affinity: { }
     # components.komodorDaemon.annotations -- Adds custom annotations - Example: `--set annotations."app\.komodor\.com/app"="komodor-agent"`
-    annotations: {}
+    annotations: { }
     # components.komodorDaemon.labels -- Adds custom labels
-    labels: {}
+    labels: { }
     # components.komodorDaemon.nodeSelector -- Set node selectors for the komodor agent daemon
-    nodeSelector: {}
+    nodeSelector: { }
     # components.komodorDaemon.tolerations -- Add tolerations to the komodor agent daemon
-    tolerations: []
+    tolerations: [ ]
     # components.komodorDaemon.podAnnotations --  # Add annotations to the komodor agent watcher pod
-    podAnnotations: {}
+    podAnnotations: { }
     # components.komodorDaemon.metrics -- Configure the komodor daemon metrics components
 
     # components.komodorDaemon.metricsInit -- Configure the komodor daemon metrics init container
@@ -256,9 +264,15 @@ components:
         name: komodor-agent
         tag:
       # components.komodorDaemon.metricsInit.resources -- Set custom resources to the komodor agent metrics init container
-      resources: {}
+      resources:
+        limits:
+          cpu: 1
+          memory: 100Mi
+        requests:
+          cpu: 0.1
+          memory: 50Mi
       # components.komodorDaemon.metricsInit.extraEnvVars -- List of additional environment variables, Each entry is a key-value pair
-      extraEnvVars: []
+      extraEnvVars: [ ]
 
     metrics:
       # components.komodorDaemon.metrics.image -- Override the komodor agent metrics image name or tag.
@@ -274,7 +288,7 @@ components:
           cpu: 0.1
           memory: 384Mi
       # components.komodorDaemon.metrics.extraEnvVars -- List of additional environment variables, Each entry is a key-value pair
-      extraEnvVars: []
+      extraEnvVars: [ ]
 
     # components.komodorDaemon.networkSniffer -- Configure the komodor daemon network sniffer components
     # @default -- See sub-values
@@ -284,7 +298,7 @@ components:
         name: network-mapper-sniffer
         tag: *networkMapperVersion
       # components.komodorDaemon.networkSniffer.resources -- Set custom resources to the komodor agent network sniffer container
-      resources: {}
+      resources: { }
 
     # components.komodorDaemon.nodeEnricher -- Configure the komodor daemon node enricher components
     # @default -- See sub-values
@@ -302,7 +316,7 @@ components:
           cpu: 1m
           memory: 10Mi
       # components.komodorDaemon.nodeEnricher.extraEnvVars -- List of additional environment variables, Each entry is a key-value pair
-      extraEnvVars: []
+      extraEnvVars: [ ]
 
   # components.komodorDaemonWindows -- Configure the komodor agent components
   # @default -- See sub-values
@@ -335,7 +349,7 @@ components:
           cpu: 0.1
           memory: 384Mi
       # components.komodorDaemonWindows.metrics.extraEnvVars -- List of additional environment variables, Each entry is a key-value pair
-      extraEnvVars: []
+      extraEnvVars: [ ]
 
 
 allowedResources:
@@ -444,7 +458,7 @@ allowedResources:
     # allowedResources.argoWorkflows.cronWorkflows -- Enables watching Argo `cronWorkflows`
     cronWorkflows: true
   # allowedResources.customReadAPIGroups -- A list of custom API groups to allow read access to - each array element should be a string which represents the group name
-  customReadAPIGroups: []
+  customReadAPIGroups: [ ]
   # allowedResources.allowReadAll -- Allow reading all the resources in the cluster
   allowReadAll: true
 

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -46,8 +46,8 @@ customCa:
   enabled: false
   # customCa.secretName -- (string) Name of the secret containing the CA
   secretName:
-  # customCa.caInitResources -- (dict) Resources for the CA init container
-  caInitResources:
+  # customCa.resources -- (dict) Set custom resources to the custom CA container
+  resources:
     limits:
       cpu: 10m
       memory: 100Mi


### PR DESCRIPTION
cu-86c0ccq6k  - OPA Violations -  Configure Liveness and Readiness Probes for node-enricher
cu-86c0ccpfj - OPA Violation - Set Resource Quotas for init-daemon and init-cert
cu-86c0ccmyv  - OPA Violation - Security Context - komodor-agent

fixes for OPA violations on liveness\readiness probes\ resource qoutas and security context missing

