### PR TITLE
Update NGINX version to 1.30.0

### DIFF
--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -340,7 +340,7 @@ components:
     # @default -- see sub-values
     image:
       name: nginx
-      tag: 1.29.8-alpine3.23-slim
+      tag: 1.30.0-alpine3.23-slim
     # components.komodorKubectlProxy.resources -- Set custom resources to the komodor kubectl proxy container
     resources: {}
     # components.komodorKubectlProxy.PriorityClassValue -- Set the priority class value for the komodor kubectl proxy deployment

--- a/scripts/nginx/Dockerfile
+++ b/scripts/nginx/Dockerfile
@@ -1,4 +1,4 @@
-ARG NGINX_VERSION=1.29.8-alpine3.23-slim
+ARG NGINX_VERSION=1.30.0-alpine3.23-slim
 FROM nginx:${NGINX_VERSION}
 
 RUN apk add --no-cache openssl


### PR DESCRIPTION
## Summary                                   
  - Bump nginx version from `1.29.8-alpine3.23-slim` to `1.30.0-alpine3.23-slim`                 
  - Updated `scripts/nginx/Dockerfile` (build ARG) and `charts/komodor-agent/values.yaml`        
  (`components.komodorKubectlProxy.image.tag`)                                                   
  - Built a Multi-arch image and pushed to `public.ecr.aws/komodor-public/nginx` and   
  `komodorio/nginx`  