### PR TITLE
Chore: expand helm capabilities value

### DIFF
--- a/.buildkite/tests/values_capabilities_test.py
+++ b/.buildkite/tests/values_capabilities_test.py
@@ -85,7 +85,7 @@ def test_network_mapper(setup_cluster):
 
 
 def test_disable_helm_capabilities():
-    set_path = "capabilities.helm"
+    set_path = "capabilities.helm.enabled"
     value = "false"
     set_command = f"{set_path}={value}"
 

--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -122,7 +122,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | capabilities.networkMapper | bool | `false` | Enable network mapping capabilities by the komodor agent |
 | capabilities.nodeEnricher | bool | `true` | Enable node enricher capabilities by the komodor agent |
 | capabilities.actions | bool | `true` | Allow users to perform actions on the cluster, granular access control is defined in the application<boolean> |
-| capabilities.helm | bool | `true` | Enable helm capabilities by the komodor agent |
+| capabilities.helm | object | `{"enabled":true,"readonly":false}` | Enable helm capabilities by the komodor agent |
+| capabilities.helm.enabled | bool | `true` | Enable helm capabilities by the komodor agent |
+| capabilities.helm.readonly | bool | `false` | Allow komodor to read helm resources only (remove create/update/delete permissions from secrets) |
 | capabilities.rbac | bool | `true` | Allow komodor to create and manage serviceaccounts, roles and bindings in cluster |
 | capabilities.events | object | See sub-values | Configure the agent events capabilities |
 | capabilities.events.watchNamespace | string | all | Watch a specific namespace, or all namespaces ("", "all") |

--- a/charts/komodor-agent/templates/_migrations.tpl
+++ b/charts/komodor-agent/templates/_migrations.tpl
@@ -1,0 +1,6 @@
+{{- define "migrateHelmValues" -}}
+{{- if eq (typeOf .Values.capabilities.helm) "bool" -}}
+  {{- $helmMap := dict "enabled" .Values.capabilities.helm "readonly" false -}}
+  {{- $_ := set .Values.capabilities "helm" $helmMap -}}
+{{- end -}}
+{{- end -}}

--- a/charts/komodor-agent/templates/clusterrole.yaml
+++ b/charts/komodor-agent/templates/clusterrole.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.createRbac -}}
+{{- include "migrateHelmValues" . -}}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -455,8 +456,18 @@ rules:
     - create
 {{- end}}
 
+{{- if .Values.capabilities.helm.enabled }}
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - list
+      - get
+      - watch
+  {{- end }}
 
-{{- if .Values.capabilities.helm }}
+  {{- if and .Values.capabilities.helm.enabled (not .Values.capabilities.helm.readonly) }}
   - apiGroups:
       - ""
     resources:
@@ -465,9 +476,6 @@ rules:
       - create
       - update
       - delete
-      - list
-      - get
-      - watch
 
   # Allow to uninstall charts
   - apiGroups: ["*"]

--- a/charts/komodor-agent/templates/configmap.yaml
+++ b/charts/komodor-agent/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- include "migrateHelmValues" . -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,7 +11,7 @@ data:
     enableAgentTaskExecution: true
     enableAgentTaskExecutionV2: true
     allowReadingPodLogs: {{ .Values.capabilities.logs.enabled}}
-    enableHelm: {{ .Values.capabilities.helm }}
+    enableHelm: {{ .Values.capabilities.helm.enabled }}
     daemon:
       enabled: {{ .Values.capabilities.metrics }}
     collectHistory: true

--- a/charts/komodor-agent/templates/watcher/_containers.tpl
+++ b/charts/komodor-agent/templates/watcher/_containers.tpl
@@ -1,4 +1,4 @@
-
+{{- include "migrateHelmValues" . -}}
 {{- define "watcher.container" -}}
 - name: {{ include "watcher.container.name" .}}
   image: {{ .Values.imageRepo }}/{{ .Values.components.komodorAgent.watcher.image.name}}:{{ .Values.components.komodorAgent.watcher.image.tag | default .Chart.AppVersion }}
@@ -15,7 +15,7 @@
   - name: podinfo
     mountPath: /etc/podinfo
   {{- end }}
-  {{- if (.Values.capabilities).helm }}
+  {{- if (.Values.capabilities).helm.enabled }}
   - name: helm-data
     mountPath: /opt/watcher/helm
   {{- end }}

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -76,7 +76,11 @@ capabilities:
   # capabilities.actions -- (bool) Allow users to perform actions on the cluster, granular access control is defined in the application<boolean>
   actions: true
   # capabilities.helm -- Enable helm capabilities by the komodor agent
-  helm: true
+  helm:
+    # capabilities.helm.enabled -- (bool) Enable helm capabilities by the komodor agent
+    enabled: true
+    # capabilities.helm.readonly -- (bool) Allow komodor to read helm resources only (remove create/update/delete permissions from secrets)
+    readonly: false
   # capabilities.rbac -- (bool) Allow komodor to create and manage serviceaccounts, roles and bindings in cluster
   rbac: true
 


### PR DESCRIPTION
## Motivation

This pull request updates the Helm capabilities configuration for the Komodor agent chart to allow the separation of read/write permissions.

The changes include modifying the structure of the Helm capabilities in the configuration files, updating the relevant templates, and ensuring backward compatibility with previous configurations.

## Changelog

  * Changed `capabilities.helm` from a boolean to an object with `enabled` and `readonly` properties in `values.yaml`.
  * Updated the `README.md` to reflect the new structure of the Helm capabilities configuration.

## Default values
```yaml
capabilities:
  helm:
    enabled: true
    readonly: false
```