### PR TITLE
[CU-86c0x1d85] Add missing toleration on daemon

### DIFF
--- a/charts/komodor-agent/Makefile
+++ b/charts/komodor-agent/Makefile
@@ -15,7 +15,8 @@ HELM_DOCS_ARGS := -s file \
                   -y="components.komodorDaemon.metrics" \
                   -y="components.komodorDaemon" \
                   -y="allowedResources" \
-                  -z ".*securityContext.*"
+                  -z ".*securityContext.*" \
+				  -z ".tolerations.*" \
 
 # Determine OS and Arch for downloading helm-docs
 OS := $(shell uname -s)

--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -187,7 +187,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorDaemon.annotations | object | `{}` | Adds custom annotations - Example: `--set annotations."app\.komodor\.com/app"="komodor-agent"` |
 | components.komodorDaemon.labels | object | `{}` | Adds custom labels |
 | components.komodorDaemon.nodeSelector | object | `{}` | Set node selectors for the komodor agent daemon |
-| components.komodorDaemon.tolerations | list | `[]` | Add tolerations to the komodor agent daemon |
+| components.komodorDaemon.tolerations | list | `[{"operator": "Exists"}]` | Add tolerations to the komodor agent daemon |
 | components.komodorDaemon.podAnnotations | object | `{}` | # Add annotations to the komodor agent watcher pod |
 | components.komodorDaemon.securityContext | object | `{}` | Set custom securityContext to the komodor agent daemon (use with caution) |
 | components.komodorDaemon.metricsInit | object | See sub-values | Configure the komodor daemon metrics init container |
@@ -210,7 +210,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorDaemonWindows.annotations | object | `{}` | Adds custom annotations - Example: `--set annotations."app\.komodor\.com/app"="komodor-agent"` |
 | components.komodorDaemonWindows.labels | object | `{}` | Adds custom labels |
 | components.komodorDaemonWindows.nodeSelector | object | `{}` | Set node selectors for the komodor agent daemon |
-| components.komodorDaemonWindows.tolerations | list | `[]` | Add tolerations to the komodor agent daemon |
+| components.komodorDaemonWindows.tolerations | list | `[{"operator": "Exists"}]` | Add tolerations to the komodor agent daemon |
 | components.komodorDaemonWindows.podAnnotations | object | `{}` | # Add annotations to the komodor agent watcher pod |
 | components.komodorDaemonWindows.metrics | object | `{"extraEnvVars":[],"image":{"name":"telegraf-windows","tag":"1.31.0-v1"},"resources":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}}` | Configure the komodor daemon metrics components |
 | components.komodorDaemonWindows.metrics.image | object | `{"name":"telegraf-windows","tag":"1.31.0-v1"}` | Override the komodor agent metrics image name or tag. |

--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -187,7 +187,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorDaemon.annotations | object | `{}` | Adds custom annotations - Example: `--set annotations."app\.komodor\.com/app"="komodor-agent"` |
 | components.komodorDaemon.labels | object | `{}` | Adds custom labels |
 | components.komodorDaemon.nodeSelector | object | `{}` | Set node selectors for the komodor agent daemon |
-| components.komodorDaemon.tolerations | list | `[{"operator": "Exists"}]` | Add tolerations to the komodor agent daemon |
+| components.komodorDaemon.tolerations | list | `[{"operator":"Exists"}]` | Add tolerations to the komodor agent daemon |
 | components.komodorDaemon.podAnnotations | object | `{}` | # Add annotations to the komodor agent watcher pod |
 | components.komodorDaemon.securityContext | object | `{}` | Set custom securityContext to the komodor agent daemon (use with caution) |
 | components.komodorDaemon.metricsInit | object | See sub-values | Configure the komodor daemon metrics init container |
@@ -210,7 +210,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorDaemonWindows.annotations | object | `{}` | Adds custom annotations - Example: `--set annotations."app\.komodor\.com/app"="komodor-agent"` |
 | components.komodorDaemonWindows.labels | object | `{}` | Adds custom labels |
 | components.komodorDaemonWindows.nodeSelector | object | `{}` | Set node selectors for the komodor agent daemon |
-| components.komodorDaemonWindows.tolerations | list | `[{"operator": "Exists"}]` | Add tolerations to the komodor agent daemon |
+| components.komodorDaemonWindows.tolerations | list | `[{"operator":"Exists"}]` | Add tolerations to the komodor agent daemon |
 | components.komodorDaemonWindows.podAnnotations | object | `{}` | # Add annotations to the komodor agent watcher pod |
 | components.komodorDaemonWindows.metrics | object | `{"extraEnvVars":[],"image":{"name":"telegraf-windows","tag":"1.31.0-v1"},"resources":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}}` | Configure the komodor daemon metrics components |
 | components.komodorDaemonWindows.metrics.image | object | `{"name":"telegraf-windows","tag":"1.31.0-v1"}` | Override the komodor agent metrics image name or tag. |

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -346,7 +346,8 @@ components:
     # components.komodorDaemonWindows.nodeSelector -- Set node selectors for the komodor agent daemon
     nodeSelector: { }
     # components.komodorDaemonWindows.tolerations -- Add tolerations to the komodor agent daemon
-    tolerations: [ ]
+    tolerations:
+      - operator: "Exists"
     # components.komodorDaemonWindows.podAnnotations --  # Add annotations to the komodor agent watcher pod
     podAnnotations: { }
 

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -262,7 +262,8 @@ components:
     # components.komodorDaemon.nodeSelector -- Set node selectors for the komodor agent daemon
     nodeSelector: { }
     # components.komodorDaemon.tolerations -- Add tolerations to the komodor agent daemon
-    tolerations: [ ]
+    tolerations:
+      - operator: "Exists"
     # components.komodorDaemon.podAnnotations --  # Add annotations to the komodor agent watcher pod
     podAnnotations: { }
     # components.komodorDaemon.securityContext -- Set custom securityContext to the komodor agent daemon (use with caution)


### PR DESCRIPTION
This was in the past and probably was missed when we moved to the komodor-agent from the watcher

https://github.com/komodorio/helm-charts/blame/b3ea76976400b58fd4df1f513b1ea5fd4d5127d0/charts/k8s-watcher/values.yaml#L72