### PR TITLE
adding support for setting up the secretKey in both user provided sec…

### DIFF
--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -94,6 +94,7 @@ The command removes all the Kubernetes components associated with the chart and 
 |-----|------|---------|-------------|
 | apiKey | guid | `nil` | **(*required*)** To be obtained from komodor app during onboarding |
 | apiKeySecret | string | `nil` | Secret name containing Komodor agent api key |
+| secretKey | string | `apiKey` | Secret key used in the provided secret |
 | createNamespace | bool | `true` | Creates the namespace |
 | tags | dict | `{}` | Tags the agent in order to identify it based on `key:value` properties separated by semicolon (`;`) example: `--set tags.env=staging,tags.team=payments` --- Can also be set in the values under `tags` as a dictionary of key:value strings |
 | clusterName | string | `nil` | **(*required*)** Name to be displayed in the Komodor web application |

--- a/charts/komodor-agent/templates/metrics/_containers_deamon.tpl
+++ b/charts/komodor-agent/templates/metrics/_containers_deamon.tpl
@@ -98,10 +98,10 @@
       secretKeyRef:
         {{- if .Values.apiKeySecret }}
         name: {{ .Values.apiKeySecret | required "Existing secret name required!" }}
-        key: apiKey
+        key: {{ .Values.secretKey }} 
         {{- else }}
         name: {{ include "komodorAgent.secret.name" . }}
-        key: apiKey
+        key: {{ .Values.secretKey }} 
         {{- end }}
   {{- if gt (len .Values.components.komodorDaemon.metricsInit.extraEnvVars) 0 }}
   {{ toYaml .Values.components.komodorDaemon.metricsInit.extraEnvVars | nindent 2 }}

--- a/charts/komodor-agent/templates/metrics/_containers_deployment.tpl
+++ b/charts/komodor-agent/templates/metrics/_containers_deployment.tpl
@@ -52,10 +52,10 @@
       secretKeyRef:
         {{- if .Values.apiKeySecret }}
         name: {{ .Values.apiKeySecret | required "Existing secret name required!" }}
-        key: apiKey
+        key: {{ .Values.secretKey }} 
         {{- else }}
         name: {{ include "komodorAgent.secret.name" . }}
-        key: apiKey
+        key: {{ .Values.secretKey }} 
         {{- end }}
   {{- if gt (len .Values.components.komodorMetrics.metricsInit.extraEnvVars) 0 }}
   {{ toYaml .Values.components.komodorMetrics.metricsInit.extraEnvVars | nindent 2 }}

--- a/charts/komodor-agent/templates/node-enricher/_containers.tpl
+++ b/charts/komodor-agent/templates/node-enricher/_containers.tpl
@@ -32,10 +32,10 @@
       secretKeyRef:
         {{- if .Values.apiKeySecret }}
         name: {{ .Values.apiKeySecret | required "Existing secret name required!" }}
-        key: apiKey
+        key: {{ .Values.secretKey }} 
         {{- else }}
         name: {{ include "komodorAgent.secret.name" . }}
-        key: apiKey
+        key: {{ .Values.secretKey }} 
         {{- end }}
   - name: NODE_NAME
     valueFrom:

--- a/charts/komodor-agent/templates/secret-credentials.yaml
+++ b/charts/komodor-agent/templates/secret-credentials.yaml
@@ -5,5 +5,5 @@ metadata:
   name: {{ include "komodorAgent.secret.name" . }}
 type: Opaque
 data:
-  apiKey: {{ .Values.apiKey | required "apiKey is a required value!" | b64enc }}
+  {{ .Values.secretKey }} : {{ .Values.apiKey | required "apiKey is a required value!" | b64enc }}
 {{- end }}

--- a/charts/komodor-agent/templates/watcher/_containers.tpl
+++ b/charts/komodor-agent/templates/watcher/_containers.tpl
@@ -30,10 +30,10 @@
       secretKeyRef:
         {{- if .Values.apiKeySecret }}
         name: {{ .Values.apiKeySecret | required "Existing secret name required!" }}
-        key: apiKey
+        key: {{ .Values.secretKey }}
         {{- else }}
         name: {{ include "komodorAgent.secret.name" . }}
-        key: apiKey
+        key: {{ .Values.secretKey }}
         {{- end }}
   - name: KOMOKW_CLUSTER_NAME
     value: {{ .Values.clusterName }}
@@ -66,7 +66,7 @@
       port: http-healthz
     initialDelaySeconds: 5
     periodSeconds: 5
-    failureThreshold: 3
+    failureThreshold: 3git 
     successThreshold: 1
 {{- end -}}
 
@@ -87,10 +87,10 @@
         secretKeyRef:
           {{- if .Values.apiKeySecret }}
           name: {{ .Values.apiKeySecret }}
-          key: apiKey
+          key: {{ .Values.secretKey }} 
           {{- else }}
           name: {{ include "komodorAgent.secret.name" . }}
-          key: apiKey
+          key: {{ .Values.secretKey }} 
           {{- end }}
     - name: KOMOKW_SERVERS_HEALTHCHECK_PORT
       value: {{ .Values.components.komodorAgent.supervisor.ports.healthCheck | quote }}

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -1,3 +1,5 @@
+# secretKey -- (string) Secret key to be used in the secret
+secretKey: apiKey
 # apiKey -- (guid) **(*required*)** To be obtained from komodor app during onboarding
 apiKey:
 # apiKeySecret -- (string) Secret name containing Komodor agent api key


### PR DESCRIPTION
Mend uses external secrets and would like to utilize different key names per cluster to support easier automation of cluster onboarding.
I'm debating whether this should also be part of the Komodor agent chart managed secret but implemented it for both currently.