### PR TITLE
feat: Mount installed values into watcher container

### DIFF
--- a/charts/komodor-agent/templates/watcher/_volumes.tpl
+++ b/charts/komodor-agent/templates/watcher/_volumes.tpl
@@ -6,6 +6,8 @@
     items:
       - key: komodor-k8s-watcher.yaml
         path: komodor-k8s-watcher.yaml
+      - key: installed-values.yaml
+        path: installed-values.yaml
 - name: tmp
   emptyDir:
     sizeLimit: 100Mi


### PR DESCRIPTION
Mount the installed values into the watcher container,
Using the values will allow Komodor backend to have a better understanding of how the agent was installed

CU-86c0x044e