### PR TITLE
fix: remove hostNetwork parameter from komodorDaemonWindows configuration - not supported on windows

### DIFF
--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -214,7 +214,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorDaemon.nodeEnricher.resources | object | `{"limits":{"cpu":"10m","memory":"100Mi"},"requests":{"cpu":"1m","memory":"10Mi"}}` | Set custom resources to the komodor agent node enricher container |
 | components.komodorDaemon.nodeEnricher.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemonWindows | object | See sub-values | Configure the komodor agent components |
-| components.komodorDaemonWindows.hostNetwork | bool | `false` | Set host network for the komodor agent daemon |
 | components.komodorDaemonWindows.dnsPolicy | string | `"ClusterFirst"` | Set dns policy for the komodor agent daemon |
 | components.komodorDaemonWindows.affinity | object | `{}` | Set node affinity for the komodor agent daemon |
 | components.komodorDaemonWindows.annotations | object | `{}` | Adds custom annotations - Example: `--set annotations."app\.komodor\.com/app"="komodor-agent"` |

--- a/charts/komodor-agent/templates/daemonset_windows.yaml
+++ b/charts/komodor-agent/templates/daemonset_windows.yaml
@@ -27,7 +27,6 @@ spec:
         {{- include "komodorAgentDaemonWindows.selectorLabels" . | nindent 8 }}
         {{- include "komodorDaemonWindows.user.labels" . | nindent 8 }}
     spec:
-      hostNetwork: {{ .Values.components.komodorDaemonWindows.hostNetwork }}
       dnsPolicy: {{ .Values.components.komodorDaemonWindows.dnsPolicy }}
       terminationGracePeriodSeconds: 0
       priorityClassName: {{ include "komodor.truncatedReleaseName"  . }}-daemon-high-priority

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -347,8 +347,6 @@ components:
   # components.komodorDaemonWindows -- Configure the komodor agent components
   # @default -- See sub-values
   komodorDaemonWindows:
-    # components.komodorDaemonWindows.hostNetwork -- Set host network for the komodor agent daemon
-    hostNetwork: false
     # components.komodorDaemonWindows.dnsPolicy -- Set dns policy for the komodor agent daemon
     dnsPolicy: ClusterFirst
     # components.komodorDaemonWindows.affinity -- Set node affinity for the komodor agent daemon


### PR DESCRIPTION
This pull request includes changes to the `komodor-agent` Helm chart to remove the `hostNetwork` configuration for the Windows daemon since it's not supported on windows.