### PR TITLE
CU-86c3zmt87 - Set test mitmproxy image to use our public ecr to prevent rate limiting with dockerhub

### DIFF
--- a/.buildkite/tests/test-data/mitm-proxy.yaml
+++ b/.buildkite/tests/test-data/mitm-proxy.yaml
@@ -26,7 +26,7 @@ metadata:
 spec:
   containers:
   - name: mitmweb
-    image: mitmproxy/mitmproxy
+    image: public.ecr.aws/komodor-public/mitmproxy/mitmproxy:12
     command: ["mitmweb"]
     args: ["-s", "/scripts/log_urls.py", "--web-host", "0.0.0.0", "--set", "block_global=false"]
     volumeMounts:


### PR DESCRIPTION
Used `regctl image copy mitmproxy/mitmproxy:12 public.ecr.aws/komodor-public/mitmproxy/mitmproxy:12`