### PR TITLE
CU-86c9me6cu - chore: bump telegraf-plugins from v2.0.40 to v2.0.41

### DIFF
--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -152,8 +152,8 @@ Relevant values:
 | tags | dict | `{}` | Tags the agent in order to identify it based on `key:value` properties separated by semicolon (`;`) example: `--set tags.env=staging,tags.team=payments` --- Can also be set in the values under `tags` as a dictionary of key:value strings |
 | clusterName | string | `nil` | **(*required*)** Name to be displayed in the Komodor web application |
 | createRbac | bool | `true` | Creates the necessary RBAC resources for the agent - use with caution! |
-| telegrafImageVersion | string | `"v2.0.40-alpine"` | Telegraf version to be used |
-| telegrafWindowsImageVersion | string | `"v2.0.40"` | Telegraf version to be used for windows |
+| telegrafImageVersion | string | `"v2.0.41-alpine"` | Telegraf version to be used |
+| telegrafWindowsImageVersion | string | `"v2.0.41"` | Telegraf version to be used for windows |
 | admissionControllerVersion | string | `"0.1.53"` | Admission controller version to be used |
 | serviceAccount | object | See sub-values | Configure service account for the agent |
 | serviceAccount.create | bool | `true` | Creates a service account for the agent |
@@ -327,7 +327,7 @@ Relevant values:
 | components.komodorMetrics.metricsInit.resources | object | `{}` | Set custom resources to the komodor agent metrics init container |
 | components.komodorMetrics.metricsInit.securityContext | object | `{}` | Set container-level securityContext for the komodor metrics init and sidecar containers. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
 | components.komodorMetrics.metricsInit.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
-| components.komodorMetrics.metrics.image | object | `{"name":"telegraf","tag":"v2.0.40-alpine"}` | Override the komodor agent metrics image name or tag. |
+| components.komodorMetrics.metrics.image | object | `{"name":"telegraf","tag":"v2.0.41-alpine"}` | Override the komodor agent metrics image name or tag. |
 | components.komodorMetrics.metrics.resources | object | `{"limits":{"cpu":1,"memory":"4Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
 | components.komodorMetrics.metrics.securityContext | object | `{}` | Set container-level securityContext for the komodor metrics (telegraf) container. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
 | components.komodorMetrics.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
@@ -352,8 +352,8 @@ Relevant values:
 | components.komodorDaemon.metricsInit.image | object | `{ "name": "init-daemon-agent", "tag": .Chart.AppVersion }` | Override the komodor agent metrics init image name or tag. |
 | components.komodorDaemon.metricsInit.resources | object | `{"limits":{"cpu":1,"memory":"100Mi"},"requests":{"cpu":0.1,"memory":"50Mi"}}` | Set custom resources to the komodor agent metrics init container |
 | components.komodorDaemon.metricsInit.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
-| components.komodorDaemon.metrics | object | `{"extraEnvVars":[],"image":{"name":"telegraf","tag":"v2.0.40-alpine"},"quiet":false,"resources":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"add":[],"drop":["ALL"]},"runAsNonRoot":true},"sidecar":{"enabled":true}}` | Configure the komodor daemon metrics components |
-| components.komodorDaemon.metrics.image | object | `{"name":"telegraf","tag":"v2.0.40-alpine"}` | Override the komodor agent metrics image name or tag. |
+| components.komodorDaemon.metrics | object | `{"extraEnvVars":[],"image":{"name":"telegraf","tag":"v2.0.41-alpine"},"quiet":false,"resources":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"add":[],"drop":["ALL"]},"runAsNonRoot":true},"sidecar":{"enabled":true}}` | Configure the komodor daemon metrics components |
+| components.komodorDaemon.metrics.image | object | `{"name":"telegraf","tag":"v2.0.41-alpine"}` | Override the komodor agent metrics image name or tag. |
 | components.komodorDaemon.metrics.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
 | components.komodorDaemon.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemon.metrics.quiet | bool | `false` | Set the quiet mode for the komodor agent metrics |
@@ -403,8 +403,8 @@ Relevant values:
 | components.komodorDaemonWindows.metricsInit.image | object | `{ "name": "init-daemon-agent", "tag": .Chart.AppVersion }` | Override the komodor agent metrics init image name or tag. |
 | components.komodorDaemonWindows.metricsInit.resources | object | `{"limits":{"cpu":1,"memory":"100Mi"},"requests":{"cpu":0.1,"memory":"50Mi"}}` | Set custom resources to the komodor agent metrics init container |
 | components.komodorDaemonWindows.metricsInit.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
-| components.komodorDaemonWindows.metrics | object | `{"extraEnvVars":[],"image":{"name":"telegraf-windows","tag":"v2.0.40"},"quiet":false,"resources":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}},"sidecar":{"enabled":true}}` | Configure the komodor daemon metrics components |
-| components.komodorDaemonWindows.metrics.image | object | `{"name":"telegraf-windows","tag":"v2.0.40"}` | Override the komodor agent metrics image name or tag. |
+| components.komodorDaemonWindows.metrics | object | `{"extraEnvVars":[],"image":{"name":"telegraf-windows","tag":"v2.0.41"},"quiet":false,"resources":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}},"sidecar":{"enabled":true}}` | Configure the komodor daemon metrics components |
+| components.komodorDaemonWindows.metrics.image | object | `{"name":"telegraf-windows","tag":"v2.0.41"}` | Override the komodor agent metrics image name or tag. |
 | components.komodorDaemonWindows.metrics.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
 | components.komodorDaemonWindows.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemonWindows.metrics.quiet | bool | `false` | Set the quiet mode for the komodor agent metrics |

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -16,9 +16,9 @@ clusterName:
 createRbac: true
 
 # telegrafImageVersion -- (string) Telegraf version to be used
-telegrafImageVersion: &telegrafVersion v2.0.40-alpine
+telegrafImageVersion: &telegrafVersion v2.0.41-alpine
 # telegrafWindowsImageVersion -- (string) Telegraf version to be used for windows
-telegrafWindowsImageVersion: &telegrafWindowsVersion v2.0.40
+telegrafWindowsImageVersion: &telegrafWindowsVersion v2.0.41
 # admissionControllerVersion -- (string) Admission controller version to be used
 admissionControllerVersion: &acVersion 0.1.53
 


### PR DESCRIPTION
## Summary

Bumps the telegraf-plugins image used by `komodor-agent` from `v2.0.40` → `v2.0.41`. The new release ([komodorio/telegraf-plugins#104](https://github.com/komodorio/telegraf-plugins/pull/104)) bumps the upstream Telegraf base image from `1.37.1` → `1.37.3` for both Linux Alpine and Windows.

Backward-compatible by design — we deliberately stayed inside the `1.37.x` line to avoid Telegraf 1.38's strict env-var handling regression ([influxdata/telegraf#17961](https://github.com/influxdata/telegraf/pull/17961)) which would have required chart-side coordination (e.g. always exporting `KOMODOR_HTTP_PROXY`, or passing `--non-strict-env-handling`). 1.37.2 and 1.37.3 are pure bugfix + dependency-refresh releases.

## What changed

- `charts/komodor-agent/values.yaml`: `telegrafImageVersion` and `telegrafWindowsImageVersion` → `v2.0.41` / `v2.0.41-alpine`
- `charts/komodor-agent/README.md`: regenerated docs to match (helm-docs equivalent — pure string substitution since only image tags changed)

## Why now / why this version specifically

- The image scanned by Wiz on the previous tag was still showing some critical findings; the OS-level package refresh in the newer Alpine layer used by `1.37.3-alpine` is expected to clean those up.
- Bumping to `1.38.x` is being deferred to a separate, properly-scoped tech-debt effort because of the strict env-var handling change and the disk-buffer rework risk.

## Pre-merge gates

- [ ] **Wait for [telegraf-plugins build #433](https://buildkite.com/komodor/telegraf-plugins/builds/433) to finish** and produce the `v2.0.41` tag / `komodorio/telegraf:v2.0.41-alpine` and `komodorio/telegraf-windows:v2.0.41` images. (The auto-bump scheme is deterministic — `VERSION=v2.0.7` < `latest tag=v2.0.40` → it will produce `v2.0.41` — but the tag must exist before this chart can pull it.)
- [ ] CI / template tests green
- [ ] Spot-check rendered manifests reference `v2.0.41`

## Test plan

- [ ] `make template` runs cleanly with default values
- [ ] Deploy to a staging cluster; confirm metrics agent comes up healthy on Linux nodes
- [ ] Confirm Windows metrics agent comes up on a Windows-node cluster (if applicable)


Made with [Cursor](https://cursor.com)