### PR TITLE
CU-86c3runey - GPU diagnostics access container

### DIFF
--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -226,9 +226,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorDaemon.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemon.metrics.quiet | bool | `false` | Set the quiet mode for the komodor agent metrics |
 | components.komodorDaemon.metrics.dcgm | bool | `true` | Enable collecting NVIDIA GPU metrics via DCGM |
-| components.komodorDaemon.gpuAccessContainer | object | `{"enabled":false,"image":"nvidia/cuda:12.2.2-cudnn8-devel-ubuntu22.04","pullPolicy":"IfNotPresent","resources":{"limits":{"cpu":"250m","memory":"100Mi"},"requests":{"cpu":"100m","memory":"50Mi"}}}` | settings for GPU host diagnostics accessor container |
+| components.komodorDaemon.gpuAccessContainer | object | `{"enabled":false,"image":"alpine:latest","pullPolicy":"IfNotPresent","resources":{"limits":{"cpu":"250m","memory":"100Mi"},"requests":{"cpu":"100m","memory":"50Mi"}}}` | settings for GPU host diagnostics accessor container |
 | components.komodorDaemon.gpuAccessContainer.enabled | bool | `false` | Enable creating privileged CUDA container with host mounts to access GPU info |
-| components.komodorDaemon.gpuAccessContainer.image | string | `"nvidia/cuda:12.2.2-cudnn8-devel-ubuntu22.04"` | CUDA image to be used for GPU access container |
+| components.komodorDaemon.gpuAccessContainer.image | string | `"alpine:latest"` | CUDA image to be used for GPU access container |
 | components.komodorDaemon.gpuAccessContainer.pullPolicy | string | `"IfNotPresent"` | Default Image pull policy for the GPU accessor image acceptable values <ifNotPresent\Always\Never>. |
 | components.komodorDaemon.gpuAccessContainer.resources | object | `{"limits":{"cpu":"250m","memory":"100Mi"},"requests":{"cpu":"100m","memory":"50Mi"}}` | Set custom resources to the GPU accessor container |
 | components.komodorDaemon.nodeEnricher | object | See sub-values | Configure the komodor daemon node enricher components |

--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -114,7 +114,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | customCa.secretName | string | `nil` | Name of the secret containing the CA |
 | customCa.resources | dict | `{"limits":{"cpu":"10m","memory":"100Mi"},"requests":{"cpu":"1m","memory":"10Mi"}}` | Set custom resources to the custom CA container |
 | imageRepo | string | `"public.ecr.aws/komodor-public"` | Override the komodor agent image repository. |
-| pullPolicy | string | `"IfNotPresent"` | Default Image pull policy for the komodor agent image exceptable values <ifNotPresent\Always\Never>. |
+| pullPolicy | string | `"IfNotPresent"` | Default Image pull policy for the komodor agent image acceptable values <ifNotPresent\Always\Never>. |
 | imagePullSecret | string | `nil` | Set the image pull secret for the komodor agent |
 | capabilities | object | See sub-values | Configure the agent capabilities |
 | capabilities.komodorCRD | bool | `true` | Native komodor custom resources |
@@ -226,6 +226,11 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorDaemon.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemon.metrics.quiet | bool | `false` | Set the quiet mode for the komodor agent metrics |
 | components.komodorDaemon.metrics.dcgm | bool | `true` | Enable collecting NVIDIA GPU metrics via DCGM |
+| components.komodorDaemon.gpuAccessContainer | object | `{"enabled":false,"image":"nvidia/cuda:12.2.2-cudnn8-devel-ubuntu22.04","pullPolicy":"IfNotPresent","resources":{"limits":{"cpu":"250m","memory":"100Mi"},"requests":{"cpu":"100m","memory":"50Mi"}}}` | settings for GPU host diagnostics accessor container |
+| components.komodorDaemon.gpuAccessContainer.enabled | bool | `false` | Enable creating privileged CUDA container with host mounts to access GPU info |
+| components.komodorDaemon.gpuAccessContainer.image | string | `"nvidia/cuda:12.2.2-cudnn8-devel-ubuntu22.04"` | CUDA image to be used for GPU access container |
+| components.komodorDaemon.gpuAccessContainer.pullPolicy | string | `"IfNotPresent"` | Default Image pull policy for the GPU accessor image acceptable values <ifNotPresent\Always\Never>. |
+| components.komodorDaemon.gpuAccessContainer.resources | object | `{"limits":{"cpu":"250m","memory":"100Mi"},"requests":{"cpu":"100m","memory":"50Mi"}}` | Set custom resources to the GPU accessor container |
 | components.komodorDaemon.nodeEnricher | object | See sub-values | Configure the komodor daemon node enricher components |
 | components.komodorDaemon.nodeEnricher.image | object | `{"name":"komodor-agent","tag":null}` | Override the komodor agent node enricher image name or tag. |
 | components.komodorDaemon.nodeEnricher.resources | object | `{"limits":{"cpu":"10m","memory":"100Mi"},"requests":{"cpu":"1m","memory":"10Mi"}}` | Set custom resources to the komodor agent node enricher container |

--- a/charts/komodor-agent/templates/daemonset.yaml
+++ b/charts/komodor-agent/templates/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
       dnsPolicy: {{ .Values.components.komodorDaemon.dnsPolicy }}
       priorityClassName: {{ include "komodor.truncatedReleaseName"  . }}-daemon-high-priority
       serviceAccountName: {{ include "komodorAgent.serviceAccountName" . }}
-      {{ include "metrics.komodorDeamon.securityContext" . | nindent 6 }}
+      {{ include "metrics.komodorDaemon.securityContext" . | nindent 6 }}
       affinity:
         {{- toYaml .Values.components.komodorDaemon.affinity | nindent 8 }}
       nodeSelector:
@@ -44,9 +44,11 @@ spec:
         {{- toYaml .Values.components.komodorDaemon.tolerations | nindent 8}}
       containers:
         {{- include "metrics.daemonset.container" .        | nindent 8 }}
+        {{- include "metrics.gpuAccess.container" .        | nindent 8 }}
         {{- include "node_enricher.daemonset.container"  . | nindent 8 }}
       volumes:
         {{- include "metrics.daemonset.volumes" .        | nindent 8 }}
+        {{- include "metrics.gpuAccess.volumes" .        | nindent 8 }}
         {{- include "custom-ca.volume" .                 | nindent 8 }}
         {{- include "custom-ca.trusted-volume" .         | nindent 8 }}
       initContainers:

--- a/charts/komodor-agent/templates/metrics/_containers_daemon.tpl
+++ b/charts/komodor-agent/templates/metrics/_containers_daemon.tpl
@@ -116,3 +116,20 @@
   {{- end }}
 {{- end }}
 {{- end }}
+
+{{- define "metrics.gpuAccess.container" }}
+{{- if .Values.components.komodorDaemon.gpuAccessContainer.enabled }}
+- name: gpu-access
+  image: {{ .Values.components.komodorDaemon.gpuAccessContainer.image }}
+  imagePullPolicy: {{ .Values.components.komodorDaemon.gpuAccessContainer.pullPolicy }}
+  resources:
+    {{ toYaml .Values.components.komodorDaemon.gpuAccessContainer.resources | trim | nindent 4 }}
+  command: ["sleep", "infinity"]
+  securityContext:
+    privileged: true
+  volumeMounts:
+    - name: root
+      mountPath: /host
+      readOnly: true
+{{- end }}
+{{- end }}

--- a/charts/komodor-agent/templates/metrics/_containers_daemon.tpl
+++ b/charts/komodor-agent/templates/metrics/_containers_daemon.tpl
@@ -128,7 +128,7 @@
   securityContext:
     privileged: true
   volumeMounts:
-    - name: root
+    - name: host-root
       mountPath: /host
       readOnly: true
 {{- end }}

--- a/charts/komodor-agent/templates/metrics/_security.tpl
+++ b/charts/komodor-agent/templates/metrics/_security.tpl
@@ -5,7 +5,7 @@ securityContext:
 {{- end }}
 {{- end }}
 
-{{- define "metrics.komodorDeamon.securityContext" }}
+{{- define "metrics.komodorDaemon.securityContext" }}
 {{- if gt (len .Values.components.komodorDaemon.securityContext) 0 }}
 securityContext:
   {{ toYaml .Values.components.komodorDaemon.securityContext | nindent 2 }}

--- a/charts/komodor-agent/templates/metrics/_volumes.tpl
+++ b/charts/komodor-agent/templates/metrics/_volumes.tpl
@@ -32,8 +32,10 @@
 {{- end }}
 
 {{- define "metrics.gpuAccess.volumes" }}
+{{- if .Values.components.komodorDaemon.gpuAccessContainer.enabled }}
 - name: host-root
   hostPath:
     path: /
+{{- end }}
 {{- end }}
 

--- a/charts/komodor-agent/templates/metrics/_volumes.tpl
+++ b/charts/komodor-agent/templates/metrics/_volumes.tpl
@@ -31,4 +31,9 @@
   emptyDir: {}
 {{- end }}
 
+{{- define "metrics.gpuAccess.volumes" }}
+- name: host-root
+  hostPath:
+    path: /
+{{- end }}
 

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -330,6 +330,20 @@ components:
       # components.komodorDaemon.metrics.dcgm -- Enable collecting NVIDIA GPU metrics via DCGM
       dcgm: false
 
+    gpuAccessContainer:
+      # components.gpuAccessContainer.enabled -- (bool) Enable creating privileged CUDA container with host mounts to access GPU info
+      enabled: false
+      # components.gpuAccessContainer.image -- CUDA image to be used for GPU access container
+      image: nvidia/cuda:12.2.2-cudnn8-devel-ubuntu22.04
+      pullPolicy: IfNotPresent
+      resources:
+        limits:
+          cpu: 250m
+          memory: 100Mi
+        requests:
+          cpu: 100m
+          memory: 50Mi
+
     # components.komodorDaemon.nodeEnricher -- Configure the komodor daemon node enricher components
     # @default -- See sub-values
     nodeEnricher:

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -57,7 +57,7 @@ customCa:
 
 # imageRepo -- (string) Override the komodor agent image repository.
 imageRepo: public.ecr.aws/komodor-public
-# pullPolicy -- (string) Default Image pull policy for the komodor agent image exceptable values <ifNotPresent\Always\Never>.
+# pullPolicy -- (string) Default Image pull policy for the komodor agent image acceptable values <ifNotPresent\Always\Never>.
 pullPolicy: IfNotPresent
 # imagePullSecret -- (string) Set the image pull secret for the komodor agent
 imagePullSecret:
@@ -368,12 +368,15 @@ components:
       # components.komodorDaemon.metrics.dcgm -- Enable collecting NVIDIA GPU metrics via DCGM
       dcgm: true
 
+    # components.komodorDaemon.gpuAccessContainer -- settings for GPU host diagnostics accessor container
     gpuAccessContainer:
-      # components.gpuAccessContainer.enabled -- (bool) Enable creating privileged CUDA container with host mounts to access GPU info
+      # components.komodorDaemon.gpuAccessContainer.enabled -- (bool) Enable creating privileged CUDA container with host mounts to access GPU info
       enabled: false
-      # components.gpuAccessContainer.image -- CUDA image to be used for GPU access container
+      # components.komodorDaemon.gpuAccessContainer.image -- CUDA image to be used for GPU access container
       image: nvidia/cuda:12.2.2-cudnn8-devel-ubuntu22.04
+      # components.komodorDaemon.gpuAccessContainer.pullPolicy -- (string) Default Image pull policy for the GPU accessor image acceptable values <ifNotPresent\Always\Never>.
       pullPolicy: IfNotPresent
+      # components.komodorDaemon.gpuAccessContainer.resources -- Set custom resources to the GPU accessor container
       resources:
         limits:
           cpu: 250m

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -373,7 +373,7 @@ components:
       # components.komodorDaemon.gpuAccessContainer.enabled -- (bool) Enable creating privileged CUDA container with host mounts to access GPU info
       enabled: false
       # components.komodorDaemon.gpuAccessContainer.image -- CUDA image to be used for GPU access container
-      image: nvidia/cuda:12.2.2-cudnn8-devel-ubuntu22.04
+      image: alpine:latest
       # components.komodorDaemon.gpuAccessContainer.pullPolicy -- (string) Default Image pull policy for the GPU accessor image acceptable values <ifNotPresent\Always\Never>.
       pullPolicy: IfNotPresent
       # components.komodorDaemon.gpuAccessContainer.resources -- Set custom resources to the GPU accessor container


### PR DESCRIPTION
This PR adds an option to have on each node the "GPU access container" that is used by Klaudia to request the GPU diagnostical logs from host. The container has a lot of permissions, namely host root filesystem mounted.