### PR TITLE
CU-86c5z257q - include log collection from komodor agent chart and podmotion only

### DIFF
--- a/charts/komodor-agent/templates/opentelemetry/configmap.yaml
+++ b/charts/komodor-agent/templates/opentelemetry/configmap.yaml
@@ -42,7 +42,8 @@ data:
               target_label: __address__
       filelog/komodor:
         include:
-          - "/var/log/pods/*komodor*/*/*.log"
+          - "/var/log/pods/*{{ include "komodorAgent.fullname" . }}*/*/*.log"
+          - "/var/log/pods/*komodor-podmotion*/*/*.log"
         include_file_name: false
         include_file_path: true
         poll_interval: 500ms


### PR DESCRIPTION
The include was too broad being *komodor* and would catch duplicate logs from our own apps in our clusters.