### PR TITLE
CU-86c3chx0b Add flag to use new GPU metrics collecting

### DIFF
--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -98,8 +98,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | tags | dict | `{}` | Tags the agent in order to identify it based on `key:value` properties separated by semicolon (`;`) example: `--set tags.env=staging,tags.team=payments` --- Can also be set in the values under `tags` as a dictionary of key:value strings |
 | clusterName | string | `nil` | **(*required*)** Name to be displayed in the Komodor web application |
 | createRbac | bool | `true` | Creates the necessary RBAC resources for the agent - use with caution! |
-| telegrafImageVersion | string | `"v1.34.1-build1-alpine"` | Telegraf version to be used |
-| telegrafWindowsImageVersion | string | `"v1.34.1-build1-windows"` | Telegraf version to be used for windows |
+| telegrafImageVersion | string | `"v1.34.1-build2-alpine"` | Telegraf version to be used |
+| telegrafWindowsImageVersion | string | `"v1.34.1-build2-windows"` | Telegraf version to be used for windows |
 | serviceAccount | object | See sub-values | Configure service account for the agent |
 | serviceAccount.create | bool | `true` | Creates a service account for the agent |
 | serviceAccount.name | string | `nil` | Name of the service account, Required if `serviceAccount.create` is false |
@@ -186,7 +186,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorMetrics.metricsInit.image | object | `{ "name": "komodor-agent", "tag": .Chart.AppVersion }` | Override the komodor agent metrics init image name or tag. |
 | components.komodorMetrics.metricsInit.resources | object | `{}` | Set custom resources to the komodor agent metrics init container |
 | components.komodorMetrics.metricsInit.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
-| components.komodorMetrics.metrics.image | object | `{"name":"telegraf","tag":"v1.34.1-build1-alpine"}` | Override the komodor agent metrics image name or tag. |
+| components.komodorMetrics.metrics.image | object | `{"name":"telegraf","tag":"v1.34.1-build2-alpine"}` | Override the komodor agent metrics image name or tag. |
 | components.komodorMetrics.metrics.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
 | components.komodorMetrics.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemon | object | See sub-values | Configure the komodor agent components |
@@ -205,11 +205,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorDaemon.metricsInit.image | object | `{ "name": "init-daemon-agent", "tag": .Chart.AppVersion }` | Override the komodor agent metrics init image name or tag. |
 | components.komodorDaemon.metricsInit.resources | object | `{"limits":{"cpu":1,"memory":"100Mi"},"requests":{"cpu":0.1,"memory":"50Mi"}}` | Set custom resources to the komodor agent metrics init container |
 | components.komodorDaemon.metricsInit.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
-| components.komodorDaemon.metrics | object | `{"extraEnvVars":[],"image":{"name":"telegraf","tag":"v1.34.1-build1-alpine"},"quiet":false,"resources":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}}` | Configure the komodor daemon metrics components |
-| components.komodorDaemon.metrics.image | object | `{"name":"telegraf","tag":"v1.34.1-build1-alpine"}` | Override the komodor agent metrics image name or tag. |
+| components.komodorDaemon.metrics | object | `{"dcgm":false,"extraEnvVars":[],"image":{"name":"telegraf","tag":"v1.34.1-build2-alpine"},"quiet":false,"resources":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}}` | Configure the komodor daemon metrics components |
+| components.komodorDaemon.metrics.image | object | `{"name":"telegraf","tag":"v1.34.1-build2-alpine"}` | Override the komodor agent metrics image name or tag. |
 | components.komodorDaemon.metrics.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
 | components.komodorDaemon.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemon.metrics.quiet | bool | `false` | Set the quiet mode for the komodor agent metrics |
+| components.komodorDaemon.metrics.dcgm | bool | `false` | Enable collecting NVIDIA GPU metrics via DCGM |
 | components.komodorDaemon.nodeEnricher | object | See sub-values | Configure the komodor daemon node enricher components |
 | components.komodorDaemon.nodeEnricher.image | object | `{"name":"komodor-agent","tag":null}` | Override the komodor agent node enricher image name or tag. |
 | components.komodorDaemon.nodeEnricher.resources | object | `{"limits":{"cpu":"10m","memory":"100Mi"},"requests":{"cpu":"1m","memory":"10Mi"}}` | Set custom resources to the komodor agent node enricher container |
@@ -223,8 +224,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorDaemonWindows.tolerations | list | `[{"operator":"Exists"}]` | Add tolerations to the komodor agent daemon |
 | components.komodorDaemonWindows.podAnnotations | object | `{}` | # Add annotations to the komodor agent watcher pod |
 | components.komodorDaemonWindows.updateStrategy | object | `{}` | Set the rolling update strategy for the komodor agent daemon deployment |
-| components.komodorDaemonWindows.metrics | object | `{"extraEnvVars":[],"image":{"name":"telegraf-windows","tag":"v1.34.1-build1-windows"},"quiet":false,"resources":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}}` | Configure the komodor daemon metrics components |
-| components.komodorDaemonWindows.metrics.image | object | `{"name":"telegraf-windows","tag":"v1.34.1-build1-windows"}` | Override the komodor agent metrics image name or tag. |
+| components.komodorDaemonWindows.metrics | object | `{"extraEnvVars":[],"image":{"name":"telegraf-windows","tag":"v1.34.1-build2-windows"},"quiet":false,"resources":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}}` | Configure the komodor daemon metrics components |
+| components.komodorDaemonWindows.metrics.image | object | `{"name":"telegraf-windows","tag":"v1.34.1-build2-windows"}` | Override the komodor agent metrics image name or tag. |
 | components.komodorDaemonWindows.metrics.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
 | components.komodorDaemonWindows.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemonWindows.metrics.quiet | bool | `false` | Set the quiet mode for the komodor agent metrics |

--- a/charts/komodor-agent/templates/metrics/_containers_deamon.tpl
+++ b/charts/komodor-agent/templates/metrics/_containers_deamon.tpl
@@ -12,6 +12,11 @@
   - name: {{ include "metrics.daemon.config.name" . }}
     mountPath: /etc/telegraf/plugin.conf
     subPath: plugin.conf
+  {{- if .Values.components.komodorDaemon.metrics.dcgm }}
+  - name: {{ include "metrics.daemon.config.name" . }}
+    mountPath: /etc/telegraf/dcgm.conf
+    subPath: dcgm.conf
+  {{- end }}
   {{- include "custom-ca.trusted-volumeMounts" . | indent 2 }}
   envFrom:
   - configMapRef:

--- a/charts/komodor-agent/templates/metrics/configmap-daemon.yaml
+++ b/charts/komodor-agent/templates/metrics/configmap-daemon.yaml
@@ -14,7 +14,7 @@ data:
 
     [[outputs.http]]
       url = {{ include "metrics.collector.endpoint" . | quote}}
-      fieldinclude = ["resource_requests_millicpu_units","resource_limits_millicpu_units","resource_requests_memory_bytes","resource_limits_memory_bytes", "capacity_cpu_cores", "capacity_millicpu_cores", "capacity_memory_bytes", "restarts_total", "memory_usage_bytes*", "cpu_usage_nanocores*", "memory_working_set_bytes*", "allocatable_millicpu_cores", "allocatable_memory_bytes"]
+      fieldinclude = ["resource_requests_millicpu_units","resource_limits_millicpu_units","resource_requests_memory_bytes","resource_limits_memory_bytes", "capacity_cpu_cores", "capacity_millicpu_cores", "capacity_memory_bytes", "restarts_total", "memory_usage_bytes*", "cpu_usage_nanocores*", "memory_working_set_bytes*", "allocatable_millicpu_cores", "allocatable_memory_bytes", "DCGM_FI_DEV_GPU_UTIL", "DCGM_FI_DEV_MEM_COPY_UTIL", "DCGM_FI_DEV_MEMORY_TEMP", "DCGM_FI_DEV_GPU_TEMP","DCGM_FI_DEV_FB_USED", "DCGM_FI_DEV_FB_TOTAL"]
       timeout = "${OUTPUT_TIMEOUT}"
       content_encoding = "gzip"
       {{- if .Values.proxy.https }}
@@ -32,6 +32,11 @@ data:
       namedrop = ["kubernetes_system_container"]
       [inputs.execd.tags]
       measure_type = "consolidated"
+
+    {{- if .Values.components.komodorDaemon.metrics.dcgm }}
+    [[inputs.execd]]
+      command = ["nvidia_dcgm", "-poll_interval", "${INTERVAL}", "-config", "/etc/telegraf/dcgm.conf"]
+    {{- end }}
 
     [[aggregators.basicstats]]
       period = "${AGGREGATED_INTERVAL}"
@@ -68,5 +73,12 @@ data:
       inventory_cache_ttl = "${FLUSH_INTERVAL_INVENTORY}"
       owner_cache_ttl = "${FLUSH_INTERVAL_INVENTORY}"
       node_name = "${NODE_NAME}"
+
+  {{- if .Values.components.komodorDaemon.metrics.dcgm }}
+  dcgm.conf: |
+    [[inputs.nvidia_dcgm]]
+      node_name = "${NODE_NAME}"
+  {{- end }}
+
 
 {{- end }}

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -13,9 +13,9 @@ clusterName:
 createRbac: true
 
 # telegrafImageVersion -- (string) Telegraf version to be used
-telegrafImageVersion: &telegrafVersion v1.34.1-build1-alpine
+telegrafImageVersion: &telegrafVersion v1.34.1-build2-alpine
 # telegrafWindowsImageVersion -- (string) Telegraf version to be used for windows
-telegrafWindowsImageVersion: &telegrafWindowsVersion v1.34.1-build1-windows
+telegrafWindowsImageVersion: &telegrafWindowsVersion v1.34.1-build2-windows
 
 # serviceAccount -- Configure service account for the agent
 # @default -- See sub-values
@@ -327,6 +327,8 @@ components:
       extraEnvVars: [ ]
       # components.komodorDaemon.metrics.quiet -- Set the quiet mode for the komodor agent metrics
       quiet: false
+      # components.komodorDaemon.metrics.dcgm -- Enable collecting NVIDIA GPU metrics via DCGM
+      dcgm: false
 
     # components.komodorDaemon.nodeEnricher -- Configure the komodor daemon node enricher components
     # @default -- See sub-values


### PR DESCRIPTION
It add new `components.komodorDaemon.metrics.dcgm=true/false` value that enables collecting metrics from NVIDIA DCGM for GPU project. Disabled by default.
Tested on GPU demo cluster that it installs and functions OK.