### PR TITLE
feat: add UPDATE operation to HPA mutating webhook

### DIFF
--- a/charts/komodor-agent/templates/admission-controller/webhookconfiguration.yaml
+++ b/charts/komodor-agent/templates/admission-controller/webhookconfiguration.yaml
@@ -83,7 +83,7 @@ webhooks:
         port: {{ include "komodorAgent.admissionController.servicePort" . }}
       caBundle: {{ .Values.capabilities.admissionController.mutatingWebhook.caBundle | default $certList._2 }}
     rules:
-      - operations: [ "CREATE" ]
+      - operations: [ "CREATE", "UPDATE" ]
         apiGroups: [ "autoscaling" ]
         apiVersions: [ "v2" ]
         resources: [ "horizontalpodautoscalers" ]


### PR DESCRIPTION
## What
Add the `UPDATE` operation to the HPA mutating webhook configuration, alongside the existing `CREATE` operation.

## Why
The mutating webhook for HorizontalPodAutoscalers was only intercepting `CREATE` operations. This meant that updates to existing HPAs were not being processed by the admission controller. Adding `UPDATE` ensures the webhook also handles modifications to HPA resources.