### PR TITLE
CU-86c6c6hz9 - feat(admission-controller): add KEDA ScaledObject mutating webhook rule

### DIFF
--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -238,6 +238,7 @@ Relevant values:
 | capabilities.admissionController.mutatingWebhook.podBinpackingWebhookPath | string | `"/webhook/binpacking/pod"` | Path for the pod binpacking webhook |
 | capabilities.admissionController.mutatingWebhook.podRightsizingWebhookPath | string | `"/webhook/rightsizing/pod"` | Path for the pod rightsizing webhook |
 | capabilities.admissionController.mutatingWebhook.hpaRightsizingWebhookPath | string | `"/webhook/rightsizing/hpa"` | Path for the HPA rightsizing webhook |
+| capabilities.admissionController.mutatingWebhook.scaledObjectRightsizingWebhookPath | string | `"/webhook/rightsizing/scaledobject"` | Path for the KEDA ScaledObject rightsizing webhook |
 | capabilities.admissionController.mutatingWebhook.caBundle | string | using the kube-root-ca.crt ConfigMap in the kube-system namespace | CA bundle for the mutating webhook configuration. It should match the webhook server CA. |
 | capabilities.admissionController.mutatingWebhook.allowOnAKSManagedNamespaces | bool | `true` | Allow mutating webhook to be called for pods in AKS-managed namespaces (See also: https://learn.microsoft.com/en-us/azure/aks/faq#can-admission-controller-webhooks-affect-kube-system-and-internal-aks-namespaces-) |
 | capabilities.admissionController.binpacking | object | See sub-values | Configure the binpacking capabilities for the admission controller |

--- a/charts/komodor-agent/templates/admission-controller/webhookconfiguration.yaml
+++ b/charts/komodor-agent/templates/admission-controller/webhookconfiguration.yaml
@@ -94,4 +94,24 @@ webhooks:
       - "v1"
     sideEffects: None
     timeoutSeconds: {{ .Values.capabilities.admissionController.mutatingWebhook.timeoutSeconds | default 5 }}
+  - name: scaledobject.rightsizing.komodor.com
+    clientConfig:
+      service:
+        name: {{ include "komodorAgent.admissionController.serviceName" . }}
+        namespace: {{ .Release.Namespace }}
+        path: {{ .Values.capabilities.admissionController.mutatingWebhook.scaledObjectRightsizingWebhookPath | default "/webhook/rightsizing/scaledobject" }}
+        port: {{ include "komodorAgent.admissionController.servicePort" . }}
+      caBundle: {{ .Values.capabilities.admissionController.mutatingWebhook.caBundle | default $certList._2 }}
+    rules:
+      - operations: [ "CREATE" ]
+        apiGroups: [ "keda.sh" ]
+        apiVersions: [ "v1alpha1" ]
+        resources: [ "scaledobjects" ]
+        scope: "Namespaced"
+    failurePolicy: Ignore
+    namespaceSelector: null
+    admissionReviewVersions:
+      - "v1"
+    sideEffects: None
+    timeoutSeconds: {{ .Values.capabilities.admissionController.mutatingWebhook.timeoutSeconds | default 5 }}
 {{- end }}

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -235,6 +235,8 @@ capabilities:
       podRightsizingWebhookPath: /webhook/rightsizing/pod
       # capabilities.admissionController.mutatingWebhook.hpaRightsizingWebhookPath -- (string) Path for the HPA rightsizing webhook
       hpaRightsizingWebhookPath: /webhook/rightsizing/hpa
+      # capabilities.admissionController.mutatingWebhook.scaledObjectRightsizingWebhookPath -- (string) Path for the KEDA ScaledObject rightsizing webhook
+      scaledObjectRightsizingWebhookPath: /webhook/rightsizing/scaledobject
       # capabilities.admissionController.mutatingWebhook.caBundle -- (string) CA bundle for the mutating webhook configuration. It should match the webhook server CA.
       # @default -- using the kube-root-ca.crt ConfigMap in the kube-system namespace
       caBundle:


### PR DESCRIPTION
## Summary
- New mutating webhook entry `scaledobject.rightsizing.komodor.com` →
  `/webhook/rightsizing/scaledobject` (CREATE on `keda.sh/v1alpha1/scaledobjects`).
- New `scaledObjectRightsizingWebhookPath` value, parallel to the existing
  pod/HPA paths.
- ClusterRole `keda.sh/scaledobjects` rule was already present — untouched.