### PR TITLE
CU-86c9pk6bj - chore(tests): allow-list known-transient k8s-watcher error logs

### DIFF
--- a/.buildkite/tests/helpers/kubernetes_helper.py
+++ b/.buildkite/tests/helpers/kubernetes_helper.py
@@ -5,6 +5,27 @@ from kubernetes import client
 from config import NAMESPACE
 
 
+# Error-level log messages from k8s-watcher that should NOT fail tests. 
+# Each entry is a list of substrings; a log line is
+# ignored when ALL substrings in any one entry are present in json_log["msg"].
+# Always include a brief comment on each entry explaining why it's safe to
+# ignore so future readers can prune the list when the underlying issue is
+# fixed.
+IGNORED_ERROR_LOG_SUBSTRINGS: list[list[str]] = [
+    # Expected during agent startup before backend registration completes.
+    ["Failed to run task", "failed with HTTP status 404"],
+    # Not in BE cache during agent startup.
+    ["failed to push RBAC data to agents-service"],
+]
+
+
+def _is_ignored_error_msg(msg: str) -> bool:
+    return any(
+        all(sub in msg for sub in patterns)
+        for patterns in IGNORED_ERROR_LOG_SUBSTRINGS
+    )
+
+
 def check_pods_running(kube_client, label_selector):
     pods = kube_client.list_pod_for_all_namespaces(label_selector=label_selector)
     if len(pods.items) == 0:
@@ -137,10 +158,12 @@ def look_for_errors_in_pod_log(pod_name, container_name="k8s-watcher"):
         if not line.startswith("{"):
             continue
         json_log = json.loads(line)
-        if "level" in json_log and json_log["level"] == "error":
-            if "Failed to run task" in json_log["msg"] and "failed with HTTP status 404" in json_log["msg"]:
-                continue # this is expected when the agent is starting up
-            assert False, f"Found error in logs of {pod_name}\nLog: {json_log['msg']}"
+        if json_log.get("level") != "error":
+            continue
+        msg = json_log.get("msg", "")
+        if _is_ignored_error_msg(msg):
+            continue
+        assert False, f"Found error in logs of {pod_name}\nLog: {msg}"
 
 
 def rollout_restart_and_wait(deployment_name, namespace):


### PR DESCRIPTION
## Motivation
Integration tests using `look_for_errors_in_pod_log` (e.g. `basic_test.py`, `legacy_k8s_versions_test.py`) fail whenever the `k8s-watcher` container emits an error-level structured log line. Some of those error lines are known-transient during agent startup and should not fail the suite. A second such line — `"failed to push RBAC data to agents-service"` — needs to be added to the allow-list, and we expect more in the future.

## Changelog
**Test infrastructure:**
- Refactor `look_for_errors_in_pod_log` in `.buildkite/tests/helpers/kubernetes_helper.py` to consume a module-level `IGNORED_ERROR_LOG_SUBSTRINGS` constant.
- Each entry is a list of substrings; a log line is ignored when **all** substrings in any one entry are present in `json_log["msg"]` (AND within an entry, OR across entries).
- Each entry carries a short comment explaining why it is safe to ignore so future readers can prune the list when the underlying issue is fixed.
- Add `"failed to push RBAC data to agents-service"` to the allow-list (transient during agent startup before agents-service is reachable).
- The existing `"Failed to run task" + "failed with HTTP status 404"` entry is preserved as the first entry.
- Adding the next ignored line is now a one-entry data change, no function-body edits required.

## Testing coverage
- [x] Manual testing — standalone Python check of the matcher confirms it returns `True` for both currently-listed transient errors and `False` for unrelated errors and partial matches.
- [x] Automated testing — covered indirectly by existing pytest suites (`basic_test.py`, `legacy_k8s_versions_test.py`) that call `look_for_errors_in_pod_log`. Will run on Buildkite.
- [ ] E2E testing — `make basic_test` from `.buildkite/tests/` (KIND-based) once CI runs.