### PR TITLE
CU-86c3zc0kd - Add command for metrics container in daemonset template

### DIFF
--- a/charts/komodor-agent/templates/metrics/_containers_daemon.tpl
+++ b/charts/komodor-agent/templates/metrics/_containers_daemon.tpl
@@ -1,6 +1,7 @@
 {{- define "metrics.daemonset.container" }}
 {{- if .Values.capabilities.metrics }}
 - name: metrics
+  command: ["telegraf"]
   image: {{ .Values.imageRepo }}/{{ .Values.components.komodorDaemon.metrics.image.name}}:{{ .Values.components.komodorDaemon.metrics.image.tag }}
   imagePullPolicy: {{ .Values.pullPolicy }}
   resources:


### PR DESCRIPTION
This change solves an issue that happens to bam & fispan 
We dont know the root cause yet 
But this simple change solves their issue and we want to include it in our next Komodor version 