### PR TITLE
Add toleration to ci values

### DIFF
--- a/.buildkite/pipeline_scripts/production-values.yaml
+++ b/.buildkite/pipeline_scripts/production-values.yaml
@@ -12,6 +12,18 @@ components:
     tolerations:
       - key: Windows
         operator: Exists
+  komodorDaemon:
+    tolerations:
+      - key: "komodor.io/sensitive"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+  komodorMetrics:
+    tolerations:
+      - key: "komodor.io/sensitive"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
   komodorAgent:
     podAnnotations:
       karpenter.sh/do-not-disrupt: "true"


### PR DESCRIPTION
Allow komodor agent to be scheduled on nodes with `komodor.io/sensitive` taint