### PR TITLE
CU-86c50d1mg - Update admission-controller version, Update memory settings of metrics deployment

### DIFF
--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -246,7 +246,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorMetrics.metricsInit.resources | object | `{}` | Set custom resources to the komodor agent metrics init container |
 | components.komodorMetrics.metricsInit.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorMetrics.metrics.image | object | `{"name":"telegraf","tag":"v2.0.4-alpine"}` | Override the komodor agent metrics image name or tag. |
-| components.komodorMetrics.metrics.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
+| components.komodorMetrics.metrics.resources | object | `{"limits":{"cpu":1,"memory":"4Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
 | components.komodorMetrics.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorMetrics.metrics.sidecar | object | `{"enabled":true}` | Configure the telegraf-init sidecar container |
 | components.komodorMetrics.metrics.sidecar.enabled | bool | `true` | Enable the telegraf-init sidecar container |

--- a/charts/komodor-agent/templates/admission-controller/deployment.yaml
+++ b/charts/komodor-agent/templates/admission-controller/deployment.yaml
@@ -57,6 +57,8 @@ spec:
           env:
             - name: KOMO_API_KEY
               {{- include "komodorAgent.apiKeySecretRef" . | nindent 14 }}
+            - name: GOMEMLIMIT
+              value: {{ .Values.components.admissionController.resources.limits.memory | replace "Ki" "KiB" | replace "Mi" "MiB" | replace "Gi" "GiB" | replace "Ti" "TiB" | quote }}
           volumeMounts:
             - name: webhook-tls
               mountPath: /etc/komodor/admission/tls

--- a/charts/komodor-agent/templates/metrics/_containers_deployment.tpl
+++ b/charts/komodor-agent/templates/metrics/_containers_deployment.tpl
@@ -25,6 +25,8 @@
     valueFrom:
       fieldRef:
         fieldPath: status.hostIP
+  - name: GOMEMLIMIT
+    value: {{ .Values.components.komodorMetrics.metrics.resources.limits.memory | replace "Ki" "KiB" | replace "Mi" "MiB" | replace "Gi" "GiB" | replace "Ti" "TiB" | quote }}
   {{- if gt (len .Values.components.komodorMetrics.metrics.extraEnvVars) 0 }}
   {{ toYaml .Values.components.komodorMetrics.metrics.extraEnvVars | nindent 2 }}
   {{- end }}

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -356,7 +356,7 @@ components:
     # @default -- see sub-values
     image:
       name: admission-controller
-      tag: 0.1.6
+      tag: 0.1.8
     # components.admissionController.resources -- Set custom resources to the komodor admission controller container - Memory utilization is relative to the amount of: [pods, nodes, pvcs, pvs, pdbs] resources you have in the cluster.
     resources:
       limits:

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -437,7 +437,7 @@ components:
       resources:
         limits:
           cpu: 1
-          memory: 1Gi
+          memory: 4Gi
         requests:
           cpu: 0.1
           memory: 384Mi


### PR DESCRIPTION
## Changelog
* Update memory limit of komodor-agent-metrics deployment from 1GB to 4GB
  * Addition of binpacking metrics require more Kubernetes related data to be kept in-memory, mostly affects larger cluster with a very high amount of Pods. Not every cluster might or will use the full limit.
 
* Adds `GOMEMLIMIT` ([Docs](https://tip.golang.org/doc/gc-guide)) env var to the komodor-agent-metrics deployment and admission-controller which will help the Go runtime manage memory more efficiently in high-consumption scenarios.

* Update admission-controller image to `0.1.8`
  * fixes a bug preventing scheduling priority of being updated once already set on a node.
  * adds a validation to rightsizing resources recommendations to prevent patching invalid yaml on resources.