### PR TITLE
CU-86c4ac72z - Add service for otel-collector to be reacheable from other komodor pods and fix container command

### DIFF
--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -275,7 +275,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorDaemon.nodeEnricher.resources | object | `{"limits":{"cpu":"10m","memory":"100Mi"},"requests":{"cpu":"1m","memory":"10Mi"}}` | Set custom resources to the komodor agent node enricher container |
 | components.komodorDaemon.nodeEnricher.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemon.opentelemetry | object | See sub-values | Configure the komodor daemon OpenTelemetry collector components |
-| components.komodorDaemon.opentelemetry.image | object | `{"name":"public.ecr.aws/komodor-public/komodor-otel-collector","tag":"5ee0c87e"}` | Override the OpenTelemetry collector image name or tag. |
+| components.komodorDaemon.opentelemetry.image | object | `{"name":"public.ecr.aws/komodor-public/komodor-otel-collector","tag":"a2a09964"}` | Override the OpenTelemetry collector image name or tag. |
 | components.komodorDaemon.opentelemetry.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Set custom resources to the OpenTelemetry collector container |
 | components.komodorDaemon.opentelemetry.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemonWindows | object | See sub-values | Configure the komodor agent components |

--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -275,7 +275,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorDaemon.nodeEnricher.resources | object | `{"limits":{"cpu":"10m","memory":"100Mi"},"requests":{"cpu":"1m","memory":"10Mi"}}` | Set custom resources to the komodor agent node enricher container |
 | components.komodorDaemon.nodeEnricher.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemon.opentelemetry | object | See sub-values | Configure the komodor daemon OpenTelemetry collector components |
-| components.komodorDaemon.opentelemetry.image | object | `{"name":"public.ecr.aws/komodor-public/komodor-otel-collector","tag":"35a47f77"}` | Override the OpenTelemetry collector image name or tag. |
+| components.komodorDaemon.opentelemetry.image | object | `{"name":"public.ecr.aws/komodor-public/komodor-otel-collector","tag":"5ee0c87e"}` | Override the OpenTelemetry collector image name or tag. |
 | components.komodorDaemon.opentelemetry.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Set custom resources to the OpenTelemetry collector container |
 | components.komodorDaemon.opentelemetry.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemonWindows | object | See sub-values | Configure the komodor agent components |

--- a/charts/komodor-agent/templates/opentelemetry/_containers.tpl
+++ b/charts/komodor-agent/templates/opentelemetry/_containers.tpl
@@ -3,7 +3,6 @@
 - name: otel-collector
   image: {{ .Values.components.komodorDaemon.opentelemetry.image.name }}:{{ .Values.components.komodorDaemon.opentelemetry.image.tag }}
   imagePullPolicy: {{ .Values.pullPolicy }}
-  command: ["/otelcol-komodor", "--config", "/etc/otelcol/config.yaml"]
   resources:
     {{ toYaml .Values.components.komodorDaemon.opentelemetry.resources | trim | nindent 4 }}
   ports:

--- a/charts/komodor-agent/templates/opentelemetry/service.yaml
+++ b/charts/komodor-agent/templates/opentelemetry/service.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.capabilities.telemetry.enabled .Values.capabilities.telemetry.useOpentelemetry }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "komodorAgent.fullname" . }}-otel-collector
+  labels:
+    {{- include "komodorAgent.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+  - name: otlp-http
+    port: 4318
+    targetPort: 4318
+    protocol: TCP
+  selector:
+    {{- include "komodorAgentDaemon.selectorLabels" . | nindent 4 }}
+{{- end }} 

--- a/charts/komodor-agent/templates/opentelemetry/service.yaml
+++ b/charts/komodor-agent/templates/opentelemetry/service.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.capabilities.telemetry.enabled .Values.capabilities.telemetry.useOpentelemetry }}
+{{- if and .Values.capabilities.telemetry.enabled .Values.capabilities.telemetry.deployOtelCollector }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -533,7 +533,7 @@ components:
       # components.komodorDaemon.opentelemetry.image -- Override the OpenTelemetry collector image name or tag.
       image:
         name: public.ecr.aws/komodor-public/komodor-otel-collector
-        tag: 35a47f77
+        tag: 5ee0c87e
       # components.komodorDaemon.opentelemetry.resources -- Set custom resources to the OpenTelemetry collector container
       resources:
         limits:

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -533,7 +533,7 @@ components:
       # components.komodorDaemon.opentelemetry.image -- Override the OpenTelemetry collector image name or tag.
       image:
         name: public.ecr.aws/komodor-public/komodor-otel-collector
-        tag: 5ee0c87e
+        tag: a2a09964
       # components.komodorDaemon.opentelemetry.resources -- Set custom resources to the OpenTelemetry collector container
       resources:
         limits:


### PR DESCRIPTION
Will allow us to route telemetry from the agent to this sidecar instead of directly to our backend
Also remove the redundant command override which caused a subprocessed to spawn