### PR TITLE
CU-86c5h62kf - update binpacking configuration to true by default

### DIFF
--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -175,8 +175,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | capabilities.admissionController.mutatingWebhook.podRightsizingWebhookPath | string | `"/webhook/rightsizing/pod"` | Path for the pod rightsizing webhook |
 | capabilities.admissionController.mutatingWebhook.caBundle | string | using the kube-root-ca.crt ConfigMap in the kube-system namespace | CA bundle for the mutating webhook configuration. It should match the webhook server CA. |
 | capabilities.admissionController.binpacking | object | See sub-values | Configure the binpacking capabilities for the admission controller |
-| capabilities.admissionController.binpacking.markUnevictable | bool | `false` | Add a label to mark pods as unevictable |
-| capabilities.admissionController.binpacking.addNodeAffinityToMarkedPods | bool | `false` | Add node affinity to marked pods to prefer scheduling on nodes with already unevictable pods |
+| capabilities.admissionController.binpacking.markUnevictable | bool | `true` | Add a label to mark pods as unevictable (requires enabling per cluster in UI in addition) |
+| capabilities.admissionController.binpacking.addNodeAffinityToMarkedPods | bool | `true` | Add node affinity to marked pods to prefer scheduling on nodes with already unevictable pods (requires enabling per cluster in UI in addition) |
 | capabilities.admissionController.rightsizing | object | See sub-values | Configure the rightsizing capabilities for the admission controller |
 | capabilities.admissionController.rightsizing.enabled | bool | `false` | Enable rightsizing capabilities by the komodor admission controller |
 | components | object | See sub-values | Configure the agent components |

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -206,10 +206,10 @@ capabilities:
     # capabilities.admissionController.binpacking -- Configure the binpacking capabilities for the admission controller
     # @default -- See sub-values
     binpacking:
-      # capabilities.admissionController.binpacking.markUnevictable -- (bool) Add a label to mark pods as unevictable
-      markUnevictable: false
-      # capabilities.admissionController.binpacking.addNodeAffinityToMarkedPods -- (bool) Add node affinity to marked pods to prefer scheduling on nodes with already unevictable pods
-      addNodeAffinityToMarkedPods: false
+      # capabilities.admissionController.binpacking.markUnevictable -- (bool) Add a label to mark pods as unevictable (requires enabling per cluster in UI in addition)
+      markUnevictable: true
+      # capabilities.admissionController.binpacking.addNodeAffinityToMarkedPods -- (bool) Add node affinity to marked pods to prefer scheduling on nodes with already unevictable pods (requires enabling per cluster in UI in addition)
+      addNodeAffinityToMarkedPods: true
       # capabilities.admissionController.binpacking.unevictableLabelKey -- (string) Label key to mark pods as unevictable
       #unevictableLabelKey: "komodor.io/unevictable"
       # capabilities.admissionController.binpacking.modifiedAnnotationKey -- (string) Annotation key to mark pods as modified by the binpacking admission controller


### PR DESCRIPTION
* Update `markUnevictable` and `addNodeAffinityToMarkedPods` to be true by default
* It will still require customers to enable Pod Placement via the UI for each cluster they want it to affect.