### PR TITLE
feat: add DELETE operation to HPA mutating webhook

### DIFF
--- a/charts/komodor-agent/templates/admission-controller/webhookconfiguration.yaml
+++ b/charts/komodor-agent/templates/admission-controller/webhookconfiguration.yaml
@@ -83,7 +83,7 @@ webhooks:
         port: {{ include "komodorAgent.admissionController.servicePort" . }}
       caBundle: {{ .Values.capabilities.admissionController.mutatingWebhook.caBundle | default $certList._2 }}
     rules:
-      - operations: [ "CREATE", "UPDATE" ]
+      - operations: [ "CREATE", "UPDATE", "DELETE" ]
         apiGroups: [ "autoscaling" ]
         apiVersions: [ "v2" ]
         resources: [ "horizontalpodautoscalers" ]


### PR DESCRIPTION
## Summary
- Add `DELETE` to the HPA webhook operations list alongside existing `CREATE` and `UPDATE`
- Allows the admission controller to observe HPA deletion events for future cleanup/revert logic

## Test plan
- [ ] Verify existing CREATE/UPDATE webhook behavior is unaffected
- [ ] Verify DELETE events are forwarded to the admission controller endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)