### PR TITLE
CU-86c40bu76 - Separate gpu accessor daemonset

### DIFF
--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -284,11 +284,14 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorDaemonWindows.metrics.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
 | components.komodorDaemonWindows.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemonWindows.metrics.quiet | bool | `false` | Set the quiet mode for the komodor agent metrics |
-| components.gpuAccess | object | `{"enabled":false,"image":"alpine:latest","pullPolicy":"IfNotPresent","resources":{"limits":{"cpu":"250m","memory":"100Mi"},"requests":{"cpu":"100m","memory":"50Mi"}}}` | settings for GPU host diagnostics accessor container |
+| components.gpuAccess | object | `{"enabled":false,"image":"alpine:latest","labels":{},"nodeSelector":{},"pullPolicy":"IfNotPresent","resources":{"limits":{"cpu":"250m","memory":"100Mi"},"requests":{"cpu":"100m","memory":"50Mi"}},"tolerations":[{"effect":"NoSchedule","key":"nvidia.com/gpu","operator":"Exists"}]}` | settings for GPU host diagnostics accessor DaemonSet |
 | components.gpuAccess.enabled | bool | `false` | Enable creating privileged CUDA container with host mounts to access GPU info |
 | components.gpuAccess.image | string | `"alpine:latest"` | CUDA image to be used for GPU access container |
 | components.gpuAccess.pullPolicy | string | `"IfNotPresent"` | Default Image pull policy for the GPU accessor image acceptable values <ifNotPresent\Always\Never>. |
 | components.gpuAccess.resources | object | `{"limits":{"cpu":"250m","memory":"100Mi"},"requests":{"cpu":"100m","memory":"50Mi"}}` | Set custom resources to the GPU accessor container |
+| components.gpuAccess.labels | object | `{}` | Adds custom labels |
+| components.gpuAccess.nodeSelector | object | `{}` | Set node selectors for the komodor agent daemon |
+| components.gpuAccess.tolerations | list | `[{"effect":"NoSchedule","key":"nvidia.com/gpu","operator":"Exists"}]` | Add tolerations to the komodor agent daemon |
 | allowedResources.event | bool | `true` | Enables watching `event` |
 | allowedResources.deployment | bool | `true` | Enables watching `deployments` |
 | allowedResources.replicationController | bool | `true` | Enables watching `replicationControllers` |

--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -262,11 +262,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorDaemon.metrics.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
 | components.komodorDaemon.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemon.metrics.quiet | bool | `false` | Set the quiet mode for the komodor agent metrics |
-| components.komodorDaemon.gpuAccessContainer | object | `{"enabled":false,"image":"alpine:latest","pullPolicy":"IfNotPresent","resources":{"limits":{"cpu":"250m","memory":"100Mi"},"requests":{"cpu":"100m","memory":"50Mi"}}}` | settings for GPU host diagnostics accessor container |
-| components.komodorDaemon.gpuAccessContainer.enabled | bool | `false` | Enable creating privileged CUDA container with host mounts to access GPU info |
-| components.komodorDaemon.gpuAccessContainer.image | string | `"alpine:latest"` | CUDA image to be used for GPU access container |
-| components.komodorDaemon.gpuAccessContainer.pullPolicy | string | `"IfNotPresent"` | Default Image pull policy for the GPU accessor image acceptable values <ifNotPresent\Always\Never>. |
-| components.komodorDaemon.gpuAccessContainer.resources | object | `{"limits":{"cpu":"250m","memory":"100Mi"},"requests":{"cpu":"100m","memory":"50Mi"}}` | Set custom resources to the GPU accessor container |
 | components.komodorDaemon.nodeEnricher | object | See sub-values | Configure the komodor daemon node enricher components |
 | components.komodorDaemon.nodeEnricher.image | object | `{"name":"komodor-agent","tag":null}` | Override the komodor agent node enricher image name or tag. |
 | components.komodorDaemon.nodeEnricher.resources | object | `{"limits":{"cpu":"10m","memory":"100Mi"},"requests":{"cpu":"1m","memory":"10Mi"}}` | Set custom resources to the komodor agent node enricher container |
@@ -289,6 +284,11 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorDaemonWindows.metrics.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
 | components.komodorDaemonWindows.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemonWindows.metrics.quiet | bool | `false` | Set the quiet mode for the komodor agent metrics |
+| components.gpuAccess | object | `{"enabled":false,"image":"alpine:latest","pullPolicy":"IfNotPresent","resources":{"limits":{"cpu":"250m","memory":"100Mi"},"requests":{"cpu":"100m","memory":"50Mi"}}}` | settings for GPU host diagnostics accessor container |
+| components.gpuAccess.enabled | bool | `false` | Enable creating privileged CUDA container with host mounts to access GPU info |
+| components.gpuAccess.image | string | `"alpine:latest"` | CUDA image to be used for GPU access container |
+| components.gpuAccess.pullPolicy | string | `"IfNotPresent"` | Default Image pull policy for the GPU accessor image acceptable values <ifNotPresent\Always\Never>. |
+| components.gpuAccess.resources | object | `{"limits":{"cpu":"250m","memory":"100Mi"},"requests":{"cpu":"100m","memory":"50Mi"}}` | Set custom resources to the GPU accessor container |
 | allowedResources.event | bool | `true` | Enables watching `event` |
 | allowedResources.deployment | bool | `true` | Enables watching `deployments` |
 | allowedResources.replicationController | bool | `true` | Enables watching `replicationControllers` |

--- a/charts/komodor-agent/templates/_helpers.tpl
+++ b/charts/komodor-agent/templates/_helpers.tpl
@@ -77,6 +77,11 @@ app.kubernetes.io/name: {{ include "komodorAgent.name" . }}-daemon-windows
 app.kubernetes.io/instance: {{ include "komodor.truncatedReleaseName"  . }}-daemon-windows
 {{- end }}
 
+{{- define "gpuAccess.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "komodorAgent.name" . }}-gpu-access
+app.kubernetes.io/instance: {{ include "komodor.truncatedReleaseName"  . }}-gpu-access
+{{- end }}
+
 {{- define "KomodorDaemon.user.labels" -}}
 {{- if not (empty (((.Values.components).komodorDaemon).labels)) }}
 {{ toYaml .Values.components.komodorDaemon.labels }}

--- a/charts/komodor-agent/templates/_helpers.tpl
+++ b/charts/komodor-agent/templates/_helpers.tpl
@@ -77,16 +77,27 @@ app.kubernetes.io/name: {{ include "komodorAgent.name" . }}-daemon-windows
 app.kubernetes.io/instance: {{ include "komodor.truncatedReleaseName"  . }}-daemon-windows
 {{- end }}
 
-{{- define "gpuAccess.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "komodorAgent.name" . }}-gpu-access
-app.kubernetes.io/instance: {{ include "komodor.truncatedReleaseName"  . }}-gpu-access
-{{- end }}
-
 {{- define "KomodorDaemon.user.labels" -}}
 {{- if not (empty (((.Values.components).komodorDaemon).labels)) }}
 {{ toYaml .Values.components.komodorDaemon.labels }}
 {{- end }}
 {{- end}}
+
+{{- define "gpuAccess.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "komodorAgent.name" . }}-gpu-access
+app.kubernetes.io/instance: {{ include "komodor.truncatedReleaseName"  . }}-gpu-access
+{{- end }}
+
+{{- define "gpuAccess.user.labels" -}}
+{{- if not (empty (((.Values.components).gpuAccess).labels)) }}
+{{ toYaml .Values.components.gpuAccess.labels }}
+{{- end }}
+{{- end}}
+
+{{- define "gpuAccess.labels" -}}
+{{ include "gpuAccess.selectorLabels" . }}
+{{ include "komodorAgent.commonLabels" . }}
+{{- end }}
 
 {{- define "komodorAgent.user.labels" -}}
 {{- if not (empty (((.Values.components).komodorAgent).labels)) }}

--- a/charts/komodor-agent/templates/crd/klaudia.yaml
+++ b/charts/komodor-agent/templates/crd/klaudia.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.capabilities.events.create (not (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "klaudia.app.komodor.com")) }}
+{{- if .Values.capabilities.events.create }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/komodor-agent/templates/daemonset.yaml
+++ b/charts/komodor-agent/templates/daemonset.yaml
@@ -44,11 +44,9 @@ spec:
         {{- toYaml .Values.components.komodorDaemon.tolerations | nindent 8}}
       containers:
         {{- include "metrics.daemonset.container" .        | nindent 8 }}
-        {{- include "metrics.gpuAccess.container" .        | nindent 8 }}
         {{- include "node_enricher.daemonset.container"  . | nindent 8 }}
       volumes:
         {{- include "metrics.shared.volume" .             | nindent 8 }}
-        {{- include "metrics.gpuAccess.volumes" .        | nindent 8 }}
         {{- include "custom-ca.volume" .                 | nindent 8 }}
         {{- include "custom-ca.trusted-volume" .         | nindent 8 }}
       initContainers:

--- a/charts/komodor-agent/templates/daemonset_gpu.yaml
+++ b/charts/komodor-agent/templates/daemonset_gpu.yaml
@@ -29,13 +29,15 @@ spec:
       tolerations:
         {{- toYaml .Values.components.gpuAccess.tolerations | nindent 8}}
       volumes:
-        {{- include "gpuAccess.volumes" . | nindent 8 }}
+        - name: host-root
+          hostPath:
+            path: /
       containers:
         - name: gpu-access
           image: {{ .Values.components.gpuAccess.image }}
           imagePullPolicy: {{ .Values.components.gpuAccess.pullPolicy }}
           resources:
-        {{ toYaml .Values.components.gpuAccess.resources | trim | nindent 4 }}
+          {{ toYaml .Values.components.gpuAccess.resources | trim | nindent 12 }}
           command: ["sleep", "infinity"]
           securityContext:
             privileged: {{ .Values.components.gpuAccess.enabled }}

--- a/charts/komodor-agent/templates/daemonset_gpu.yaml
+++ b/charts/komodor-agent/templates/daemonset_gpu.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.components.gpuAccess.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "komodorAgent.fullname" . }}-gpu-host-access
+  labels:
+    {{- include "gpuAccess.labels" . | nindent 4 }}
+    {{- include "gpuAccess.user.labels" . | nindent 4 }}
+
+  {{- if not (empty ((.Values.components).gpuAccess).annotations) }}
+  annotations: {{ toYaml ((.Values.components).gpuAccess).annotations | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels: {{- include "gpuAccess.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        app.komodor.com/purpose: gpu-access
+        {{- include "gpuAccess.selectorLabels" . | nindent 8 }}
+        {{- include "gpuAccess.user.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "komodorAgent.serviceAccountName" . }}
+      nodeSelector:
+        kubernetes.io/os: linux
+        {{- if not (empty (((.Values.components).gpuAccess).nodeSelector)) }}
+        {{- toYaml .Values.components.gpuAccess.nodeSelector | nindent 8 }}
+        {{- end }}
+      tolerations:
+        {{- toYaml .Values.components.gpuAccess.tolerations | nindent 8}}
+      volumes:
+        {{- include "gpuAccess.volumes" . | nindent 8 }}
+      containers:
+        - name: gpu-access
+          image: {{ .Values.components.gpuAccess.image }}
+          imagePullPolicy: {{ .Values.components.gpuAccess.pullPolicy }}
+          resources:
+        {{ toYaml .Values.components.gpuAccess.resources | trim | nindent 4 }}
+          command: ["sleep", "infinity"]
+          securityContext:
+            privileged: {{ .Values.components.gpuAccess.enabled }}
+          volumeMounts:
+            - name: host-root
+              mountPath: /host
+              readOnly: true
+{{- end }}

--- a/charts/komodor-agent/templates/metrics/_containers_daemon.tpl
+++ b/charts/komodor-agent/templates/metrics/_containers_daemon.tpl
@@ -105,24 +105,6 @@
 {{- end }}
 {{- end }}
 
-{{- define "metrics.gpuAccess.container" }}
-{{- if .Values.components.komodorDaemon.gpuAccessContainer.enabled }}
-- name: gpu-access
-  image: {{ .Values.components.komodorDaemon.gpuAccessContainer.image }}
-  imagePullPolicy: {{ .Values.components.komodorDaemon.gpuAccessContainer.pullPolicy }}
-  resources:
-    {{ toYaml .Values.components.komodorDaemon.gpuAccessContainer.resources | trim | nindent 4 }}
-  command: ["sleep", "infinity"]
-  securityContext:
-    privileged: true
-  volumeMounts:
-    - name: host-root
-      mountPath: /host
-      readOnly: true
-{{- end }}
-{{- end }}
-
-
 {{- define "metrics.daemonset.init.windows.container" }}
 {{- if .Values.capabilities.metrics }}
 - name: init-daemon

--- a/charts/komodor-agent/templates/metrics/_volumes.tpl
+++ b/charts/komodor-agent/templates/metrics/_volumes.tpl
@@ -14,11 +14,3 @@
   emptyDir: {}
 {{- end }}
 
-{{- define "gpuAccess.volumes" }}
-{{- if .Values.components.gpuAccess.enabled }}
-- name: host-root
-  hostPath:
-    path: /
-{{- end }}
-{{- end }}
-

--- a/charts/komodor-agent/templates/metrics/_volumes.tpl
+++ b/charts/komodor-agent/templates/metrics/_volumes.tpl
@@ -14,8 +14,8 @@
   emptyDir: {}
 {{- end }}
 
-{{- define "metrics.gpuAccess.volumes" }}
-{{- if .Values.components.komodorDaemon.gpuAccessContainer.enabled }}
+{{- define "gpuAccess.volumes" }}
+{{- if .Values.components.gpuAccess.enabled }}
 - name: host-root
   hostPath:
     path: /

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -571,8 +571,7 @@ components:
     # components.gpuAccess.labels -- Adds custom labels
     labels: {}
     # components.gpuAccess.nodeSelector -- Set node selectors for the komodor agent daemon
-    nodeSelector:
-      nvidia.com/gpu: "present"
+    nodeSelector: {}
     # components.gpuAccess.tolerations -- Add tolerations to the komodor agent daemon
     tolerations:
     - key: "nvidia.com/gpu"

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -475,23 +475,6 @@ components:
       # components.komodorDaemon.metrics.quiet -- Set the quiet mode for the komodor agent metrics
       quiet: false
 
-    # components.komodorDaemon.gpuAccessContainer -- settings for GPU host diagnostics accessor container
-    gpuAccessContainer:
-      # components.komodorDaemon.gpuAccessContainer.enabled -- (bool) Enable creating privileged CUDA container with host mounts to access GPU info
-      enabled: false
-      # components.komodorDaemon.gpuAccessContainer.image -- CUDA image to be used for GPU access container
-      image: alpine:latest
-      # components.komodorDaemon.gpuAccessContainer.pullPolicy -- (string) Default Image pull policy for the GPU accessor image acceptable values <ifNotPresent\Always\Never>.
-      pullPolicy: IfNotPresent
-      # components.komodorDaemon.gpuAccessContainer.resources -- Set custom resources to the GPU accessor container
-      resources:
-        limits:
-          cpu: 250m
-          memory: 100Mi
-        requests:
-          cpu: 100m
-          memory: 50Mi
-
     # components.komodorDaemon.nodeEnricher -- Configure the komodor daemon node enricher components
     # @default -- See sub-values
     nodeEnricher:
@@ -568,6 +551,24 @@ components:
       extraEnvVars: []
       # components.komodorDaemonWindows.metrics.quiet -- Set the quiet mode for the komodor agent metrics
       quiet: false
+
+  # components.gpuAccess -- settings for GPU host diagnostics accessor DaemonSet
+  gpuAccess:
+    # components.gpuAccess.enabled -- (bool) Enable creating privileged CUDA container with host mounts to access GPU info
+    enabled: false
+    # components.gpuAccess.image -- CUDA image to be used for GPU access container
+    image: alpine:latest
+    # components.gpuAccess.pullPolicy -- (string) Default Image pull policy for the GPU accessor image acceptable values <ifNotPresent\Always\Never>.
+    pullPolicy: IfNotPresent
+    # components.gpuAccess.resources -- Set custom resources to the GPU accessor container
+    resources:
+      limits:
+        cpu: 250m
+        memory: 100Mi
+      requests:
+        cpu: 100m
+        memory: 50Mi
+
 
 allowedResources:
   # allowedResources.event -- Enables watching `event`

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -568,7 +568,16 @@ components:
       requests:
         cpu: 100m
         memory: 50Mi
-
+    # components.gpuAccess.labels -- Adds custom labels
+    labels: {}
+    # components.gpuAccess.nodeSelector -- Set node selectors for the komodor agent daemon
+    nodeSelector:
+      nvidia.com/gpu: "present"
+    # components.gpuAccess.tolerations -- Add tolerations to the komodor agent daemon
+    tolerations:
+    - key: "nvidia.com/gpu"
+      operator: "Exists"
+      effect: "NoSchedule"
 
 allowedResources:
   # allowedResources.event -- Enables watching `event`


### PR DESCRIPTION
Following up @nirbenator's comment on Slack:

we have a couple of refinements before we GA this
1. Separate the GPU container to a different daemonset to allow it to be set with a specific toleration for the following taint (we validated gke and eks but im not sure )
```
  taints:
    - effect: NoSchedule
      key: nvidia.com/gpu
      value: "true"
```
2. By default, don’t set the container as privileged and have it controlled by the components.komodorDaemon.gpuAccessContainer.enabled value (even though it is not installed by default - some helm chart scanners don’t like seeing security contexts with priviledge)

Can we please add this to the backlog and push this sometime before the end of the month ?