### PR TITLE
Admission controller - rework values and configs, update to 0.1.11

### DIFF
--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -234,6 +234,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.admissionController.securityContext | object | `{}` | Set custom securityContext to the komodor admission controller deployment (use with caution) |
 | components.admissionController.strategy | object | `{}` | Set the rolling update strategy for the komodor admission controller |
 | components.admissionController.extraVolumes | list | `[]` | List of additional volumes to mount in the komodor admission controller deployment/pod      extraVolumes:        - volume:            name: webhook-tls            secret:              secretName: komodor-admission-controller-tls          volumeMount:            name: webhook-tls            mountPath: /etc/komodor/admission/tls            readOnly: true |
+| components.admissionController.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorMetrics.PriorityClassValue | int | `10000000` | Set the priority class value for the komodor metrics agent deployment |
 | components.komodorMetrics.priorityClassName | string | `""` | Use an existing priority class for the komodor metrics agent deployment. If not set, will create and use a priority class with PriorityClassValue. WARNING: priorityClassName is immutable and cannot be changed after initial deployment |
 | components.komodorMetrics.affinity | object | `{}` | Set node affinity for the komodor metrics agent deployment |

--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -175,7 +175,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | capabilities.admissionController.mutatingWebhook.podRightsizingWebhookPath | string | `"/webhook/rightsizing/pod"` | Path for the pod rightsizing webhook |
 | capabilities.admissionController.mutatingWebhook.caBundle | string | using the kube-root-ca.crt ConfigMap in the kube-system namespace | CA bundle for the mutating webhook configuration. It should match the webhook server CA. |
 | capabilities.admissionController.binpacking | object | See sub-values | Configure the binpacking capabilities for the admission controller |
-| capabilities.admissionController.binpacking.enabled | bool | `false` | Enable binpacking capabilities by the komodor admission controller |
 | capabilities.admissionController.binpacking.markUnevictable | bool | `false` | Add a label to mark pods as unevictable |
 | capabilities.admissionController.binpacking.addNodeAffinityToMarkedPods | bool | `false` | Add node affinity to marked pods to prefer scheduling on nodes with already unevictable pods |
 | capabilities.admissionController.rightsizing | object | See sub-values | Configure the rightsizing capabilities for the admission controller |
@@ -218,7 +217,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | components.komodorKubectlProxy.securityContext | object | `{}` | Set custom securityContext to the komodor kubectl proxy deployment (use with caution) |
 | components.komodorKubectlProxy.strategy | object | `{}` | Set the rolling update strategy for the komodor kubectl proxy deployment |
 | components.admissionController | object | See sub-values | Configure the komodor admission controller component |
-| components.admissionController.enabled | bool | `false` | Enable the komodor admission controller |
 | components.admissionController.serviceAccount | object | see sub-values | Configure the service account for the admission controller |
 | components.admissionController.serviceAccount.create | bool | `true` | Creates a service account for the admission controller |
 | components.admissionController.serviceAccount.name | string | `nil` | Name of the service account, Required if `serviceAccount.create` is false |

--- a/charts/komodor-agent/templates/admission-controller/configmap.yaml
+++ b/charts/komodor-agent/templates/admission-controller/configmap.yaml
@@ -29,6 +29,10 @@ data:
       {{- if .Values.capabilities.admissionController.binpacking.unevictablePodNodeAffinityWeight }}
       unevictablePodNodeAffinityWeight: {{ .Values.capabilities.admissionController.binpacking.unevictablePodNodeAffinityWeight }}
       {{- end }}
+      {{- if .Values.capabilities.admissionController.binpacking.ignoredNamespaces }}
+      ignoredNamespaces:
+      {{- toYaml .Values.capabilities.admissionController.binpacking.ignoredNamespaces | nindent 8 }}
+      {{- end }}
     rightsizing:
       enabled: {{ .Values.capabilities.admissionController.rightsizing.enabled }}
       {{- if .Values.capabilities.admissionController.rightsizing.recommendationsSyncInterval }}

--- a/charts/komodor-agent/templates/admission-controller/configmap.yaml
+++ b/charts/komodor-agent/templates/admission-controller/configmap.yaml
@@ -18,7 +18,6 @@ data:
       logLevel: {{ .Values.capabilities.admissionController.logLevel }}
       format: {{ .Values.capabilities.admissionController.logFormat }}
     binpacking:
-      enabled: {{ .Values.capabilities.admissionController.binpacking.enabled }}
       markUnevictable: {{ .Values.capabilities.admissionController.binpacking.markUnevictable }}
       addNodeAffinityToMarkedPods: {{ .Values.capabilities.admissionController.binpacking.addNodeAffinityToMarkedPods }}
       {{- if .Values.capabilities.admissionController.binpacking.unevictableLabelKey }}

--- a/charts/komodor-agent/templates/admission-controller/deployment.yaml
+++ b/charts/komodor-agent/templates/admission-controller/deployment.yaml
@@ -59,6 +59,9 @@ spec:
               {{- include "komodorAgent.apiKeySecretRef" . | nindent 14 }}
             - name: GOMEMLIMIT
               value: {{ .Values.components.admissionController.resources.limits.memory | replace "Ki" "KiB" | replace "Mi" "MiB" | replace "Gi" "GiB" | replace "Ti" "TiB" | quote }}
+          {{- with .Values.components.admissionController.extraEnvVars }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: webhook-tls
               mountPath: /etc/komodor/admission/tls

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -207,8 +207,6 @@ capabilities:
     # capabilities.admissionController.binpacking -- Configure the binpacking capabilities for the admission controller
     # @default -- See sub-values
     binpacking:
-      # capabilities.admissionController.binpacking.enabled -- (bool) Enable binpacking capabilities by the komodor admission controller
-      enabled: false
       # capabilities.admissionController.binpacking.markUnevictable -- (bool) Add a label to mark pods as unevictable
       markUnevictable: false
       # capabilities.admissionController.binpacking.addNodeAffinityToMarkedPods -- (bool) Add node affinity to marked pods to prefer scheduling on nodes with already unevictable pods
@@ -347,8 +345,6 @@ components:
   # components.admissionController -- Configure the komodor admission controller component
   # @default -- See sub-values
   admissionController:
-    # components.admissionController.enabled -- (bool) Enable the komodor admission controller
-    enabled: false
     # components.admissionController.serviceAccount -- Configure the service account for the admission controller
     # @default -- see sub-values
     serviceAccount:

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -362,7 +362,7 @@ components:
     # @default -- see sub-values
     image:
       name: admission-controller
-      tag: 0.1.10
+      tag: 0.1.11
     # components.admissionController.resources -- Set custom resources to the komodor admission controller container - Memory utilization is relative to the amount of: [pods, nodes, pvcs, pvs, pdbs] resources you have in the cluster.
     resources:
       limits:

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -217,6 +217,8 @@ capabilities:
       #modifiedAnnotationKey: "komodor.io/modified-at"
       # capabilities.admissionController.binpacking.unevictablePodNodeAffinityWeight -- (int) Weight for the node affinity of unevictable pods
       #unevictablePodNodeAffinityWeight: 100
+      # capabilities.admissionController.binpacking.ignoredNamespaces -- (list) List of namespaces to ignore for binpacking
+      #ignoredNamespaces: []
 
     # capabilities.admissionController.rightsizing -- Configure the rightsizing capabilities for the admission controller
     # @default -- See sub-values

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -398,6 +398,8 @@ components:
     #            mountPath: /etc/komodor/admission/tls
     #            readOnly: true
     extraVolumes: []
+    # components.admissionController.extraEnvVars -- List of additional environment variables, Each entry is a key-value pair
+    extraEnvVars: []
 
   komodorMetrics:
     # components.komodorMetrics.PriorityClassValue -- Set the priority class value for the komodor metrics agent deployment


### PR DESCRIPTION
CU-86c57ww8m
CU-86c59032b

**Key changes:**

**Admission Controller Configuration Updates:**
- Removed the `enabled` flag from both `components.admissionController` (unused) and `capabilities.admissionController.binpacking`, simplifying configuration and possibly shifting enablement logic to the UI. [[1]](diffhunk://#diff-a1c7c440ff8832984790b9cc6143fb153a3783a5e3074e6338e61365cf5a0f2aL221) [[2]](diffhunk://#diff-64879027a4c59e7dafa9421f48f94cbdadcfc11f5cb2c41d928e568077bd90a1L350-L351) [[3]](diffhunk://#diff-a1c7c440ff8832984790b9cc6143fb153a3783a5e3074e6338e61365cf5a0f2aL178) [[4]](diffhunk://#diff-64879027a4c59e7dafa9421f48f94cbdadcfc11f5cb2c41d928e568077bd90a1L210-L211) [[5]](diffhunk://#diff-0e53e2080893dbe7a4a3e15a0f189eccd80811fcd548117abf7ba01e71ee2e09L21)
- Updated the admission controller image tag from `0.1.10` to `0.1.11` - Adds support for `ignoredNamespaces` configuration in binpacking

**Extra Environment Variable Support for Admission Controller:**
- Added a new `extraEnvVars` field to `components.admissionController` in `values.yaml` and documented it in `README.md`, allowing users to specify additional environment variables for the admission controller deployment. [[1]](diffhunk://#diff-64879027a4c59e7dafa9421f48f94cbdadcfc11f5cb2c41d928e568077bd90a1R401-R402) [[2]](diffhunk://#diff-a1c7c440ff8832984790b9cc6143fb153a3783a5e3074e6338e61365cf5a0f2aR237)
- Modified the admission controller deployment template to inject these extra environment variables if specified.