### PR TITLE
CU-86c0fwhr0 - feat: allow not creating rbac at all

### DIFF
--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -97,6 +97,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | createNamespace | bool | `true` | Creates the namespace |
 | tags | dict | `{}` | Tags the agent in order to identify it based on `key:value` properties separated by semicolon (`;`) example: `--set tags.env=staging,tags.team=payments` --- Can also be set in the values under `tags` as a dictionary of key:value strings |
 | clusterName | string | `nil` | **(*required*)** Name to be displayed in the Komodor web application |
+| createRbac | bool | `true` | Creates the necessary RBAC resources for the agent - use with caution! |
 | telegrafImageVersion | string | `"1.31.3-alpine-v1"` | Telegraf version to be used |
 | telegrafWindowsImageVersion | string | `"1.31.0-v1"` | Telegraf version to be used for windows |
 | networkMapperImageVersion | string | `"v1.0.3"` | Network mapper version to be used |

--- a/charts/komodor-agent/templates/clusterrole.yaml
+++ b/charts/komodor-agent/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
----
+{{- if .Values.createRbac -}}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -519,3 +519,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "komodorAgent.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -9,6 +9,8 @@ createNamespace: true
 tags: { }
 # clusterName -- **(*required*)** Name to be displayed in the Komodor web application
 clusterName:
+# createRbac -- Creates the necessary RBAC resources for the agent - use with caution!
+createRbac: true
 
 # telegrafImageVersion -- (string) Telegraf version to be used
 telegrafImageVersion: &telegrafVersion 1.31.3-alpine-v1


### PR DESCRIPTION
# Motivation
Some accounts have security policies that require teams to validate changes in Kubernetes RBAC. By not creating RBAC, the Helm chart will avoid generating any cluster roles or bindings. However, modifying RBAC places full responsibility on the account for managing permission errors, which can lead to unexpected behavior. This approach is not recommended and should be used with caution.