### PR TITLE
[skip ci] - CU-86c16t7fu - fix(CD): Publish relevant charts to OCI registry

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -50,7 +50,7 @@ process_chart() {
     helm lint "$chart"
     mkdir -p "$chart_name"
     helm package -d "$chart_name" "$chart"
-    push_chart_to_docker_hub "$chart_name/$chart_name-$chart_version.tgz"
+    [ "$chart_name" = "komodor-agent" ] && push_chart_to_docker_hub "$chart_name/$chart_name-$chart_version.tgz"
     sync_to_s3 "$chart_name"
 }
 


### PR DESCRIPTION
This PR updates the pipeline to publish only the `Komodor-agent` Helm chart to the OCI registry.