### PR TITLE
CU-86c4byh2t - Deploy OTEL Collector by default for internal telemetry

### DIFF
--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -152,7 +152,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | capabilities.telemetry | object | See sub-values | Configure the agent telemetry capabilities |
 | capabilities.telemetry.enabled | bool | `true` | Enable telemetry capabilities by the komodor agent |
 | capabilities.telemetry.collectApiServerMetrics | bool | `false` | Collect metrics from the api server (Should only be used for debugging purposes) |
-| capabilities.telemetry.deployOtelCollector | bool | `false` | Deploys OpenTelemetry collector daemonset sidecar |
+| capabilities.telemetry.deployOtelCollector | bool | `true` | Deploys OpenTelemetry collector daemonset sidecar |
 | capabilities.kubectlProxy | object | See sub-values | Configure the komodor kubectl proxy capabilities |
 | capabilities.kubectlProxy.enabled | bool | `false` | Enable the komodor kubectl proxy |
 | capabilities.admissionController | object | See sub-values | Configure the komodor admission controller capabilities |

--- a/charts/komodor-agent/templates/configmap.yaml
+++ b/charts/komodor-agent/templates/configmap.yaml
@@ -31,7 +31,11 @@ data:
     telemetry:
       enable: {{ .Values.capabilities.telemetry.enabled }}
       collectApiServerMetrics: {{ .Values.capabilities.telemetry.collectApiServerMetrics }}
+      {{- if .Values.capabilities.telemetry.deployOtelCollector }}
+      serverHost: {{ include "komodorAgent.openTelemetry.serviceFqdn" . }}
+      {{- else }}
       serverHost: {{ .Values.communications.telemetryServerHost }}
+      {{- end }}
     resync:
       period: "0"
 

--- a/charts/komodor-agent/templates/configmap.yaml
+++ b/charts/komodor-agent/templates/configmap.yaml
@@ -36,6 +36,12 @@ data:
       {{- else }}
       serverHost: {{ .Values.communications.telemetryServerHost }}
       {{- end }}
+    {{- if .Values.capabilities.telemetry.deployOtelCollector }}
+    {{-/* When the OTEL Collector is enabled, it collect logs already thus not needing the remote sink */}}
+    logger:
+      remote:
+        enabled: false
+    {{- end }}
     resync:
       period: "0"
 

--- a/charts/komodor-agent/templates/configmap.yaml
+++ b/charts/komodor-agent/templates/configmap.yaml
@@ -37,7 +37,7 @@ data:
       serverHost: {{ .Values.communications.telemetryServerHost }}
       {{- end }}
     {{- if .Values.capabilities.telemetry.deployOtelCollector }}
-    {{-/* When the OTEL Collector is enabled, it collect logs already thus not needing the remote sink */}}
+    {{/* When the OTEL Collector is enabled, it collect logs already thus not needing the remote sink */}}
     logger:
       remote:
         enabled: false

--- a/charts/komodor-agent/templates/opentelemetry/_containers.tpl
+++ b/charts/komodor-agent/templates/opentelemetry/_containers.tpl
@@ -37,6 +37,7 @@
     failureThreshold: 3
     successThreshold: 1
   env:
+  {{- include "komodorAgent.proxy-conf" . | indent 2 }}
   - name: NODE_NAME
     valueFrom:
       fieldRef:

--- a/charts/komodor-agent/templates/opentelemetry/_containers.tpl
+++ b/charts/komodor-agent/templates/opentelemetry/_containers.tpl
@@ -17,7 +17,7 @@
     protocol: TCP
   volumeMounts:
   - name: opentelemetry-config
-    mountPath: /etc/otelcol
+    mountPath: /etc/otel
   - name: opentelemetry-varlogpods
     mountPath: /var/log/pods
   livenessProbe:

--- a/charts/komodor-agent/templates/opentelemetry/_helpers.tpl
+++ b/charts/komodor-agent/templates/opentelemetry/_helpers.tpl
@@ -1,0 +1,7 @@
+{{- define "komodorAgent.openTelemetry.serviceName" -}}
+{{- printf "%s-otel-collector" (include "komodorAgent.fullname" .) -}}
+{{- end -}}
+
+{{- define "komodorAgent.openTelemetry.serviceFqdn" -}}
+{{- printf "http://%s.%s.svc.cluster.local:4318" (include "komodorAgent.openTelemetry.serviceName" .) .Release.Namespace -}}
+{{- end -}}

--- a/charts/komodor-agent/templates/opentelemetry/configmap.yaml
+++ b/charts/komodor-agent/templates/opentelemetry/configmap.yaml
@@ -60,8 +60,6 @@ data:
         check_interval: 1s
         limit_percentage: 75
         spike_limit_percentage: 20
-      probabilistic_sampler:
-        sampling_percentage: 70.0
 
     exporters:
       # Debug exporter can be used for development and testing purposes
@@ -85,7 +83,7 @@ data:
       pipelines:
         traces:
           receivers: [otlp]
-          processors: [memory_limiter, probabilistic_sampler, batch]
+          processors: [memory_limiter, batch]
           exporters: [otlphttp/komodor]
         metrics:
           receivers: [otlp]

--- a/charts/komodor-agent/templates/opentelemetry/service.yaml
+++ b/charts/komodor-agent/templates/opentelemetry/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "komodorAgent.fullname" . }}-otel-collector
+  name: {{ include "komodorAgent.openTelemetry.serviceName" . }}
   labels:
     {{- include "komodorAgent.labels" . | nindent 4 }}
 spec:

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -147,7 +147,7 @@ capabilities:
     # capabilities.telemetry.collectApiServerMetrics -- Collect metrics from the api server (Should only be used for debugging purposes)
     collectApiServerMetrics: false
     # capabilities.telemetry.deployOtelCollector -- (bool) Deploys OpenTelemetry collector daemonset sidecar
-    deployOtelCollector: false
+    deployOtelCollector: true
 
   # capabilities.kubectlProxy -- Configure the komodor kubectl proxy capabilities
   # @default -- See sub-values


### PR DESCRIPTION
--------- Chart changes:
* Otel collector will now be deployed by default along with the agent
* If otel collector deployment is enabled, route agent telemetry to it instead of remote endpoint directly & disable remote log sink as otel collector gets them automatically via filelog
* Fix otel collector config mount path
* Include proxy configuration env vars for otel collector container

--------- Internal Monitoring:
* Created new log indexes for staging+production to organize what comes from this otel collector
* Updated in Datadog the startup/liveness metrics we generate from logs
* Checked that there's no critical monitors/alerts that were relying only on old log sources.

Tested deployment on actual cluster vs. production account