### PR TITLE
feat: support custom update strategy

### DIFF
--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -154,6 +154,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorAgent.tolerations | list | `[]` | Set tolerations for the komodor agent deployment |
 | components.komodorAgent.podAnnotations | object | `{}` | Set pod annotations for the komodor agent deployment |
 | components.komodorAgent.securityContext | object | `{}` | Set custom securityContext to the komodor agent deployment (use with caution) |
+| components.komodorAgent.strategy | object | `{}` | Set the rolling update strategy for the komodor agent deployment |
 | components.komodorAgent.watcher.image | object | `{ "name": "k8s-watcher", "tag": .Chart.AppVersion }` | Override the komodor agent watcher image name or tag. |
 | components.komodorAgent.watcher.resources | object | `{"limits":{"cpu":2,"memory":"8Gi"},"requests":{"cpu":0.25,"memory":"256Mi"}}` | Set custom resources to the komodor agent watcher container |
 | components.komodorAgent.watcher.securityContext | object | `{}` | Set security context for the komodor agent watcher container (use with caution) |
@@ -176,6 +177,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorMetrics.tolerations | list | `[]` | Set tolerations for the komodor metrics agent deployment |
 | components.komodorMetrics.podAnnotations | object | `{}` | Set pod annotations for the komodor metrics agent deployment |
 | components.komodorMetrics.securityContext | object | `{}` | Set custom securityContext to the komodor metrics agent deployment (use with caution) |
+| components.komodorMetrics.strategy | object | `{}` | Set the rolling update strategy for the komodor metrics agent deployment |
 | components.komodorMetrics.metricsInit | object | See sub-values | Configure the komodor metrics init container |
 | components.komodorMetrics.metricsInit.image | object | `{ "name": "komodor-agent", "tag": .Chart.AppVersion }` | Override the komodor agent metrics init image name or tag. |
 | components.komodorMetrics.metricsInit.resources | object | `{}` | Set custom resources to the komodor agent metrics init container |
@@ -192,6 +194,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorDaemon.tolerations | list | `[{"operator":"Exists"}]` | Add tolerations to the komodor agent daemon |
 | components.komodorDaemon.podAnnotations | object | `{}` | # Add annotations to the komodor agent watcher pod |
 | components.komodorDaemon.securityContext | object | `{}` | Set custom securityContext to the komodor agent daemon (use with caution) |
+| components.komodorDaemon.updateStrategy | object | `{}` | Set the rolling update strategy for the komodor agent daemon deployment |
 | components.komodorDaemon.metricsInit | object | See sub-values | Configure the komodor daemon metrics init container |
 | components.komodorDaemon.metricsInit.image | object | `{ "name": "init-daemon-agent", "tag": .Chart.AppVersion }` | Override the komodor agent metrics init image name or tag. |
 | components.komodorDaemon.metricsInit.resources | object | `{"limits":{"cpu":1,"memory":"100Mi"},"requests":{"cpu":0.1,"memory":"50Mi"}}` | Set custom resources to the komodor agent metrics init container |
@@ -214,6 +217,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorDaemonWindows.nodeSelector | object | `{}` | Set node selectors for the komodor agent daemon |
 | components.komodorDaemonWindows.tolerations | list | `[{"operator":"Exists"}]` | Add tolerations to the komodor agent daemon |
 | components.komodorDaemonWindows.podAnnotations | object | `{}` | # Add annotations to the komodor agent watcher pod |
+| components.komodorDaemonWindows.updateStrategy | object | `{}` | Set the rolling update strategy for the komodor agent daemon deployment |
 | components.komodorDaemonWindows.metrics | object | `{"extraEnvVars":[],"image":{"name":"telegraf-windows","tag":"1.31.0-v1"},"resources":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}}` | Configure the komodor daemon metrics components |
 | components.komodorDaemonWindows.metrics.image | object | `{"name":"telegraf-windows","tag":"1.31.0-v1"}` | Override the komodor agent metrics image name or tag. |
 | components.komodorDaemonWindows.metrics.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |

--- a/charts/komodor-agent/templates/daemonset.yaml
+++ b/charts/komodor-agent/templates/daemonset.yaml
@@ -11,6 +11,10 @@ metadata:
   annotations: {{ toYaml ((.Values.components).komodorDaemon).annotations | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not (empty .Values.components.komodorDaemon.updateStrategy) }}
+  updateStrategy:
+    {{- toYaml .Values.components.komodorDaemon.updateStrategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels: {{- include "komodorAgentDaemon.selectorLabels" . | nindent 6 }}
   template:

--- a/charts/komodor-agent/templates/daemonset_windows.yaml
+++ b/charts/komodor-agent/templates/daemonset_windows.yaml
@@ -10,6 +10,10 @@ metadata:
   annotations: {{ toYaml ((.Values.components).komodorDaemonWindows).annotations | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not (empty .Values.components.komodorDaemonWindows.updateStrategy) }}
+  updateStrategy:
+    {{- toYaml .Values.components.komodorDaemonWindows.updateStrategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels: {{- include "komodorAgentDaemonWindows.selectorLabels" . | nindent 6 }}
   template:

--- a/charts/komodor-agent/templates/deployment.yaml
+++ b/charts/komodor-agent/templates/deployment.yaml
@@ -10,9 +10,14 @@ metadata:
 spec:
   replicas: 1
   strategy:
+  {{- if not (empty .Values.components.komodorAgent.strategy) }}
+    {{- toYaml .Values.components.komodorAgent.strategy | nindent 4 }}
+  {{ else }}
+    type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 1
+  {{- end }}
   selector:
     matchLabels:
       {{- include "komodorAgent.selectorLabels" . | nindent 6 }}

--- a/charts/komodor-agent/templates/deployment_metrics.yaml
+++ b/charts/komodor-agent/templates/deployment_metrics.yaml
@@ -10,6 +10,10 @@ metadata:
   annotations: {{ toYaml ((.Values.components).komodorMetrics).annotations | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not (empty .Values.components.komodorMetrics.strategy) }}
+  strategy:
+    {{- toYaml .Values.components.komodorMetrics.strategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels: {{- include "komodorMetrics.selectorLabels" . | nindent 6 }}
   template:

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -151,6 +151,8 @@ components:
     podAnnotations: { }
     # components.komodorAgent.securityContext -- Set custom securityContext to the komodor agent deployment (use with caution)
     securityContext: { }
+    # components.komodorAgent.strategy -- Set the rolling update strategy for the komodor agent deployment
+    strategy: { }
 
     watcher:
       # components.komodorAgent.watcher.image -- Override the komodor agent watcher image name or tag.
@@ -222,6 +224,8 @@ components:
     podAnnotations: { }
     # components.komodorMetrics.securityContext -- Set custom securityContext to the komodor metrics agent deployment (use with caution)
     securityContext: { }
+    # components.komodorMetrics.strategy -- Set the rolling update strategy for the komodor metrics agent deployment
+    strategy: { }
 
     # components.komodorMetrics.metricsInit -- Configure the komodor metrics init container
     # @default -- See sub-values
@@ -272,6 +276,8 @@ components:
     podAnnotations: { }
     # components.komodorDaemon.securityContext -- Set custom securityContext to the komodor agent daemon (use with caution)
     securityContext: { }
+    # components.komodorDaemon.updateStrategy -- Set the rolling update strategy for the komodor agent daemon deployment
+    updateStrategy: { }
 
     # components.komodorDaemon.metrics -- Configure the komodor daemon metrics components
 
@@ -354,6 +360,8 @@ components:
       - operator: "Exists"
     # components.komodorDaemonWindows.podAnnotations --  # Add annotations to the komodor agent watcher pod
     podAnnotations: { }
+    # components.komodorDaemonWindows.updateStrategy -- Set the rolling update strategy for the komodor agent daemon deployment
+    updateStrategy: { }
 
     # components.komodorDaemonWindows.metrics -- Configure the komodor daemon metrics components
     metrics:


### PR DESCRIPTION
## Motivation
Allow users to set a custom rolling update strategy for each resource
This pull request introduces support for configurable rolling update strategies. 

## Changelog:
* Update the `README.md` to include descriptions for the new `strategy` and `updateStrategy` configuration options.
* Update the templates to override the default strategy when users set a custom strategy.
* Added a new test case: `test_override_update_strategy` to validate the rolling update strategy configuration for different components.
