### PR TITLE
Add helm value and env var to skip tls verification

### DIFF
--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -98,6 +98,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | tags | dict | `{}` | Tags the agent in order to identify it based on `key:value` properties separated by semicolon (`;`) example: `--set tags.env=staging,tags.team=payments` --- Can also be set in the values under `tags` as a dictionary of key:value strings |
 | clusterName | string | `nil` | **(*required*)** Name to be displayed in the Komodor web application |
 | createRbac | bool | `true` | Creates the necessary RBAC resources for the agent - use with caution! |
+| skipTlsVerify | bool | `false` | Skip TLS certificate verification for the agent (sets SKIP_TLS_VERIFY environment variable) |
 | telegrafImageVersion | string | `"v2.0.3-alpine"` | Telegraf version to be used |
 | telegrafWindowsImageVersion | string | `"v2.0.3-windows"` | Telegraf version to be used for windows |
 | serviceAccount | object | See sub-values | Configure service account for the agent |

--- a/charts/komodor-agent/templates/watcher/_containers.tpl
+++ b/charts/komodor-agent/templates/watcher/_containers.tpl
@@ -35,6 +35,10 @@
     value: /opt/watcher/helm/config
   - name: HELM_DATA_HOME
     value: /opt/watcher/helm/data
+  {{- if .Values.skipTlsVerify }}
+  - name: SKIP_TLS_VERIFY
+    value: "true"
+  {{- end }}
   {{- if gt (len .Values.components.komodorAgent.watcher.extraEnvVars) 0 }}
   {{ toYaml .Values.components.komodorAgent.watcher.extraEnvVars | nindent 2 }}
   {{- end }}

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -12,6 +12,9 @@ clusterName:
 # createRbac -- Creates the necessary RBAC resources for the agent - use with caution!
 createRbac: true
 
+# skipTlsVerify -- (bool) Skip TLS certificate verification for the agent (sets SKIP_TLS_VERIFY environment variable)
+skipTlsVerify: false
+
 # telegrafImageVersion -- (string) Telegraf version to be used
 telegrafImageVersion: &telegrafVersion v2.0.3-alpine
 # telegrafWindowsImageVersion -- (string) Telegraf version to be used for windows


### PR DESCRIPTION
Support setting skip TLS verification during helm installation.
This option is already supported in agent code:
	if os.Getenv("SKIP_TLS_VERIFY") != "" {
		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
	}


Question - do we want to use the same http client for both k8s API and general http requests OR
have a dedicated client for general http requests with its own config vars?