### PR TITLE
fixing hpa permissions to be included under capabilities.actions

### DIFF
--- a/charts/komodor-agent/templates/clusterrole.yaml
+++ b/charts/komodor-agent/templates/clusterrole.yaml
@@ -401,7 +401,7 @@ rules:
     - patch
     - update
     - create
-   - apiGroups:
+  - apiGroups:
     - autoscaling
     resources:
     - horizontalpodautoscalers

--- a/charts/komodor-agent/templates/clusterrole.yaml
+++ b/charts/komodor-agent/templates/clusterrole.yaml
@@ -255,7 +255,6 @@ rules:
     - get
     - watch
     - list
-    - patch
 {{- end }}
 {{- if .Values.allowedResources.certificateSigningRequest }}
   - apiGroups:
@@ -400,6 +399,15 @@ rules:
     verbs:
     - delete
     - patch
+    - update
+    - create
+   - apiGroups:
+    - autoscaling
+    resources:
+    - horizontalpodautoscalers
+    verbs:
+    - patch
+    - delete
     - update
     - create
 {{- end }}


### PR DESCRIPTION
- Moved the HPA permissions under the capabiliteis.actions value
- Added delete which we should add as an action in our platform
- Added create & update to align with other resources we give permissions in the capabilities.actions section (it's currently not required but might be used in the future?)