### PR TITLE
Add sidecar config container to metrics daemon and deployment

### DIFF
--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -241,6 +241,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorMetrics.metrics.image | object | `{"name":"telegraf","tag":"v2.0.1-alpine"}` | Override the komodor agent metrics image name or tag. |
 | components.komodorMetrics.metrics.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
 | components.komodorMetrics.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
+| components.komodorMetrics.metrics.sidecar | object | `{"enabled":true}` | Configure the telegraf-init sidecar container |
+| components.komodorMetrics.metrics.sidecar.enabled | bool | `true` | Enable the telegraf-init sidecar container |
 | components.komodorDaemon | object | See sub-values | Configure the komodor agent components |
 | components.komodorDaemon.hostNetwork | bool | `false` | Set host network for the komodor agent daemon |
 | components.komodorDaemon.dnsPolicy | string | `"ClusterFirst"` | Set dns policy for the komodor agent daemon |
@@ -257,11 +259,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorDaemon.metricsInit.image | object | `{ "name": "init-daemon-agent", "tag": .Chart.AppVersion }` | Override the komodor agent metrics init image name or tag. |
 | components.komodorDaemon.metricsInit.resources | object | `{"limits":{"cpu":1,"memory":"100Mi"},"requests":{"cpu":0.1,"memory":"50Mi"}}` | Set custom resources to the komodor agent metrics init container |
 | components.komodorDaemon.metricsInit.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
-| components.komodorDaemon.metrics | object | `{"extraEnvVars":[],"image":{"name":"telegraf","tag":"v2.0.1-alpine"},"quiet":false,"resources":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}}` | Configure the komodor daemon metrics components |
+| components.komodorDaemon.metrics | object | `{"extraEnvVars":[],"image":{"name":"telegraf","tag":"v2.0.1-alpine"},"quiet":false,"resources":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}},"sidecar":{"enabled":true}}` | Configure the komodor daemon metrics components |
 | components.komodorDaemon.metrics.image | object | `{"name":"telegraf","tag":"v2.0.1-alpine"}` | Override the komodor agent metrics image name or tag. |
 | components.komodorDaemon.metrics.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
 | components.komodorDaemon.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemon.metrics.quiet | bool | `false` | Set the quiet mode for the komodor agent metrics |
+| components.komodorDaemon.metrics.sidecar | object | `{"enabled":true}` | Configure the telegraf-init sidecar container |
+| components.komodorDaemon.metrics.sidecar.enabled | bool | `true` | Enable the telegraf-init sidecar container |
 | components.komodorDaemon.nodeEnricher | object | See sub-values | Configure the komodor daemon node enricher components |
 | components.komodorDaemon.nodeEnricher.image | object | `{"name":"komodor-agent","tag":null}` | Override the komodor agent node enricher image name or tag. |
 | components.komodorDaemon.nodeEnricher.resources | object | `{"limits":{"cpu":"10m","memory":"100Mi"},"requests":{"cpu":"1m","memory":"10Mi"}}` | Set custom resources to the komodor agent node enricher container |
@@ -279,11 +283,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorDaemonWindows.metricsInit.image | object | `{ "name": "init-daemon-agent", "tag": .Chart.AppVersion }` | Override the komodor agent metrics init image name or tag. |
 | components.komodorDaemonWindows.metricsInit.resources | object | `{"limits":{"cpu":1,"memory":"100Mi"},"requests":{"cpu":0.1,"memory":"50Mi"}}` | Set custom resources to the komodor agent metrics init container |
 | components.komodorDaemonWindows.metricsInit.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
-| components.komodorDaemonWindows.metrics | object | `{"extraEnvVars":[],"image":{"name":"telegraf-windows","tag":"v2.0.1-windows"},"quiet":false,"resources":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}}` | Configure the komodor daemon metrics components |
+| components.komodorDaemonWindows.metrics | object | `{"extraEnvVars":[],"image":{"name":"telegraf-windows","tag":"v2.0.1-windows"},"quiet":false,"resources":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}},"sidecar":{"enabled":true}}` | Configure the komodor daemon metrics components |
 | components.komodorDaemonWindows.metrics.image | object | `{"name":"telegraf-windows","tag":"v2.0.1-windows"}` | Override the komodor agent metrics image name or tag. |
 | components.komodorDaemonWindows.metrics.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
 | components.komodorDaemonWindows.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemonWindows.metrics.quiet | bool | `false` | Set the quiet mode for the komodor agent metrics |
+| components.komodorDaemonWindows.metrics.sidecar | object | `{"enabled":true}` | Configure the telegraf-init sidecar container |
+| components.komodorDaemonWindows.metrics.sidecar.enabled | bool | `true` | Enable the telegraf-init sidecar container |
 | components.gpuAccess | object | `{"enabled":false,"image":"alpine:latest","labels":{},"nodeSelector":{},"pullPolicy":"IfNotPresent","resources":{"limits":{"cpu":"250m","memory":"100Mi"},"requests":{"cpu":"100m","memory":"50Mi"}},"tolerations":[{"effect":"NoSchedule","key":"nvidia.com/gpu","operator":"Exists"}]}` | settings for GPU host diagnostics accessor DaemonSet |
 | components.gpuAccess.enabled | bool | `false` | Enable creating privileged CUDA container with host mounts to access GPU info |
 | components.gpuAccess.image | string | `"alpine:latest"` | CUDA image to be used for GPU access container |

--- a/charts/komodor-agent/templates/daemonset.yaml
+++ b/charts/komodor-agent/templates/daemonset.yaml
@@ -44,9 +44,7 @@ spec:
         {{- toYaml .Values.components.komodorDaemon.tolerations | nindent 8}}
       containers:
         {{- include "metrics.daemonset.container" .        | nindent 8 }}
-        {{- if .Values.components.komodorDaemon.metrics.sidecar.enabled }}
         {{- include "metrics.daemonset.sidecar.container" . | nindent 8 }}
-        {{- end }}
         {{- include "node_enricher.daemonset.container"  . | nindent 8 }}
       volumes:
         {{- include "metrics.shared.volume" .             | nindent 8 }}

--- a/charts/komodor-agent/templates/daemonset.yaml
+++ b/charts/komodor-agent/templates/daemonset.yaml
@@ -44,6 +44,9 @@ spec:
         {{- toYaml .Values.components.komodorDaemon.tolerations | nindent 8}}
       containers:
         {{- include "metrics.daemonset.container" .        | nindent 8 }}
+        {{- if .Values.components.komodorDaemon.metrics.sidecar.enabled }}
+        {{- include "metrics.daemonset.sidecar.container" . | nindent 8 }}
+        {{- end }}
         {{- include "node_enricher.daemonset.container"  . | nindent 8 }}
       volumes:
         {{- include "metrics.shared.volume" .             | nindent 8 }}

--- a/charts/komodor-agent/templates/daemonset_windows.yaml
+++ b/charts/komodor-agent/templates/daemonset_windows.yaml
@@ -42,6 +42,9 @@ spec:
         {{- toYaml .Values.components.komodorDaemonWindows.tolerations | nindent 8}}
       containers:
         {{- include "metrics.daemonsetWindows.container" .        | nindent 8 }}
+        {{- if .Values.components.komodorDaemonWindows.metrics.sidecar.enabled }}
+        {{- include "metrics.daemonset.sidecar.windows.container" . | nindent 8 }}
+        {{- end }}
       volumes:
         {{- include "metrics.shared.volume" .             | nindent 8 }}
         {{- include "custom-ca.volume" .                 | nindent 8 }}

--- a/charts/komodor-agent/templates/daemonset_windows.yaml
+++ b/charts/komodor-agent/templates/daemonset_windows.yaml
@@ -42,9 +42,7 @@ spec:
         {{- toYaml .Values.components.komodorDaemonWindows.tolerations | nindent 8}}
       containers:
         {{- include "metrics.daemonsetWindows.container" .        | nindent 8 }}
-        {{- if .Values.components.komodorDaemonWindows.metrics.sidecar.enabled }}
         {{- include "metrics.daemonset.sidecar.windows.container" . | nindent 8 }}
-        {{- end }}
       volumes:
         {{- include "metrics.shared.volume" .             | nindent 8 }}
         {{- include "custom-ca.volume" .                 | nindent 8 }}

--- a/charts/komodor-agent/templates/deployment_metrics.yaml
+++ b/charts/komodor-agent/templates/deployment_metrics.yaml
@@ -40,9 +40,7 @@ spec:
         {{- toYaml .Values.components.komodorMetrics.tolerations | nindent 8}}
       containers:
         {{- include "metrics.deployment.container" .      | nindent 8 }}
-        {{- if .Values.components.komodorMetrics.metrics.sidecar.enabled }}
         {{- include "metrics.deployment.sidecar.container" . | nindent 8 }}
-        {{- end }}
       volumes:
         {{- include "metrics.shared.volume" .             | nindent 8 }}
         {{- include "custom-ca.volume" .                  | nindent 8 }}

--- a/charts/komodor-agent/templates/deployment_metrics.yaml
+++ b/charts/komodor-agent/templates/deployment_metrics.yaml
@@ -40,6 +40,9 @@ spec:
         {{- toYaml .Values.components.komodorMetrics.tolerations | nindent 8}}
       containers:
         {{- include "metrics.deployment.container" .      | nindent 8 }}
+        {{- if .Values.components.komodorMetrics.metrics.sidecar.enabled }}
+        {{- include "metrics.deployment.sidecar.container" . | nindent 8 }}
+        {{- end }}
       volumes:
         {{- include "metrics.shared.volume" .             | nindent 8 }}
         {{- include "custom-ca.volume" .                  | nindent 8 }}

--- a/charts/komodor-agent/templates/metrics/_containers_daemon.tpl
+++ b/charts/komodor-agent/templates/metrics/_containers_daemon.tpl
@@ -38,7 +38,7 @@
 {{- define "metrics.daemonsetWindows.container" }}
 {{- if .Values.capabilities.metrics }}
 - name: metrics
-  command: ["/usr/bin/telegraf", "--config", "/etc/telegraf/telegraf.conf", "--watch-config", "poll"]
+  command: ["C:/telegraf/telegraf.exe", "--config", "C:/telegraf/telegraf.conf", "--watch-config", "poll"]
   image: {{ .Values.imageRepo }}/{{ .Values.components.komodorDaemonWindows.metrics.image.name}}:{{ .Values.components.komodorDaemonWindows.metrics.image.tag }}
   imagePullPolicy: {{ .Values.pullPolicy }}
   resources:
@@ -150,7 +150,7 @@
 {{- end }}
 
 {{- define "metrics.daemonset.sidecar.container" }}
-{{- if .Values.capabilities.metrics }}
+{{- if and .Values.capabilities.metrics .Values.components.komodorDaemon.metrics.sidecar.enabled }}
 - name: telegraf-init-sidecar
   image: {{ .Values.imageRepo }}/{{ .Values.components.komodorDaemon.metricsInit.image.name}}:{{ .Values.components.komodorDaemon.metricsInit.image.tag | default .Chart.AppVersion }}
   imagePullPolicy: {{ .Values.pullPolicy }}
@@ -186,7 +186,7 @@
 {{- end }}
 
 {{- define "metrics.daemonset.sidecar.windows.container" }}
-{{- if .Values.capabilities.metrics }}
+{{- if and .Values.capabilities.metrics .Values.components.komodorDaemonWindows.metrics.sidecar.enabled }}
 - name: telegraf-init-sidecar
   image: {{ .Values.imageRepo }}/{{ .Values.components.komodorDaemonWindows.metricsInit.image.name}}:{{ .Values.components.komodorDaemonWindows.metricsInit.image.tag | default .Chart.AppVersion }}
   imagePullPolicy: {{ .Values.pullPolicy }}

--- a/charts/komodor-agent/templates/metrics/_containers_daemon.tpl
+++ b/charts/komodor-agent/templates/metrics/_containers_daemon.tpl
@@ -1,7 +1,7 @@
 {{- define "metrics.daemonset.container" }}
 {{- if .Values.capabilities.metrics }}
 - name: metrics
-  command: ["telegraf"]
+  command: ["/usr/bin/telegraf", "--config", "/etc/telegraf/telegraf.conf", "--watch-config", "notify"]
   image: {{ .Values.imageRepo }}/{{ .Values.components.komodorDaemon.metrics.image.name}}:{{ .Values.components.komodorDaemon.metrics.image.tag }}
   imagePullPolicy: {{ .Values.pullPolicy }}
   resources:
@@ -38,6 +38,7 @@
 {{- define "metrics.daemonsetWindows.container" }}
 {{- if .Values.capabilities.metrics }}
 - name: metrics
+  command: ["/usr/bin/telegraf", "--config", "/etc/telegraf/telegraf.conf", "--watch-config", "poll"]
   image: {{ .Values.imageRepo }}/{{ .Values.components.komodorDaemonWindows.metrics.image.name}}:{{ .Values.components.komodorDaemonWindows.metrics.image.tag }}
   imagePullPolicy: {{ .Values.pullPolicy }}
   resources:
@@ -94,6 +95,8 @@
   {{- include "custom-ca.volumeMounts" . | nindent 2 }}
   env:
   {{- include "komodorAgent.proxy-conf" . | indent 2 }}
+  - name: KOMOKW_RUNTIME_MODE
+    value: init
   - name: KOMOKW_COMPONENT
     value: {{ .Chart.Name  }}-daemon
   - name: NAMESPACE
@@ -122,6 +125,8 @@
   {{- include "custom-ca.volumeMounts" . | nindent 2 }}
   env:
   {{- include "komodorAgent.proxy-conf" . | indent 2 }}
+  - name: KOMOKW_RUNTIME_MODE
+    value: init
   - name: KOMOKW_COMPONENT
     value: {{ .Chart.Name  }}-daemon-windows
   - name: NAMESPACE
@@ -136,6 +141,84 @@
         name: {{ include "komodorAgent.secret.name" . }}
         key: apiKey
         {{- end }}
+  - name: KOMOKW_POLLING_INTERVAL_SECONDS
+    value: "300"
+  {{- if gt (len .Values.components.komodorDaemonWindows.metricsInit.extraEnvVars) 0 }}
+  {{ toYaml .Values.components.komodorDaemonWindows.metricsInit.extraEnvVars | nindent 2 }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "metrics.daemonset.sidecar.container" }}
+{{- if .Values.capabilities.metrics }}
+- name: telegraf-init-sidecar
+  image: {{ .Values.imageRepo }}/{{ .Values.components.komodorDaemon.metricsInit.image.name}}:{{ .Values.components.komodorDaemon.metricsInit.image.tag | default .Chart.AppVersion }}
+  imagePullPolicy: {{ .Values.pullPolicy }}
+  resources:
+    {{ toYaml .Values.components.komodorDaemon.metricsInit.resources | trim | nindent 4 }}
+  {{- if .Values.customCa.enabled }}
+  {{ include "custom-ca.trusted-telegraf-init-container.command" . | indent 2 }}
+  {{- else }}
+  command: ["telegraf_init"]
+  {{- end }}
+  volumeMounts:
+  - name: configuration
+    mountPath: /etc/komodor
+  - name: {{ include "metrics.shared.volume.name" . }}
+    mountPath: /etc/telegraf
+  {{- include "custom-ca.volumeMounts" . | nindent 2 }}
+  env:
+  {{- include "komodorAgent.proxy-conf" . | indent 2 }}
+  - name: KOMOKW_RUNTIME_MODE
+    value: sidecar
+  - name: KOMOKW_COMPONENT
+    value: {{ .Chart.Name  }}-daemon
+  - name: NAMESPACE
+    value: {{ .Release.Namespace }}
+  - name: KOMOKW_API_KEY
+    {{ include "komodorAgent.apiKeySecretRef" . | nindent 4 }}
+  - name: KOMOKW_POLLING_INTERVAL_SECONDS
+    value: "300"
+  {{- if gt (len .Values.components.komodorDaemon.metricsInit.extraEnvVars) 0 }}
+  {{ toYaml .Values.components.komodorDaemon.metricsInit.extraEnvVars | nindent 2 }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "metrics.daemonset.sidecar.windows.container" }}
+{{- if .Values.capabilities.metrics }}
+- name: telegraf-init-sidecar
+  image: {{ .Values.imageRepo }}/{{ .Values.components.komodorDaemonWindows.metricsInit.image.name}}:{{ .Values.components.komodorDaemonWindows.metricsInit.image.tag | default .Chart.AppVersion }}
+  imagePullPolicy: {{ .Values.pullPolicy }}
+  resources:
+    {{ toYaml .Values.components.komodorDaemonWindows.metricsInit.resources | trim | nindent 4 }}
+  command: ["telegraf_init"]
+  volumeMounts:
+  - name: configuration
+    mountPath: /etc/komodor
+  - name: {{ include "metrics.shared.volume.name" . }}
+    mountPath: /etc/telegraf
+  {{- include "custom-ca.volumeMounts" . | nindent 2 }}
+  env:
+  {{- include "komodorAgent.proxy-conf" . | indent 2 }}
+  - name: KOMOKW_RUNTIME_MODE
+    value: sidecar
+  - name: KOMOKW_COMPONENT
+    value: {{ .Chart.Name  }}-daemon-windows
+  - name: NAMESPACE
+    value: {{ .Release.Namespace }}
+  - name: KOMOKW_API_KEY
+    valueFrom:
+      secretKeyRef:
+        {{- if .Values.apiKeySecret }}
+        name: {{ .Values.apiKeySecret | required "Existing secret name required!" }}
+        key: apiKey
+        {{- else }}
+        name: {{ include "komodorAgent.secret.name" . }}
+        key: apiKey
+        {{- end }}
+  - name: KOMOKW_POLLING_INTERVAL_SECONDS
+    value: "300"
   {{- if gt (len .Values.components.komodorDaemonWindows.metricsInit.extraEnvVars) 0 }}
   {{ toYaml .Values.components.komodorDaemonWindows.metricsInit.extraEnvVars | nindent 2 }}
   {{- end }}

--- a/charts/komodor-agent/templates/metrics/_containers_deployment.tpl
+++ b/charts/komodor-agent/templates/metrics/_containers_deployment.tpl
@@ -31,6 +31,7 @@
 {{- end }}
 
 {{- define "metrics.deployment.sidecar.container" }}
+{{- if .Values.components.komodorMetrics.metrics.sidecar.enabled }}
 - name: telegraf-init-sidecar
   image: {{ .Values.imageRepo }}/{{ .Values.components.komodorMetrics.metricsInit.image.name}}:{{ .Values.components.komodorMetrics.metricsInit.image.tag | default .Chart.AppVersion }}
   imagePullPolicy: {{ .Values.pullPolicy }}
@@ -62,6 +63,7 @@
   {{- if gt (len .Values.components.komodorMetrics.metricsInit.extraEnvVars) 0 }}
   {{ toYaml .Values.components.komodorMetrics.metricsInit.extraEnvVars | nindent 2 }}
   {{- end }}
+{{- end }}
 {{- end }}
 
 {{- define "metrics.deployment.init.container" }}

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -408,6 +408,10 @@ components:
           memory: 384Mi
       # components.komodorMetrics.metrics.extraEnvVars -- List of additional environment variables, Each entry is a key-value pair
       extraEnvVars: []
+      # components.komodorMetrics.metrics.sidecar -- Configure the telegraf-init sidecar container
+      sidecar:
+        # components.komodorMetrics.metrics.sidecar.enabled -- (bool) Enable the telegraf-init sidecar container
+        enabled: true
 
   # components.komodorDaemon -- Configure the komodor agent components
   # @default -- See sub-values
@@ -474,6 +478,10 @@ components:
       extraEnvVars: []
       # components.komodorDaemon.metrics.quiet -- Set the quiet mode for the komodor agent metrics
       quiet: false
+      # components.komodorDaemon.metrics.sidecar -- Configure the telegraf-init sidecar container
+      sidecar:
+        # components.komodorDaemon.metrics.sidecar.enabled -- (bool) Enable the telegraf-init sidecar container
+        enabled: true
 
     # components.komodorDaemon.nodeEnricher -- Configure the komodor daemon node enricher components
     # @default -- See sub-values
@@ -551,6 +559,10 @@ components:
       extraEnvVars: []
       # components.komodorDaemonWindows.metrics.quiet -- Set the quiet mode for the komodor agent metrics
       quiet: false
+      # components.komodorDaemonWindows.metrics.sidecar -- Configure the telegraf-init sidecar container
+      sidecar:
+        # components.komodorDaemonWindows.metrics.sidecar.enabled -- (bool) Enable the telegraf-init sidecar container
+        enabled: true
 
   # components.gpuAccess -- settings for GPU host diagnostics accessor DaemonSet
   gpuAccess:


### PR DESCRIPTION
CU-86c4150pe
* Add configuration sidecar for daemon and metrics deployment to support dynamic config

* !!! Will need to update telegraf_init image tag, after that is released before merging this PR