### PR TITLE
Security/updates nov 24

### DIFF
--- a/.buildkite/pipeline_scripts/production-values.yaml
+++ b/.buildkite/pipeline_scripts/production-values.yaml
@@ -12,6 +12,18 @@ components:
     tolerations:
       - key: Windows
         operator: Exists
+  komodorDaemon:
+    tolerations:
+      - key: "komodor.io/sensitive"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+  komodorMetrics:
+    tolerations:
+      - key: "komodor.io/sensitive"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
   komodorAgent:
     podAnnotations:
       karpenter.sh/do-not-disrupt: "true"

--- a/.buildkite/tests/values_components_test.py
+++ b/.buildkite/tests/values_components_test.py
@@ -142,3 +142,24 @@ def test_extra_env_vars(component, location, container, container_index, deploym
 
     assert deployment_env_vars[-1][
                "name"] == "TEST_ENV_VAR", f"Expected TEST_ENV_VAR in deployment env vars {deployment_env_vars}"
+
+
+@pytest.mark.parametrize("component_name, deployment_name_suffix", [
+    ("komodorAgent", ""),
+    ("komodorMetrics", "-metrics"),
+    ("komodorDaemon", "")])
+def test_override_security_context(component_name, deployment_name_suffix):
+    values_file = f"""
+    components:
+      {component_name}:
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 3000
+          fsGroup: 2000
+    """
+
+    deployment_name = f"{RELEASE_NAME}-komodor-agent{deployment_name_suffix}"
+    deployment_affinity = get_yaml_from_helm_template("test=test", "Deployment", deployment_name,
+                                                      "spec.template.spec.securityContext", values_file=values_file)
+
+    assert deployment_affinity is not None, f"Expected securityContext in deployment {deployment_affinity}"

--- a/charts/komodor-agent/Makefile
+++ b/charts/komodor-agent/Makefile
@@ -14,7 +14,8 @@ HELM_DOCS_ARGS := -s file \
                   -y="components.komodorMetrics.metrics" \
                   -y="components.komodorDaemon.metrics" \
                   -y="components.komodorDaemon" \
-                  -y="allowedResources"
+                  -y="allowedResources" \
+                  -z ".*securityContext.*"
 
 # Determine OS and Arch for downloading helm-docs
 OS := $(shell uname -s)

--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -154,13 +154,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorAgent.securityContext | object | `{}` | Set custom securityContext to the komodor agent deployment (use with caution) |
 | components.komodorAgent.watcher.image | object | `{ "name": "k8s-watcher", "tag": .Chart.AppVersion }` | Override the komodor agent watcher image name or tag. |
 | components.komodorAgent.watcher.resources | object | `{"limits":{"cpu":2,"memory":"8Gi"},"requests":{"cpu":0.25,"memory":"256Mi"}}` | Set custom resources to the komodor agent watcher container |
-| components.komodorAgent.watcher.securityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsUser":1000}` | Set security context for the komodor agent watcher container |
+| components.komodorAgent.watcher.securityContext | object | `{}` | Set security context for the komodor agent watcher container |
 | components.komodorAgent.watcher.ports | object | `{"healthCheck":8090}` | Override the komodor agent watcher ports configuration |
 | components.komodorAgent.watcher.ports.healthCheck | int | `8090` | Override the health check port of the komodor agent watcher |
 | components.komodorAgent.watcher.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorAgent.supervisor.image | object | `{ "name": "supervisor", "tag": .Chart.AppVersion }` | Override the komodor agent supervisor image name or tag. |
 | components.komodorAgent.supervisor.resources | object | `{"requests":{"cpu":0.1,"memory":"256Mi"}}` | Set custom resources to the komodor agent supervisor container |
-| components.komodorAgent.supervisor.securityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsUser":1000}` | Set security context for the komodor agent watcher container |
+| components.komodorAgent.supervisor.securityContext | object | `{}` | Set security context for the komodor agent watcher container |
 | components.komodorAgent.supervisor.ports | object | `{"healthCheck":8089}` | Override the komodor agent supervisor ports configuration |
 | components.komodorAgent.supervisor.ports.healthCheck | int | `8089` | Override the health check port of the komodor agent supervisor |
 | components.komodorAgent.supervisor.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |

--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -154,13 +154,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorAgent.securityContext | object | `{}` | Set custom securityContext to the komodor agent deployment (use with caution) |
 | components.komodorAgent.watcher.image | object | `{ "name": "k8s-watcher", "tag": .Chart.AppVersion }` | Override the komodor agent watcher image name or tag. |
 | components.komodorAgent.watcher.resources | object | `{"limits":{"cpu":2,"memory":"8Gi"},"requests":{"cpu":0.25,"memory":"256Mi"}}` | Set custom resources to the komodor agent watcher container |
-| components.komodorAgent.watcher.securityContext | object | `{}` | Set security context for the komodor agent watcher container |
+| components.komodorAgent.watcher.securityContext | object | `{}` | Set security context for the komodor agent watcher container (use with caution) |
 | components.komodorAgent.watcher.ports | object | `{"healthCheck":8090}` | Override the komodor agent watcher ports configuration |
 | components.komodorAgent.watcher.ports.healthCheck | int | `8090` | Override the health check port of the komodor agent watcher |
 | components.komodorAgent.watcher.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorAgent.supervisor.image | object | `{ "name": "supervisor", "tag": .Chart.AppVersion }` | Override the komodor agent supervisor image name or tag. |
 | components.komodorAgent.supervisor.resources | object | `{"requests":{"cpu":0.1,"memory":"256Mi"}}` | Set custom resources to the komodor agent supervisor container |
-| components.komodorAgent.supervisor.securityContext | object | `{}` | Set security context for the komodor agent watcher container |
+| components.komodorAgent.supervisor.securityContext | object | `{}` | Set security context for the komodor agent supervisor container (use with caution) |
 | components.komodorAgent.supervisor.ports | object | `{"healthCheck":8089}` | Override the komodor agent supervisor ports configuration |
 | components.komodorAgent.supervisor.ports.healthCheck | int | `8089` | Override the health check port of the komodor agent supervisor |
 | components.komodorAgent.supervisor.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |

--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -98,7 +98,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | tags | dict | `{}` | Tags the agent in order to identify it based on `key:value` properties separated by semicolon (`;`) example: `--set tags.env=staging,tags.team=payments` --- Can also be set in the values under `tags` as a dictionary of key:value strings |
 | clusterName | string | `nil` | **(*required*)** Name to be displayed in the Komodor web application |
 | createRbac | bool | `true` | Creates the necessary RBAC resources for the agent - use with caution! |
-| telegrafImageVersion | string | `"1.31.3-alpine-v1"` | Telegraf version to be used |
+| telegrafImageVersion | string | `"1.32.2-alpine-v1"` | Telegraf version to be used |
 | telegrafWindowsImageVersion | string | `"1.31.0-v1"` | Telegraf version to be used for windows |
 | networkMapperImageVersion | string | `"v1.0.3"` | Network mapper version to be used |
 | serviceAccount | object | See sub-values | Configure service account for the agent |
@@ -151,13 +151,16 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorAgent.nodeSelector | object | `{}` | Set node selectors for the komodor agent deployment |
 | components.komodorAgent.tolerations | list | `[]` | Set tolerations for the komodor agent deployment |
 | components.komodorAgent.podAnnotations | object | `{}` | Set pod annotations for the komodor agent deployment |
+| components.komodorAgent.securityContext | object | `{}` | Set custom securityContext to the komodor agent deployment (use with caution) |
 | components.komodorAgent.watcher.image | object | `{ "name": "k8s-watcher", "tag": .Chart.AppVersion }` | Override the komodor agent watcher image name or tag. |
 | components.komodorAgent.watcher.resources | object | `{"limits":{"cpu":2,"memory":"8Gi"},"requests":{"cpu":0.25,"memory":"256Mi"}}` | Set custom resources to the komodor agent watcher container |
+| components.komodorAgent.watcher.securityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsUser":1000}` | Set security context for the komodor agent watcher container |
 | components.komodorAgent.watcher.ports | object | `{"healthCheck":8090}` | Override the komodor agent watcher ports configuration |
 | components.komodorAgent.watcher.ports.healthCheck | int | `8090` | Override the health check port of the komodor agent watcher |
 | components.komodorAgent.watcher.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorAgent.supervisor.image | object | `{ "name": "supervisor", "tag": .Chart.AppVersion }` | Override the komodor agent supervisor image name or tag. |
 | components.komodorAgent.supervisor.resources | object | `{"requests":{"cpu":0.1,"memory":"256Mi"}}` | Set custom resources to the komodor agent supervisor container |
+| components.komodorAgent.supervisor.securityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsUser":1000}` | Set security context for the komodor agent watcher container |
 | components.komodorAgent.supervisor.ports | object | `{"healthCheck":8089}` | Override the komodor agent supervisor ports configuration |
 | components.komodorAgent.supervisor.ports.healthCheck | int | `8089` | Override the health check port of the komodor agent supervisor |
 | components.komodorAgent.supervisor.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
@@ -170,11 +173,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorMetrics.nodeSelector | object | `{}` | Set node selectors for the komodor metrics agent deployment |
 | components.komodorMetrics.tolerations | list | `[]` | Set tolerations for the komodor metrics agent deployment |
 | components.komodorMetrics.podAnnotations | object | `{}` | Set pod annotations for the komodor metrics agent deployment |
+| components.komodorMetrics.securityContext | object | `{}` | Set custom securityContext to the komodor metrics agent deployment (use with caution) |
 | components.komodorMetrics.metricsInit | object | See sub-values | Configure the komodor metrics init container |
 | components.komodorMetrics.metricsInit.image | object | `{ "name": "komodor-agent", "tag": .Chart.AppVersion }` | Override the komodor agent metrics init image name or tag. |
 | components.komodorMetrics.metricsInit.resources | object | `{}` | Set custom resources to the komodor agent metrics init container |
 | components.komodorMetrics.metricsInit.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
-| components.komodorMetrics.metrics.image | object | `{"name":"telegraf","tag":"1.31.3-alpine-v1"}` | Override the komodor agent metrics image name or tag. |
+| components.komodorMetrics.metrics.image | object | `{"name":"telegraf","tag":"1.32.2-alpine-v1"}` | Override the komodor agent metrics image name or tag. |
 | components.komodorMetrics.metrics.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
 | components.komodorMetrics.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemon | object | See sub-values | Configure the komodor agent components |
@@ -185,12 +189,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorDaemon.nodeSelector | object | `{}` | Set node selectors for the komodor agent daemon |
 | components.komodorDaemon.tolerations | list | `[]` | Add tolerations to the komodor agent daemon |
 | components.komodorDaemon.podAnnotations | object | `{}` | # Add annotations to the komodor agent watcher pod |
+| components.komodorDaemon.securityContext | object | `{}` | Set custom securityContext to the komodor agent daemon (use with caution) |
 | components.komodorDaemon.metricsInit | object | See sub-values | Configure the komodor daemon metrics init container |
 | components.komodorDaemon.metricsInit.image | object | `{ "name": "init-daemon-agent", "tag": .Chart.AppVersion }` | Override the komodor agent metrics init image name or tag. |
 | components.komodorDaemon.metricsInit.resources | object | `{"limits":{"cpu":1,"memory":"100Mi"},"requests":{"cpu":0.1,"memory":"50Mi"}}` | Set custom resources to the komodor agent metrics init container |
 | components.komodorDaemon.metricsInit.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
-| components.komodorDaemon.metrics | object | `{"extraEnvVars":[],"image":{"name":"telegraf","tag":"1.31.3-alpine-v1"},"resources":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}}` | Configure the komodor daemon metrics components |
-| components.komodorDaemon.metrics.image | object | `{"name":"telegraf","tag":"1.31.3-alpine-v1"}` | Override the komodor agent metrics image name or tag. |
+| components.komodorDaemon.metrics | object | `{"extraEnvVars":[],"image":{"name":"telegraf","tag":"1.32.2-alpine-v1"},"resources":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}}` | Configure the komodor daemon metrics components |
+| components.komodorDaemon.metrics.image | object | `{"name":"telegraf","tag":"1.32.2-alpine-v1"}` | Override the komodor agent metrics image name or tag. |
 | components.komodorDaemon.metrics.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
 | components.komodorDaemon.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemon.networkSniffer | object | See sub-values | Configure the komodor daemon network sniffer components |

--- a/charts/komodor-agent/templates/daemonset.yaml
+++ b/charts/komodor-agent/templates/daemonset.yaml
@@ -28,6 +28,7 @@ spec:
 
       priorityClassName: {{ include "komodor.truncatedReleaseName"  . }}-daemon-high-priority
       serviceAccountName: {{ include "komodorAgent.serviceAccountName" . }}
+      {{ include "metrics.komodorDeamon.securityContext" . | nindent 6 }}
       affinity:
         {{- toYaml .Values.components.komodorDaemon.affinity | nindent 8 }}
       nodeSelector:

--- a/charts/komodor-agent/templates/deployment.yaml
+++ b/charts/komodor-agent/templates/deployment.yaml
@@ -27,11 +27,7 @@ spec:
         {{- include "komodorAgent.selectorLabels" . | nindent 8 }}
         {{- include "komodorAgent.user.labels" . | nindent 8 }}
     spec:
-      {{- if not (.Values.capabilities.networkMapper) }}
-      securityContext:
-        runAsUser: 0
-        runAsGroup: 0
-      {{- end }}
+      {{ include "komodorAgent.pod.securityContext" . | nindent 6 }}
       priorityClassName: {{ include "komodor.truncatedReleaseName"  . }}-agent-high-priority
       serviceAccountName: {{ include "komodorAgent.serviceAccountName" . }}
       affinity:

--- a/charts/komodor-agent/templates/deployment_metrics.yaml
+++ b/charts/komodor-agent/templates/deployment_metrics.yaml
@@ -31,6 +31,7 @@ spec:
         {{- if not (empty (((.Values.components).komodorMetrics).nodeSelector)) }}
         {{- toYaml .Values.components.komodorMetrics.nodeSelector | nindent 8 }}
         {{- end }}
+      {{ include "metrics.komodorMetrics.securityContext" . | nindent 6 }}
       tolerations:
         {{- toYaml .Values.components.komodorMetrics.tolerations | nindent 8}}
       containers:

--- a/charts/komodor-agent/templates/metrics/_security.tpl
+++ b/charts/komodor-agent/templates/metrics/_security.tpl
@@ -1,0 +1,14 @@
+{{- define "metrics.komodorMetrics.securityContext" }}
+{{- if gt (len .Values.components.komodorMetrics.securityContext) 0 }}
+securityContext:
+  {{ toYaml .Values.components.komodorMetrics.securityContext | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- define "metrics.komodorDeamon.securityContext" }}
+{{- if gt (len .Values.components.komodorDaemon.securityContext) 0 }}
+securityContext:
+  {{ toYaml .Values.components.komodorDaemon.securityContext | nindent 2 }}
+{{- end }}
+{{- end }}
+

--- a/charts/komodor-agent/templates/watcher/_containers.tpl
+++ b/charts/komodor-agent/templates/watcher/_containers.tpl
@@ -48,7 +48,7 @@
   {{- end }}
 
   {{- include "komodorAgent.proxy-conf" . | indent 2 }}
-  {{- include "komodorAgent.securityContext" . | nindent 2}}
+  {{- include "komodorAgent.container.securityContext" . | nindent 2}}
   ports:
     - name: http-healthz
       containerPort: {{ .Values.components.komodorAgent.watcher.ports.healthCheck  }}
@@ -99,7 +99,7 @@
     {{- end }}
 
   {{- include "komodorAgent.proxy-conf" . | indent 4 }}
-  {{- include "komodorAgent.securityContext" . | nindent 2}}
+  {{- include "komodorAgent.container.securityContext" . | nindent 2}}
   ports:
     - name: http-healthz
       containerPort: {{ .Values.components.komodorAgent.supervisor.ports.healthCheck }}

--- a/charts/komodor-agent/templates/watcher/_security.tpl
+++ b/charts/komodor-agent/templates/watcher/_security.tpl
@@ -1,7 +1,22 @@
-{{- define "komodorAgent.securityContext" }}
+{{- define "komodorAgent.container.securityContext" }}
 securityContext:
+{{- if gt (len .Values.components.komodorAgent.securityContext) 0 }}
+  {{toYaml .Values.components.komodorAgent.securityContext | nindent 2}}
+{{- else}}
   readOnlyRootFilesystem: true
   runAsUser: 1000
   runAsGroup: 1000
   allowPrivilegeEscalation: false
+{{- end }}
+{{- end }}
+
+{{- define "komodorAgent.pod.securityContext" }}
+{{- if gt (len .Values.components.komodorAgent.securityContext) 0 }}
+securityContext:
+  {{- toYaml .Values.components.komodorAgent.securityContext | nindent 2 }}
+{{- else if not (.Values.capabilities.networkMapper) }}
+securityContext:
+  runAsUser: 0
+  runAsGroup: 0
+{{- end }}
 {{- end }}

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -13,7 +13,7 @@ clusterName:
 createRbac: true
 
 # telegrafImageVersion -- (string) Telegraf version to be used
-telegrafImageVersion: &telegrafVersion 1.31.3-alpine-v1
+telegrafImageVersion: &telegrafVersion 1.32.2-alpine-v1
 # telegrafWindowsImageVersion -- (string) Telegraf version to be used for windows
 telegrafWindowsImageVersion: &telegrafWindowsVersion 1.31.0-v1
 # networkMapperImageVersion -- (string) Network mapper version to be used

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -145,6 +145,8 @@ components:
     tolerations: [ ]
     # components.komodorAgent.podAnnotations -- Set pod annotations for the komodor agent deployment
     podAnnotations: { }
+    # components.komodorAgent.securityContext -- Set custom securityContext to the komodor agent deployment (use with caution)
+    securityContext: { }
 
     watcher:
       # components.komodorAgent.watcher.image -- Override the komodor agent watcher image name or tag.
@@ -160,6 +162,8 @@ components:
         requests:
           cpu: 0.25
           memory: 256Mi
+      # components.komodorAgent.watcher.securityContext -- Set security context for the komodor agent watcher container
+      securityContext: { }
       # components.komodorAgent.watcher.ports -- Override the komodor agent watcher ports configuration
       ports:
         # components.komodorAgent.watcher.ports.healthCheck -- Override the health check port of the komodor agent watcher
@@ -180,6 +184,8 @@ components:
         requests:
           cpu: 0.1
           memory: 256Mi
+      # components.komodorAgent.supervisor.securityContext -- Set security context for the komodor agent watcher container
+      securityContext: { }
       # components.komodorAgent.supervisor.ports -- Override the komodor agent supervisor ports configuration
       ports:
         # components.komodorAgent.supervisor.ports.healthCheck -- Override the health check port of the komodor agent supervisor
@@ -210,6 +216,8 @@ components:
     tolerations: [ ]
     # components.komodorMetrics.podAnnotations -- Set pod annotations for the komodor metrics agent deployment
     podAnnotations: { }
+    # components.komodorMetrics.securityContext -- Set custom securityContext to the komodor metrics agent deployment (use with caution)
+    securityContext: { }
 
     # components.komodorMetrics.metricsInit -- Configure the komodor metrics init container
     # @default -- See sub-values
@@ -257,6 +265,9 @@ components:
     tolerations: [ ]
     # components.komodorDaemon.podAnnotations --  # Add annotations to the komodor agent watcher pod
     podAnnotations: { }
+    # components.komodorDaemon.securityContext -- Set custom securityContext to the komodor agent daemon (use with caution)
+    securityContext: { }
+
     # components.komodorDaemon.metrics -- Configure the komodor daemon metrics components
 
     # components.komodorDaemon.metricsInit -- Configure the komodor daemon metrics init container

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -162,7 +162,7 @@ components:
         requests:
           cpu: 0.25
           memory: 256Mi
-      # components.komodorAgent.watcher.securityContext -- Set security context for the komodor agent watcher container
+      # components.komodorAgent.watcher.securityContext -- Set security context for the komodor agent watcher container (use with caution)
       securityContext: { }
       # components.komodorAgent.watcher.ports -- Override the komodor agent watcher ports configuration
       ports:
@@ -184,7 +184,7 @@ components:
         requests:
           cpu: 0.1
           memory: 256Mi
-      # components.komodorAgent.supervisor.securityContext -- Set security context for the komodor agent watcher container
+      # components.komodorAgent.supervisor.securityContext -- Set security context for the komodor agent supervisor container (use with caution)
       securityContext: { }
       # components.komodorAgent.supervisor.ports -- Override the komodor agent supervisor ports configuration
       ports:


### PR DESCRIPTION
* Bump telegraf version
* Expose securityContext
* Allow ci agent to run on `komodor.io/sensitive` nodes