### PR TITLE
CU-86c3rx3zc - chore: disable installation in staging and production

### DIFF
--- a/.buildkite/pipeline_scripts/production-values.yaml
+++ b/.buildkite/pipeline_scripts/production-values.yaml
@@ -3,6 +3,8 @@ imagePullSecret: docker-cfg-komodorio
 capabilities:
   event:
     redact: "{.*KEY.*,.*key.*,.*BUGSNAG.*}"
+  events:
+    create: false
   kubectlProxy:
     enabled: true
 

--- a/.buildkite/pipeline_scripts/staging-values.yaml
+++ b/.buildkite/pipeline_scripts/staging-values.yaml
@@ -15,6 +15,8 @@ capabilities:
     serverHost: https://staging.telemetry.komodor.com
   event:
     redact: "{.*KEY.*,.*key.*,.*BUGSNAG.*}"
+  events:
+    create: false
   kubectlProxy:
     enabled: true
 

--- a/charts/komodor-agent/templates/crd/klaudia.yaml
+++ b/charts/komodor-agent/templates/crd/klaudia.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.capabilities.events.create }}
+{{- if and .Values.capabilities.events.create (not (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "klaudia.app.komodor.com")) }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/komodor-agent/templates/crd/klaudia.yaml
+++ b/charts/komodor-agent/templates/crd/klaudia.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.capabilities.events.create }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -55,3 +56,4 @@ spec:
     kind: Klaudia
     shortNames:
       - klaudia
+{{- end }}


### PR DESCRIPTION
This pull request introduces changes to streamline event creation capabilities and conditional resource definition logic across various files. The most important changes include disabling event creation in specific environments and adding conditional logic for the creation of a custom resource definition (`CRD`) in Kubernetes.

### Event Creation Configuration Updates:
* [`.buildkite/pipeline_scripts/production-values.yaml`](diffhunk://#diff-a104f7c8810e77e2b02cd35525fd1dd1dab78eb08859bff47f42cde19ca619b3R6-R7): Added `events.create: false` under `capabilities` to disable event creation in the production environment.
* [`.buildkite/pipeline_scripts/staging-values.yaml`](diffhunk://#diff-9fd4be794439138ee3073095e6e609b1c71006eb27393c12aa310269e36d320dR18-R19): Added `events.create: false` under `capabilities` to disable event creation in the staging environment.

### Conditional Custom Resource Definition Logic:
* [`charts/komodor-agent/templates/crd/klaudia.yaml`](diffhunk://#diff-843779df1680750bb8489af427867e73aaa946ccb10ae944a892bb51111495f1R1): Introduced conditional logic using Helm templates to create the `klaudia.app.komodor.com` CRD only if `capabilities.events.create` is enabled and the CRD does not already exist.
* [`charts/komodor-agent/templates/crd/klaudia.yaml`](diffhunk://#diff-843779df1680750bb8489af427867e73aaa946ccb10ae944a892bb51111495f1R59): Added a closing conditional block to ensure proper handling of the CRD creation logic.