### PR TITLE
CU-86c2f0mpdstop - serviceaccount template from generating when imagePullSecret is specified

### DIFF
--- a/charts/komodor-agent/templates/serviceaccount.yaml
+++ b/charts/komodor-agent/templates/serviceaccount.yaml
@@ -8,8 +8,8 @@ metadata:
     {{- include "komodorAgent.user.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.components.komodorAgent.annotations | nindent 4 }}
-{{- end }}
 {{- if not (empty .Values.imagePullSecret) }}
 imagePullSecrets:
   - name: {{ .Values.imagePullSecret }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
when the following are specified:

- `serviceAccount.create: false`
- `serviceAccount.name: some-sa`
- `imagePullSecret: some-secret`

we are currently generating incorrect serviceaccount.yaml due to improper if blocks. This resolves that