### PR TITLE
chore(CI): Allow komodorDaemon to schedule on redis nodes

### DIFF
--- a/.buildkite/pipeline_scripts/production-values.yaml
+++ b/.buildkite/pipeline_scripts/production-values.yaml
@@ -30,6 +30,10 @@ components:
         operator: "Equal"
         value: "true"
         effect: "NoSchedule"
+      - key: dedicated
+        operator: "Equal"
+        value: "ws-redis"
+        effect: "NoSchedule"
   komodorMetrics:
     tolerations:
       - key: "komodor.io/sensitive"


### PR DESCRIPTION
* Add `dedicated` toleration for `ws-redis` in production-values.yaml