### PR TITLE
CU-86c81na13 chore: update AC version from 0.1.51 to 0.1.52

### DIFF
--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -154,7 +154,7 @@ Relevant values:
 | createRbac | bool | `true` | Creates the necessary RBAC resources for the agent - use with caution! |
 | telegrafImageVersion | string | `"v2.0.40-alpine"` | Telegraf version to be used |
 | telegrafWindowsImageVersion | string | `"v2.0.40"` | Telegraf version to be used for windows |
-| admissionControllerVersion | string | `"0.1.51"` | Admission controller version to be used |
+| admissionControllerVersion | string | `"0.1.52"` | Admission controller version to be used |
 | serviceAccount | object | See sub-values | Configure service account for the agent |
 | serviceAccount.create | bool | `true` | Creates a service account for the agent |
 | serviceAccount.name | string | `nil` | Name of the service account, Required if `serviceAccount.create` is false |

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -20,7 +20,7 @@ telegrafImageVersion: &telegrafVersion v2.0.40-alpine
 # telegrafWindowsImageVersion -- (string) Telegraf version to be used for windows
 telegrafWindowsImageVersion: &telegrafWindowsVersion v2.0.40
 # admissionControllerVersion -- (string) Admission controller version to be used
-admissionControllerVersion: &acVersion 0.1.51
+admissionControllerVersion: &acVersion 0.1.52
 
 # serviceAccount -- Configure service account for the agent
 # @default -- See sub-values


### PR DESCRIPTION
1. update AC version from 0.1.51 to 0.1.52
2. update README file with `make generate-readme` command inside `/komodor-agent`