### PR TITLE
CU-86c1z5mux  - add basicstats aggregator and regex processor to metrics confingmaps

### DIFF
--- a/charts/komodor-agent/templates/metrics/configmap-daemon-windows.yaml
+++ b/charts/komodor-agent/templates/metrics/configmap-daemon-windows.yaml
@@ -9,9 +9,11 @@ data:
       precision = "${INTERVAL}"
       interval = "${INTERVAL}"
       flush_interval = "${FLUSH_INTERVAL}"
+      skip_processors_after_aggregators = false
 
     [[outputs.http]]
       url = {{ include "metrics.collector.endpoint" . | quote}}
+      fieldinclude = ["resource_requests_millicpu_units","resource_limits_millicpu_units","resource_requests_memory_bytes","resource_limits_memory_bytes", "capacity_cpu_cores", "capacity_millicpu_cores", "capacity_memory_bytes", "restarts_total", "memory_usage_bytes*", "cpu_usage_nanocores*", "memory_working_set_bytes*", "allocatable_millicpu_cores", "allocatable_memory_bytes"]
       timeout = "${OUTPUT_TIMEOUT}"
       content_encoding = "gzip"
       {{- if .Values.proxy.https }}
@@ -27,22 +29,30 @@ data:
     [[inputs.execd]]
       command = ["C:/telegraf/custom_input.exe", "-config", "C:/telegraf/plugin.conf"]
       namedrop = ["kubernetes_system_container"]
-      fieldinclude = ["resource_requests_millicpu_units","resource_limits_millicpu_units","resource_requests_memory_bytes","resource_limits_memory_bytes", "capacity_cpu_cores", "capacity_millicpu_cores", "capacity_memory_bytes", "restarts_total", "memory_usage_bytes", "cpu_usage_nanocores", "memory_working_set_bytes", "allocatable_millicpu_cores", "allocatable_memory_bytes", "komodor_owner_refs"]
       [inputs.execd.tags]
       measure_type = "consolidated"
 
     [[aggregators.basicstats]]
       period = "${AGGREGATED_INTERVAL}"
       drop_original = true
-      stats = ["count","min","max","mean"]
+      stats = ["max","mean"]
+
+    [[aggregators.quantile]]
+      period = "${AGGREGATED_INTERVAL}"
+      drop_original = true
+      quantiles = [0.75, 0.90, 0.95,0.99]        
 
     [[processors.regex]]
       [[processors.regex.field_rename]]
-        ## Regular expression to match on the field name
-        pattern = "^(?P<fieldName>.*)_mean$"
-        ## Replacement expression defining the name of the new field
-        replacement = "${fieldName}"
-        
+        fieldinclude = ["memory_usage_bytes*", "cpu_usage_nanocores*", "memory_working_set_bytes*"]
+        pattern = "^(?P<method>.*)_mean$"
+        replacement = "${method}"
+
+      [[processors.regex.field_rename]]
+        fieldexclude = ["memory_usage_bytes*", "cpu_usage_nanocores*", "memory_working_set_bytes*"]
+        pattern = "^(?P<method>.*)_max$"
+        replacement = "${method}"
+
   plugin.conf: |
     [[inputs.kube_consolidated]]
       bearer_token = "C:/var/run/secrets/kubernetes.io/serviceaccount/token"

--- a/charts/komodor-agent/templates/metrics/configmap-daemon-windows.yaml
+++ b/charts/komodor-agent/templates/metrics/configmap-daemon-windows.yaml
@@ -31,6 +31,18 @@ data:
       [inputs.execd.tags]
       measure_type = "consolidated"
 
+    [[aggregators.basicstats]]
+      period = "${AGGREGATED_INTERVAL}"
+      drop_original = true
+      stats = ["count","min","max","mean"]
+
+    [[processors.regex]]
+      [[processors.regex.field_rename]]
+        ## Regular expression to match on the field name
+        pattern = "^(?P<fieldName>.*)_mean$"
+        ## Replacement expression defining the name of the new field
+        replacement = "${fieldName}"
+        
   plugin.conf: |
     [[inputs.kube_consolidated]]
       bearer_token = "C:/var/run/secrets/kubernetes.io/serviceaccount/token"
@@ -41,8 +53,6 @@ data:
       poll_interval = "${INTERVAL}"
 
       resource_include = [ "pods", "nodes" ]
-      interval = "${INTERVAL_INVENTORY}"
-      flush_interval = "${FLUSH_INTERVAL_INVENTORY}"
       inventory_cache_ttl = "${FLUSH_INTERVAL_INVENTORY}"
       owner_cache_ttl = "${FLUSH_INTERVAL_INVENTORY}"
       node_name = "${NODE_NAME}"

--- a/charts/komodor-agent/templates/metrics/configmap-daemon.yaml
+++ b/charts/komodor-agent/templates/metrics/configmap-daemon.yaml
@@ -31,6 +31,18 @@ data:
       [inputs.execd.tags]
       measure_type = "consolidated"
 
+    [[aggregators.basicstats]]
+      period = "${AGGREGATED_INTERVAL}"
+      drop_original = true
+      stats = ["count","min","max","mean"]
+
+    [[processors.regex]]
+      [[processors.regex.field_rename]]
+        ## Regular expression to match on the field name
+        pattern = "^(?P<fieldName>.*)_mean$"
+        ## Replacement expression defining the name of the new field
+        replacement = "${fieldName}"
+
   plugin.conf: |
     [[inputs.kube_consolidated]]
       bearer_token = "/run/secrets/kubernetes.io/serviceaccount/token"
@@ -41,8 +53,6 @@ data:
       poll_interval = "${INTERVAL}"
 
       resource_include = [ "pods", "nodes" ]
-      interval = "${INTERVAL_INVENTORY}"
-      flush_interval = "${FLUSH_INTERVAL_INVENTORY}"
       inventory_cache_ttl = "${FLUSH_INTERVAL_INVENTORY}"
       owner_cache_ttl = "${FLUSH_INTERVAL_INVENTORY}"
       node_name = "${NODE_NAME}"

--- a/charts/komodor-agent/templates/metrics/configmap-daemon.yaml
+++ b/charts/komodor-agent/templates/metrics/configmap-daemon.yaml
@@ -9,9 +9,11 @@ data:
       precision = "${INTERVAL}"
       interval = "${INTERVAL}"
       flush_interval = "${FLUSH_INTERVAL}"
+      skip_processors_after_aggregators = false
 
     [[outputs.http]]
       url = {{ include "metrics.collector.endpoint" . | quote}}
+      fieldinclude = ["resource_requests_millicpu_units","resource_limits_millicpu_units","resource_requests_memory_bytes","resource_limits_memory_bytes", "capacity_cpu_cores", "capacity_millicpu_cores", "capacity_memory_bytes", "restarts_total", "memory_usage_bytes*", "cpu_usage_nanocores*", "memory_working_set_bytes*", "allocatable_millicpu_cores", "allocatable_memory_bytes"]
       timeout = "${OUTPUT_TIMEOUT}"
       content_encoding = "gzip"
       {{- if .Values.proxy.https }}
@@ -27,21 +29,30 @@ data:
     [[inputs.execd]]
       command = ["custom_input", "-config", "/etc/telegraf/plugin.conf"]
       namedrop = ["kubernetes_system_container"]
-      fieldinclude = ["resource_requests_millicpu_units","resource_limits_millicpu_units","resource_requests_memory_bytes","resource_limits_memory_bytes", "capacity_cpu_cores", "capacity_millicpu_cores", "capacity_memory_bytes", "restarts_total", "memory_usage_bytes", "cpu_usage_nanocores", "memory_working_set_bytes", "allocatable_millicpu_cores", "allocatable_memory_bytes", "komodor_owner_refs"]
       [inputs.execd.tags]
       measure_type = "consolidated"
 
     [[aggregators.basicstats]]
       period = "${AGGREGATED_INTERVAL}"
       drop_original = true
-      stats = ["count","min","max","mean"]
+      stats = ["max","mean"]
+
+    [[aggregators.quantile]]
+      period = "${AGGREGATED_INTERVAL}"
+      drop_original = true
+      quantiles = [0.75, 0.90, 0.95,0.99]        
 
     [[processors.regex]]
       [[processors.regex.field_rename]]
-        ## Regular expression to match on the field name
-        pattern = "^(?P<fieldName>.*)_mean$"
-        ## Replacement expression defining the name of the new field
-        replacement = "${fieldName}"
+        fieldinclude = ["memory_usage_bytes*", "cpu_usage_nanocores*", "memory_working_set_bytes*"]
+        pattern = "^(?P<method>.*)_mean$"
+        replacement = "${method}"
+        
+      [[processors.regex.field_rename]]
+        fieldexclude = ["memory_usage_bytes*", "cpu_usage_nanocores*", "memory_working_set_bytes*"]
+        pattern = "^(?P<method>.*)_max$"
+        replacement = "${method}"
+
 
   plugin.conf: |
     [[inputs.kube_consolidated]]


### PR DESCRIPTION
Adds max , mean ,p90,p95,p99 and p75 aggregations to get more accurate results 

* Added `skip_processors_after_aggregators` - default now is false but from 1.4 the default value will change to true
* update fieldinclude to pass the aggregated fields 
* Introduced `aggregators.basicstats` and `aggregators.quantile` to perform statistical aggregation on metrics. [[1]](diffhunk://#diff-b39f2416903c6d23246a5a65e8b9f229f6c82f7b3e00a927af947c1f6794606aL30-R55) [[2]](diffhunk://#diff-c0903fd3cf76da60d2584e6dc9095d3e5dd0066abbefb28740de7c52c7d12c80L30-R56)
* Added `processors.regex` to rename fields based on patterns for backward compatibility. [[1]](diffhunk://#diff-b39f2416903c6d23246a5a65e8b9f229f6c82f7b3e00a927af947c1f6794606aL30-R55) [[2]](diffhunk://#diff-c0903fd3cf76da60d2584e6dc9095d3e5dd0066abbefb28740de7c52c7d12c80L30-R56)

Simplification and cleanup:

* Removed redundant `interval` and `flush_interval` fields to streamline the configuration. [[1]](diffhunk://#diff-b39f2416903c6d23246a5a65e8b9f229f6c82f7b3e00a927af947c1f6794606aL44-L45) [[2]](diffhunk://#diff-c0903fd3cf76da60d2584e6dc9095d3e5dd0066abbefb28740de7c52c7d12c80L44-L45)