### PR TITLE
feat: add quiet mode configuration for komodor agent metrics [CU-86c2kua4v]

### DIFF
--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -189,6 +189,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorMetrics.metrics.image | object | `{"name":"telegraf","tag":"v1.34.1-build1-alpine"}` | Override the komodor agent metrics image name or tag. |
 | components.komodorMetrics.metrics.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
 | components.komodorMetrics.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
+| components.komodorMetrics.metrics.quiet | bool | `false` | Set the quiet mode for the komodor agent metrics |
 | components.komodorDaemon | object | See sub-values | Configure the komodor agent components |
 | components.komodorDaemon.hostNetwork | bool | `false` | Set host network for the komodor agent daemon |
 | components.komodorDaemon.dnsPolicy | string | `"ClusterFirst"` | Set dns policy for the komodor agent daemon |
@@ -205,10 +206,11 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorDaemon.metricsInit.image | object | `{ "name": "init-daemon-agent", "tag": .Chart.AppVersion }` | Override the komodor agent metrics init image name or tag. |
 | components.komodorDaemon.metricsInit.resources | object | `{"limits":{"cpu":1,"memory":"100Mi"},"requests":{"cpu":0.1,"memory":"50Mi"}}` | Set custom resources to the komodor agent metrics init container |
 | components.komodorDaemon.metricsInit.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
-| components.komodorDaemon.metrics | object | `{"extraEnvVars":[],"image":{"name":"telegraf","tag":"v1.34.1-build1-alpine"},"resources":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}}` | Configure the komodor daemon metrics components |
+| components.komodorDaemon.metrics | object | `{"extraEnvVars":[],"image":{"name":"telegraf","tag":"v1.34.1-build1-alpine"},"quiet":false,"resources":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}}` | Configure the komodor daemon metrics components |
 | components.komodorDaemon.metrics.image | object | `{"name":"telegraf","tag":"v1.34.1-build1-alpine"}` | Override the komodor agent metrics image name or tag. |
 | components.komodorDaemon.metrics.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
 | components.komodorDaemon.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
+| components.komodorDaemon.metrics.quiet | bool | `false` | Set the quiet mode for the komodor agent metrics |
 | components.komodorDaemon.nodeEnricher | object | See sub-values | Configure the komodor daemon node enricher components |
 | components.komodorDaemon.nodeEnricher.image | object | `{"name":"komodor-agent","tag":null}` | Override the komodor agent node enricher image name or tag. |
 | components.komodorDaemon.nodeEnricher.resources | object | `{"limits":{"cpu":"10m","memory":"100Mi"},"requests":{"cpu":"1m","memory":"10Mi"}}` | Set custom resources to the komodor agent node enricher container |
@@ -222,10 +224,11 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorDaemonWindows.tolerations | list | `[{"operator":"Exists"}]` | Add tolerations to the komodor agent daemon |
 | components.komodorDaemonWindows.podAnnotations | object | `{}` | # Add annotations to the komodor agent watcher pod |
 | components.komodorDaemonWindows.updateStrategy | object | `{}` | Set the rolling update strategy for the komodor agent daemon deployment |
-| components.komodorDaemonWindows.metrics | object | `{"extraEnvVars":[],"image":{"name":"telegraf-windows","tag":"v1.34.1-build1-windows"},"resources":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}}` | Configure the komodor daemon metrics components |
+| components.komodorDaemonWindows.metrics | object | `{"extraEnvVars":[],"image":{"name":"telegraf-windows","tag":"v1.34.1-build1-windows"},"quiet":false,"resources":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}}` | Configure the komodor daemon metrics components |
 | components.komodorDaemonWindows.metrics.image | object | `{"name":"telegraf-windows","tag":"v1.34.1-build1-windows"}` | Override the komodor agent metrics image name or tag. |
 | components.komodorDaemonWindows.metrics.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
 | components.komodorDaemonWindows.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
+| components.komodorDaemonWindows.metrics.quiet | bool | `false` | Set the quiet mode for the komodor agent metrics |
 | allowedResources.event | bool | `true` | Enables watching `event` |
 | allowedResources.deployment | bool | `true` | Enables watching `deployments` |
 | allowedResources.replicationController | bool | `true` | Enables watching `replicationControllers` |

--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -189,7 +189,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorMetrics.metrics.image | object | `{"name":"telegraf","tag":"v1.34.1-build1-alpine"}` | Override the komodor agent metrics image name or tag. |
 | components.komodorMetrics.metrics.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
 | components.komodorMetrics.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
-| components.komodorMetrics.metrics.quiet | bool | `false` | Set the quiet mode for the komodor agent metrics |
 | components.komodorDaemon | object | See sub-values | Configure the komodor agent components |
 | components.komodorDaemon.hostNetwork | bool | `false` | Set host network for the komodor agent daemon |
 | components.komodorDaemon.dnsPolicy | string | `"ClusterFirst"` | Set dns policy for the komodor agent daemon |

--- a/charts/komodor-agent/templates/metrics/configmap-daemon-windows.yaml
+++ b/charts/komodor-agent/templates/metrics/configmap-daemon-windows.yaml
@@ -10,7 +10,7 @@ data:
       interval = "${INTERVAL}"
       flush_interval = "${FLUSH_INTERVAL}"
       skip_processors_after_aggregators = false
-      quiet = ${ .Values.components.komodorDaemonWindows.metrics.quiet }
+      quiet = {{ .Values.components.komodorDaemonWindows.metrics.quiet }}
 
     [[outputs.http]]
       url = {{ include "metrics.collector.endpoint" . | quote}}

--- a/charts/komodor-agent/templates/metrics/configmap-daemon-windows.yaml
+++ b/charts/komodor-agent/templates/metrics/configmap-daemon-windows.yaml
@@ -10,6 +10,7 @@ data:
       interval = "${INTERVAL}"
       flush_interval = "${FLUSH_INTERVAL}"
       skip_processors_after_aggregators = false
+      quiet = false
 
     [[outputs.http]]
       url = {{ include "metrics.collector.endpoint" . | quote}}

--- a/charts/komodor-agent/templates/metrics/configmap-daemon-windows.yaml
+++ b/charts/komodor-agent/templates/metrics/configmap-daemon-windows.yaml
@@ -10,7 +10,7 @@ data:
       interval = "${INTERVAL}"
       flush_interval = "${FLUSH_INTERVAL}"
       skip_processors_after_aggregators = false
-      quiet = false
+      quiet = ${ .Values.components.komodorDaemonWindows.metrics.quiet }
 
     [[outputs.http]]
       url = {{ include "metrics.collector.endpoint" . | quote}}

--- a/charts/komodor-agent/templates/metrics/configmap-daemon.yaml
+++ b/charts/komodor-agent/templates/metrics/configmap-daemon.yaml
@@ -10,7 +10,7 @@ data:
       interval = "${INTERVAL}"
       flush_interval = "${FLUSH_INTERVAL}"
       skip_processors_after_aggregators = false
-      quiet = ${ .Values.components.komodorDaemon.metrics.quiet }
+      quiet = {{ .Values.components.komodorDaemon.metrics.quiet }}
 
     [[outputs.http]]
       url = {{ include "metrics.collector.endpoint" . | quote}}

--- a/charts/komodor-agent/templates/metrics/configmap-daemon.yaml
+++ b/charts/komodor-agent/templates/metrics/configmap-daemon.yaml
@@ -10,6 +10,7 @@ data:
       interval = "${INTERVAL}"
       flush_interval = "${FLUSH_INTERVAL}"
       skip_processors_after_aggregators = false
+      quiet = false
 
     [[outputs.http]]
       url = {{ include "metrics.collector.endpoint" . | quote}}

--- a/charts/komodor-agent/templates/metrics/configmap-daemon.yaml
+++ b/charts/komodor-agent/templates/metrics/configmap-daemon.yaml
@@ -10,7 +10,7 @@ data:
       interval = "${INTERVAL}"
       flush_interval = "${FLUSH_INTERVAL}"
       skip_processors_after_aggregators = false
-      quiet = false
+      quiet = ${ .Values.components.komodorDaemon.metrics.quiet }
 
     [[outputs.http]]
       url = {{ include "metrics.collector.endpoint" . | quote}}

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -261,8 +261,6 @@ components:
           memory: 384Mi
       # components.komodorMetrics.metrics.extraEnvVars -- List of additional environment variables, Each entry is a key-value pair
       extraEnvVars: [ ]
-      # components.komodorMetrics.metrics.quiet -- Set the quiet mode for the komodor agent metrics
-      quiet: false
 
   # components.komodorDaemon -- Configure the komodor agent components
   # @default -- See sub-values

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -261,6 +261,8 @@ components:
           memory: 384Mi
       # components.komodorMetrics.metrics.extraEnvVars -- List of additional environment variables, Each entry is a key-value pair
       extraEnvVars: [ ]
+      # components.komodorMetrics.metrics.quiet -- Set the quiet mode for the komodor agent metrics
+      quiet: false
 
   # components.komodorDaemon -- Configure the komodor agent components
   # @default -- See sub-values
@@ -325,6 +327,8 @@ components:
           memory: 384Mi
       # components.komodorDaemon.metrics.extraEnvVars -- List of additional environment variables, Each entry is a key-value pair
       extraEnvVars: [ ]
+      # components.komodorDaemon.metrics.quiet -- Set the quiet mode for the komodor agent metrics
+      quiet: false
 
     # components.komodorDaemon.nodeEnricher -- Configure the komodor daemon node enricher components
     # @default -- See sub-values
@@ -381,6 +385,8 @@ components:
           memory: 384Mi
       # components.komodorDaemonWindows.metrics.extraEnvVars -- List of additional environment variables, Each entry is a key-value pair
       extraEnvVars: [ ]
+      # components.komodorDaemonWindows.metrics.quiet -- Set the quiet mode for the komodor agent metrics
+      quiet: false
 
 
 allowedResources:


### PR DESCRIPTION
This pull request includes changes to the `komodor-agent` Helm chart to add a new configuration option for setting the quiet mode for the komodor agent metrics. The most important changes include updates to the `README.md` file, the metrics configuration templates, and the `values.yaml` file.

### Add quiet mode configuration for komodor agent metrics:

* [`charts/komodor-agent/README.md`](diffhunk://#diff-a1c7c440ff8832984790b9cc6143fb153a3783a5e3074e6338e61365cf5a0f2aL208-R212): Added `quiet` option to the `components.komodorDaemon.metrics` and `components.komodorDaemonWindows.metrics` sections. [[1]](diffhunk://#diff-a1c7c440ff8832984790b9cc6143fb153a3783a5e3074e6338e61365cf5a0f2aL208-R212) [[2]](diffhunk://#diff-a1c7c440ff8832984790b9cc6143fb153a3783a5e3074e6338e61365cf5a0f2aL225-R230)
* [`charts/komodor-agent/templates/metrics/configmap-daemon.yaml`](diffhunk://#diff-c0903fd3cf76da60d2584e6dc9095d3e5dd0066abbefb28740de7c52c7d12c80R13): Added `quiet` configuration to the metrics configmap for the daemon.
* [`charts/komodor-agent/templates/metrics/configmap-daemon-windows.yaml`](diffhunk://#diff-b39f2416903c6d23246a5a65e8b9f229f6c82f7b3e00a927af947c1f6794606aR13): Added `quiet` configuration to the metrics configmap for the Windows daemon.
* [`charts/komodor-agent/values.yaml`](diffhunk://#diff-64879027a4c59e7dafa9421f48f94cbdadcfc11f5cb2c41d928e568077bd90a1R328-R329): Added `quiet` option to the `components.komodorDaemon.metrics` and `components.komodorDaemonWindows.metrics` sections. [[1]](diffhunk://#diff-64879027a4c59e7dafa9421f48f94cbdadcfc11f5cb2c41d928e568077bd90a1R328-R329) [[2]](diffhunk://#diff-64879027a4c59e7dafa9421f48f94cbdadcfc11f5cb2c41d928e568077bd90a1R386-R387)