### PR TITLE
Admission Controller: allow read all resources and API groups

### DIFF
--- a/charts/komodor-agent/templates/admission-controller/rbac.yaml
+++ b/charts/komodor-agent/templates/admission-controller/rbac.yaml
@@ -54,10 +54,9 @@ rules:
       - watch
       - list
   - apiGroups:
-      - "sparkoperator.k8s.io"
+      - "*"
     resources:
-      - sparkapplications
-      - scheduledsparkapplications
+      - "*"
     verbs:
       - get
 


### PR DESCRIPTION
Update RBAC permissions to allow access to all resources and API groups.