### PR TITLE
CU-86c9r7g90 - Add optional agent sandbox pod

### DIFF
--- a/.buildkite/tests/values_components_test.py
+++ b/.buildkite/tests/values_components_test.py
@@ -1,7 +1,8 @@
 import pytest
+import yaml
 
 from config import RELEASE_NAME
-from helpers.helm_helper import get_yaml_from_helm_template
+from helpers.helm_helper import get_yaml_from_helm_template, helm_agent_template
 from helpers.utils import get_filename_as_cluster_name
 
 CLUSTER_NAME = get_filename_as_cluster_name(__file__)
@@ -37,7 +38,8 @@ def run_label_test(set_path, value, deployment_name, resource_type, capability_t
     ("components.komodorDaemonWindows.labels.test", "test_value", f"{RELEASE_NAME}-komodor-agent-daemon-windows",
      "DaemonSet", None),
     ("components.komodorMetrics.labels.test", "test_value", f"{RELEASE_NAME}-komodor-agent-metrics", "Deployment", None),
-    ("components.komodorKubectlProxy.labels.test", "test_value", f"{RELEASE_NAME}-komodor-agent-proxy", "Deployment", "kubectlProxy.enabled")
+    ("components.komodorKubectlProxy.labels.test", "test_value", f"{RELEASE_NAME}-komodor-agent-proxy", "Deployment", "kubectlProxy.enabled"),
+    ("components.sandbox.labels.test", "test_value", f"{RELEASE_NAME}-komodor-agent-sandbox", "Deployment", "tasks.sandbox.enabled")
 ])
 def test_user_labels(set_path, value, deployment_name, resource_type, capability_to_enable):
     run_label_test(set_path, value, deployment_name, resource_type, capability_to_enable)
@@ -46,7 +48,8 @@ def test_user_labels(set_path, value, deployment_name, resource_type, capability
 @pytest.mark.parametrize("component_name, deployment_name_suffix, capability_to_enable", [
     ("komodorAgent", "", None),
     ("komodorMetrics", "-metrics", None),
-    ("komodorKubectlProxy", "-proxy", "kubectlProxy.enabled")
+    ("komodorKubectlProxy", "-proxy", "kubectlProxy.enabled"),
+    ("sandbox", "-sandbox", "tasks.sandbox.enabled")
 ])
 def test_override_deployment_tolerations(component_name, deployment_name_suffix, capability_to_enable):
     values_file = f"""
@@ -73,7 +76,8 @@ def test_override_deployment_tolerations(component_name, deployment_name_suffix,
 @pytest.mark.parametrize("component_name, deployment_name_suffix, capability_to_enable", [
     ("komodorAgent", "", None),
     ("komodorMetrics", "-metrics", None),
-    ("komodorKubectlProxy", "-proxy", "kubectlProxy.enabled")
+    ("komodorKubectlProxy", "-proxy", "kubectlProxy.enabled"),
+    ("sandbox", "-sandbox", "tasks.sandbox.enabled")
 ])
 def test_override_deployment_node_selector(component_name, deployment_name_suffix, capability_to_enable):
     set_path = f"components.{component_name}.nodeSelector.test_node_selector"
@@ -92,7 +96,8 @@ def test_override_deployment_node_selector(component_name, deployment_name_suffi
 @pytest.mark.parametrize("component_name, deployment_name_suffix, capability_to_enable", [
     ("komodorAgent", "", None),
     ("komodorMetrics", "-metrics", None),
-    ("komodorKubectlProxy", "-proxy", "kubectlProxy.enabled")
+    ("komodorKubectlProxy", "-proxy", "kubectlProxy.enabled"),
+    ("sandbox", "-sandbox", "tasks.sandbox.enabled")
 ])
 def test_override_deployment_annotations(component_name, deployment_name_suffix, capability_to_enable):
     set_path = f"components.{component_name}.annotations.test"
@@ -111,7 +116,8 @@ def test_override_deployment_annotations(component_name, deployment_name_suffix,
 @pytest.mark.parametrize("component_name, deployment_name_suffix, capability_to_enable", [
     ("komodorAgent", "", None),
     ("komodorMetrics", "-metrics", None),
-    ("komodorKubectlProxy", "-proxy", "kubectlProxy.enabled")
+    ("komodorKubectlProxy", "-proxy", "kubectlProxy.enabled"),
+    ("sandbox", "-sandbox", "tasks.sandbox.enabled")
 ])
 def test_override_deployment_affinity(component_name, deployment_name_suffix, capability_to_enable):
     values_file = f"""
@@ -166,6 +172,48 @@ def test_extra_env_vars(component, location, container, container_index, deploym
     assert  any(env_var["name"] == "TEST_ENV_VAR" for env_var in deployment_env_vars), f"Expected TEST_ENV_VAR in deployment env vars {deployment_env_vars}"
 
 
+def test_sandbox_deployment_disabled_by_default():
+    yaml_templates, exit_code = helm_agent_template()
+    assert exit_code == 0, f"helm template failed, output: {yaml_templates}"
+
+    documents = list(yaml.safe_load_all(yaml_templates))
+    sandbox_deployments = [
+        doc for doc in documents
+        if doc and doc.get("kind") == "Deployment" and
+        doc.get("metadata", {}).get("name") == f"{RELEASE_NAME}-komodor-agent-sandbox"
+    ]
+
+    assert len(sandbox_deployments) == 0, f"Expected sandbox deployment to be disabled by default, got {sandbox_deployments}"
+
+
+def test_sandbox_deployment_enabled_with_configurable_container():
+    values_file = """
+    components:
+      sandbox:
+        image: ghcr.io/komodor/agent-tools:test
+        command: ["bash", "-lc"]
+        args: ["sleep infinity"]
+        env:
+          STATIC_ENV: "static"
+        extraEnvVars:
+          - name: "EXTRA_ENV"
+            value: "extra"
+    """
+
+    deployment_name = f"{RELEASE_NAME}-komodor-agent-sandbox"
+    container = get_yaml_from_helm_template("capabilities.tasks.sandbox.enabled=true", "Deployment", deployment_name,
+                                           "spec.template.spec.containers.0", values_file=values_file)
+
+    assert container["name"] == "komodor-agent-sandbox", f"Expected sandbox container name, got {container}"
+    assert container["image"] == "ghcr.io/komodor/agent-tools:test", f"Expected custom sandbox image, got {container}"
+    assert container["command"] == ["bash", "-lc"], f"Expected custom sandbox command, got {container}"
+    assert container["args"] == ["sleep infinity"], f"Expected custom sandbox args, got {container}"
+    assert any(env_var["name"] == "STATIC_ENV" and env_var["value"] == "static" for env_var in container["env"]), \
+        f"Expected STATIC_ENV in env vars {container['env']}"
+    assert any(env_var["name"] == "EXTRA_ENV" and env_var["value"] == "extra" for env_var in container["env"]), \
+        f"Expected EXTRA_ENV in env vars {container['env']}"
+
+
 @pytest.mark.parametrize("component_name, resource_kind, deployment_name_suffix, capability_to_enable", [
     ("komodorAgent",       "Deployment", "",       None),
     ("komodorMetrics",     "Deployment", "-metrics", None),
@@ -197,7 +245,8 @@ def test_override_security_context(component_name, resource_kind, deployment_nam
     ("komodorAgent",       "Deployment", "",        None),
     ("komodorMetrics",     "Deployment", "-metrics", None),
     ("komodorDaemon",      "DaemonSet",  "-daemon",  None),
-    ("komodorKubectlProxy","Deployment", "-proxy",   "kubectlProxy.enabled")
+    ("komodorKubectlProxy","Deployment", "-proxy",   "kubectlProxy.enabled"),
+    ("sandbox",            "Deployment", "-sandbox", "tasks.sandbox.enabled")
 ])
 def test_override_pod_security_context(component_name, resource_kind, resource_name_suffix, capability_to_enable):
     """Tests that podSecurityContext is applied at pod level and takes precedence over the deprecated securityContext."""
@@ -321,6 +370,18 @@ def test_override_pod_security_context(component_name, resource_kind, resource_n
              capabilities:
                drop:
                  - ALL
+     """,
+     "spec.template.spec.containers.0.securityContext"),
+    ("Deployment", "-sandbox", "tasks.sandbox.enabled",
+     """
+     components:
+       sandbox:
+         containerSecurityContext:
+           allowPrivilegeEscalation: false
+           runAsUser: 1500
+           capabilities:
+             drop:
+               - ALL
      """,
      "spec.template.spec.containers.0.securityContext"),
 ])

--- a/.buildkite/tests/values_components_test.py
+++ b/.buildkite/tests/values_components_test.py
@@ -198,6 +198,9 @@ def test_sandbox_deployment_enabled_with_configurable_container():
         extraEnvVars:
           - name: "EXTRA_ENV"
             value: "extra"
+        service:
+          port: 9090
+          targetPort: 9091
     """
 
     deployment_name = f"{RELEASE_NAME}-komodor-agent-sandbox"
@@ -212,6 +215,21 @@ def test_sandbox_deployment_enabled_with_configurable_container():
         f"Expected STATIC_ENV in env vars {container['env']}"
     assert any(env_var["name"] == "EXTRA_ENV" and env_var["value"] == "extra" for env_var in container["env"]), \
         f"Expected EXTRA_ENV in env vars {container['env']}"
+    assert container["ports"][0]["containerPort"] == 9091, f"Expected custom target port, got {container}"
+
+    service = get_yaml_from_helm_template("capabilities.tasks.sandbox.enabled=true", "Service", deployment_name,
+                                          "spec", values_file=values_file)
+    assert service["ports"][0]["port"] == 9090, f"Expected custom service port, got {service}"
+    assert service["ports"][0]["targetPort"] == "http", f"Expected named targetPort, got {service}"
+
+    watcher_env = get_yaml_from_helm_template("capabilities.tasks.sandbox.enabled=true", "Deployment",
+                                              f"{RELEASE_NAME}-komodor-agent",
+                                              "spec.template.spec.containers.0.env", values_file=values_file)
+    assert any(
+        env_var["name"] == "SANDBOX_API_URL" and
+        env_var["value"] == f"http://{RELEASE_NAME}-komodor-agent-sandbox:9090"
+        for env_var in watcher_env
+    ), f"Expected SANDBOX_API_URL in watcher env vars {watcher_env}"
 
 
 @pytest.mark.parametrize("component_name, resource_kind, deployment_name_suffix, capability_to_enable", [

--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -287,22 +287,28 @@ Relevant values:
 | components.komodorKubectlProxy.securityContext | object | `{}` | DEPRECATED: use podSecurityContext instead. Kept as a fallback for backward compatibility with pod-level securityContext. |
 | components.komodorKubectlProxy.containerSecurityContext | object | `{}` | Set container-level securityContext for the komodor kubectl proxy container. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
 | components.komodorKubectlProxy.strategy | object | `{}` | Set the rolling update strategy for the komodor kubectl proxy deployment |
-| components.sandbox | object | See sub-values | Configure the reusable sandbox pod for sandbox-bash-command tasks |
-| components.sandbox.image | string | `"bash:5.2"` | Sandbox pod image used by sandbox-bash-command tasks. The image must include bash. |
-| components.sandbox.pullPolicy | string | `"IfNotPresent"` | Image pull policy for the sandbox pod |
-| components.sandbox.command | list | `["bash","-lc"]` | Container command for keeping the reusable sandbox pod warm |
-| components.sandbox.args | list | `["trap : TERM INT; sleep infinity & wait"]` | Container args for keeping the reusable sandbox pod warm |
-| components.sandbox.env | object | `{}` | Static environment variables for the sandbox pod |
-| components.sandbox.extraEnvVars | list | `[]` | List of additional environment variables for the sandbox pod |
-| components.sandbox.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"25m","memory":"64Mi"}}` | Set resources for the sandbox pod |
-| components.sandbox.annotations | object | `{}` | Set annotations for the sandbox deployment |
-| components.sandbox.podAnnotations | object | `{}` | Set annotations for the sandbox pod |
-| components.sandbox.labels | object | `{}` | Set additional labels for the sandbox pod and deployment |
-| components.sandbox.nodeSelector | object | `{}` | Set node selector for the sandbox pod |
-| components.sandbox.tolerations | list | `[]` | Set tolerations for the sandbox pod |
-| components.sandbox.affinity | object | `{}` | Set affinity for the sandbox pod |
-| components.sandbox.podSecurityContext | object | `{}` | Set custom pod-level securityContext for the sandbox pod. (use with caution) |
-| components.sandbox.containerSecurityContext | object | `{"allowPrivilegeEscalation":false}` | Set container-level securityContext for the sandbox container. (use with caution) |
+| components.sandbox | object | See sub-values | Configure the sandbox API deployment used by sandbox-bash-command tasks |
+| components.sandbox.replicas | int | `1` | Number of sandbox API replicas. Keep at 1 unless the sandbox API uses shared session state or sticky routing. |
+| components.sandbox.image | string | `"public.ecr.aws/komodor-public/komodor-agent-sandbox:latest"` | Sandbox API image. The image receives agent HTTP requests and manages sandbox lifecycle/reuse. |
+| components.sandbox.pullPolicy | string | `"IfNotPresent"` | Image pull policy for the sandbox API pod |
+| components.sandbox.command | list | `[]` | Optional container command override for the sandbox API pod |
+| components.sandbox.args | list | `[]` | Optional container args override for the sandbox API pod |
+| components.sandbox.service | object | See sub-values | Configure the sandbox API service |
+| components.sandbox.service.type | string | `"ClusterIP"` | Sandbox API service type |
+| components.sandbox.service.port | int | `8080` | Sandbox API service port |
+| components.sandbox.service.targetPort | int | `8080` | Sandbox API container port |
+| components.sandbox.service.annotations | object | `{}` | Set annotations for the sandbox API service |
+| components.sandbox.env | object | `{}` | Static environment variables for the sandbox API pod |
+| components.sandbox.extraEnvVars | list | `[]` | List of additional environment variables for the sandbox API pod |
+| components.sandbox.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"25m","memory":"64Mi"}}` | Set resources for the sandbox API pod |
+| components.sandbox.annotations | object | `{}` | Set annotations for the sandbox API deployment |
+| components.sandbox.podAnnotations | object | `{}` | Set annotations for the sandbox API pod |
+| components.sandbox.labels | object | `{}` | Set additional labels for the sandbox API pod and deployment |
+| components.sandbox.nodeSelector | object | `{}` | Set node selector for the sandbox API pod |
+| components.sandbox.tolerations | list | `[]` | Set tolerations for the sandbox API pod |
+| components.sandbox.affinity | object | `{}` | Set affinity for the sandbox API pod |
+| components.sandbox.podSecurityContext | object | `{}` | Set custom pod-level securityContext for the sandbox API pod. (use with caution) |
+| components.sandbox.containerSecurityContext | object | `{"allowPrivilegeEscalation":false}` | Set container-level securityContext for the sandbox API container. (use with caution) |
 | components.admissionController | object | See sub-values | Configure the komodor admission controller component |
 | components.admissionController.replicas | int | `2` | Number of replicas for the admission controller deployment |
 | components.admissionController.serviceAccount | object | see sub-values | Configure the service account for the admission controller |

--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -217,6 +217,8 @@ Relevant values:
 | capabilities.tasks | object | See sub-values | Configure the agent task capabilities |
 | capabilities.tasks.httpRequests | object | See sub-values | Configure HTTP request capabilities |
 | capabilities.tasks.httpRequests.skipTlsVerify | bool | `false` | Skip TLS certificate verification for HTTP requests (sets HTTP_REQUESTS_SKIP_TLS_VERIFY environment variable) |
+| capabilities.tasks.sandbox | object | See sub-values | Configure reusable sandbox pod for bash command tasks |
+| capabilities.tasks.sandbox.enabled | bool | `false` | Deploy a reusable sandbox pod for sandbox-bash-command tasks |
 | capabilities.tunnel | object | See sub-values | Configure the WebSocket tunnel feature |
 | capabilities.tunnel.enabled | bool | `true` | Enable the network tunnel for remote WebSocket connections |
 | capabilities.tunnel.whitelist | list | `[]` | Allowed destinations for tunnel connections (empty = allow all) If no entries are configured, all destinations are allowed (default-allow). Entries can be:   - CIDR ranges (e.g. "10.0.0.0/8") — any port, matched against resolved IPs   - "host:port" pairs (e.g. "myservice:8080") — exact match   - plain hosts (e.g. "myservice") — any port on that host |
@@ -285,6 +287,22 @@ Relevant values:
 | components.komodorKubectlProxy.securityContext | object | `{}` | DEPRECATED: use podSecurityContext instead. Kept as a fallback for backward compatibility with pod-level securityContext. |
 | components.komodorKubectlProxy.containerSecurityContext | object | `{}` | Set container-level securityContext for the komodor kubectl proxy container. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
 | components.komodorKubectlProxy.strategy | object | `{}` | Set the rolling update strategy for the komodor kubectl proxy deployment |
+| components.sandbox | object | See sub-values | Configure the reusable sandbox pod for sandbox-bash-command tasks |
+| components.sandbox.image | string | `"bash:5.2"` | Sandbox pod image used by sandbox-bash-command tasks. The image must include bash. |
+| components.sandbox.pullPolicy | string | `"IfNotPresent"` | Image pull policy for the sandbox pod |
+| components.sandbox.command | list | `["bash","-lc"]` | Container command for keeping the reusable sandbox pod warm |
+| components.sandbox.args | list | `["trap : TERM INT; sleep infinity & wait"]` | Container args for keeping the reusable sandbox pod warm |
+| components.sandbox.env | object | `{}` | Static environment variables for the sandbox pod |
+| components.sandbox.extraEnvVars | list | `[]` | List of additional environment variables for the sandbox pod |
+| components.sandbox.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"25m","memory":"64Mi"}}` | Set resources for the sandbox pod |
+| components.sandbox.annotations | object | `{}` | Set annotations for the sandbox deployment |
+| components.sandbox.podAnnotations | object | `{}` | Set annotations for the sandbox pod |
+| components.sandbox.labels | object | `{}` | Set additional labels for the sandbox pod and deployment |
+| components.sandbox.nodeSelector | object | `{}` | Set node selector for the sandbox pod |
+| components.sandbox.tolerations | list | `[]` | Set tolerations for the sandbox pod |
+| components.sandbox.affinity | object | `{}` | Set affinity for the sandbox pod |
+| components.sandbox.podSecurityContext | object | `{}` | Set custom pod-level securityContext for the sandbox pod. (use with caution) |
+| components.sandbox.containerSecurityContext | object | `{"allowPrivilegeEscalation":false}` | Set container-level securityContext for the sandbox container. (use with caution) |
 | components.admissionController | object | See sub-values | Configure the komodor admission controller component |
 | components.admissionController.replicas | int | `2` | Number of replicas for the admission controller deployment |
 | components.admissionController.serviceAccount | object | see sub-values | Configure the service account for the admission controller |

--- a/charts/komodor-agent/templates/_helpers.tpl
+++ b/charts/komodor-agent/templates/_helpers.tpl
@@ -105,6 +105,23 @@ app.kubernetes.io/instance: {{ include "komodor.truncatedReleaseName"  . }}-gpu-
 {{ include "komodorAgent.commonLabels" . }}
 {{- end }}
 
+{{- define "sandbox.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "komodorAgent.name" . }}-sandbox
+app.kubernetes.io/instance: {{ include "komodor.truncatedReleaseName"  . }}-sandbox
+app.kubernetes.io/component: sandbox
+{{- end }}
+
+{{- define "sandbox.user.labels" -}}
+{{- if not (empty (((.Values.components).sandbox).labels)) }}
+{{ toYaml .Values.components.sandbox.labels }}
+{{- end }}
+{{- end}}
+
+{{- define "sandbox.labels" -}}
+{{ include "sandbox.selectorLabels" . }}
+{{ include "komodorAgent.commonLabels" . }}
+{{- end }}
+
 {{- define "komodorAgent.user.labels" -}}
 {{- if not (empty (((.Values.components).komodorAgent).labels)) }}
 {{ toYaml .Values.components.komodorAgent.labels }}

--- a/charts/komodor-agent/templates/deployment.yaml
+++ b/charts/komodor-agent/templates/deployment.yaml
@@ -56,3 +56,76 @@ spec:
         {{- include "agent.deploy.volumes" .                | trim | nindent 8 }}
         {{- include "custom-ca.volume" .                    | trim | nindent 8 }}
         {{- include "custom-ca.trusted-volume" .            | trim | nindent 8 }}
+---
+{{- if .Values.capabilities.tasks.sandbox.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "komodorAgent.fullname" . }}-sandbox
+  {{- with .Values.components.sandbox.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "sandbox.labels" . | nindent 4 }}
+    {{- include "sandbox.user.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "sandbox.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "sandbox.selectorLabels" . | nindent 8 }}
+        {{- include "sandbox.user.labels" . | nindent 8 }}
+      {{- with .Values.components.sandbox.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "komodorAgent.serviceAccountName" . }}
+      {{- with .Values.components.sandbox.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.components.sandbox.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      nodeSelector:
+        "kubernetes.io/os": "linux"
+        {{- if not (empty (((.Values.components).sandbox).nodeSelector)) }}
+        {{- toYaml .Values.components.sandbox.nodeSelector | nindent 8 }}
+        {{- end }}
+      {{- with .Values.components.sandbox.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: komodor-agent-sandbox
+          image: {{ .Values.components.sandbox.image }}
+          imagePullPolicy: {{ .Values.components.sandbox.pullPolicy }}
+          command:
+            {{- toYaml .Values.components.sandbox.command | nindent 12 }}
+          args:
+            {{- toYaml .Values.components.sandbox.args | nindent 12 }}
+          {{- if or .Values.components.sandbox.env .Values.components.sandbox.extraEnvVars }}
+          env:
+            {{- range $name, $value := .Values.components.sandbox.env }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- with .Values.components.sandbox.extraEnvVars }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- with .Values.components.sandbox.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.components.sandbox.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/charts/komodor-agent/templates/deployment.yaml
+++ b/charts/komodor-agent/templates/deployment.yaml
@@ -58,6 +58,27 @@ spec:
         {{- include "custom-ca.trusted-volume" .            | trim | nindent 8 }}
 ---
 {{- if .Values.capabilities.tasks.sandbox.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "komodorAgent.fullname" . }}-sandbox
+  {{- with .Values.components.sandbox.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "sandbox.labels" . | nindent 4 }}
+    {{- include "sandbox.user.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.components.sandbox.service.type }}
+  selector:
+    {{- include "sandbox.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.components.sandbox.service.port }}
+      targetPort: http
+      protocol: TCP
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -70,7 +91,7 @@ metadata:
     {{- include "sandbox.labels" . | nindent 4 }}
     {{- include "sandbox.user.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.components.sandbox.replicas }}
   selector:
     matchLabels:
       {{- include "sandbox.selectorLabels" . | nindent 6 }}
@@ -106,10 +127,18 @@ spec:
         - name: komodor-agent-sandbox
           image: {{ .Values.components.sandbox.image }}
           imagePullPolicy: {{ .Values.components.sandbox.pullPolicy }}
+          {{- with .Values.components.sandbox.command }}
           command:
-            {{- toYaml .Values.components.sandbox.command | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.components.sandbox.args }}
           args:
-            {{- toYaml .Values.components.sandbox.args | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.components.sandbox.service.targetPort }}
+              protocol: TCP
           {{- if or .Values.components.sandbox.env .Values.components.sandbox.extraEnvVars }}
           env:
             {{- range $name, $value := .Values.components.sandbox.env }}

--- a/charts/komodor-agent/templates/watcher/_containers.tpl
+++ b/charts/komodor-agent/templates/watcher/_containers.tpl
@@ -41,6 +41,10 @@
   - name: HTTP_REQUESTS_SKIP_TLS_VERIFY
     value: "true"
   {{- end }}
+  {{- if .Values.capabilities.tasks.sandbox.enabled }}
+  - name: SANDBOX_API_URL
+    value: {{ printf "http://%s-sandbox:%v" (include "komodorAgent.fullname" .) .Values.components.sandbox.service.port | quote }}
+  {{- end }}
   {{- if gt (len .Values.components.komodorAgent.watcher.extraEnvVars) 0 }}
   {{ toYaml .Values.components.komodorAgent.watcher.extraEnvVars | nindent 2 }}
   {{- end }}

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -179,6 +179,11 @@ capabilities:
     httpRequests:
       # capabilities.tasks.httpRequests.skipTlsVerify -- (bool) Skip TLS certificate verification for HTTP requests (sets HTTP_REQUESTS_SKIP_TLS_VERIFY environment variable)
       skipTlsVerify: false
+    # capabilities.tasks.sandbox -- Configure reusable sandbox pod for bash command tasks
+    # @default -- See sub-values
+    sandbox:
+      # capabilities.tasks.sandbox.enabled -- (bool) Deploy a reusable sandbox pod for sandbox-bash-command tasks
+      enabled: false
 
   # capabilities.tunnel -- Configure the WebSocket tunnel feature
   # @default -- See sub-values
@@ -367,8 +372,50 @@ components:
     securityContext: {}
     # components.komodorKubectlProxy.containerSecurityContext -- Set container-level securityContext for the komodor kubectl proxy container. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution)
     containerSecurityContext: {}
+
     # components.komodorKubectlProxy.strategy -- Set the rolling update strategy for the komodor kubectl proxy deployment
     strategy: {}
+
+  # components.sandbox -- Configure the reusable sandbox pod for sandbox-bash-command tasks
+  # @default -- See sub-values
+  sandbox:
+    # components.sandbox.image -- Sandbox pod image used by sandbox-bash-command tasks. The image must include bash.
+    image: bash:5.2
+    # components.sandbox.pullPolicy -- Image pull policy for the sandbox pod
+    pullPolicy: IfNotPresent
+    # components.sandbox.command -- Container command for keeping the reusable sandbox pod warm
+    command: ["bash", "-lc"]
+    # components.sandbox.args -- Container args for keeping the reusable sandbox pod warm
+    args: ["trap : TERM INT; sleep infinity & wait"]
+    # components.sandbox.env -- Static environment variables for the sandbox pod
+    env: {}
+    # components.sandbox.extraEnvVars -- List of additional environment variables for the sandbox pod
+    extraEnvVars: []
+    # components.sandbox.resources -- Set resources for the sandbox pod
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 25m
+        memory: 64Mi
+    # components.sandbox.annotations -- Set annotations for the sandbox deployment
+    annotations: {}
+    # components.sandbox.podAnnotations -- Set annotations for the sandbox pod
+    podAnnotations: {}
+    # components.sandbox.labels -- Set additional labels for the sandbox pod and deployment
+    labels: {}
+    # components.sandbox.nodeSelector -- Set node selector for the sandbox pod
+    nodeSelector: {}
+    # components.sandbox.tolerations -- Set tolerations for the sandbox pod
+    tolerations: []
+    # components.sandbox.affinity -- Set affinity for the sandbox pod
+    affinity: {}
+    # components.sandbox.podSecurityContext -- Set custom pod-level securityContext for the sandbox pod. (use with caution)
+    podSecurityContext: {}
+    # components.sandbox.containerSecurityContext -- Set container-level securityContext for the sandbox container. (use with caution)
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
 
   # components.admissionController -- Configure the komodor admission controller component
   # @default -- See sub-values

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -372,7 +372,6 @@ components:
     securityContext: {}
     # components.komodorKubectlProxy.containerSecurityContext -- Set container-level securityContext for the komodor kubectl proxy container. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution)
     containerSecurityContext: {}
-
     # components.komodorKubectlProxy.strategy -- Set the rolling update strategy for the komodor kubectl proxy deployment
     strategy: {}
 

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -375,22 +375,35 @@ components:
     # components.komodorKubectlProxy.strategy -- Set the rolling update strategy for the komodor kubectl proxy deployment
     strategy: {}
 
-  # components.sandbox -- Configure the reusable sandbox pod for sandbox-bash-command tasks
+  # components.sandbox -- Configure the sandbox API deployment used by sandbox-bash-command tasks
   # @default -- See sub-values
   sandbox:
-    # components.sandbox.image -- Sandbox pod image used by sandbox-bash-command tasks. The image must include bash.
-    image: bash:5.2
-    # components.sandbox.pullPolicy -- Image pull policy for the sandbox pod
+    # components.sandbox.replicas -- Number of sandbox API replicas. Keep at 1 unless the sandbox API uses shared session state or sticky routing.
+    replicas: 1
+    # components.sandbox.image -- Sandbox API image. The image receives agent HTTP requests and manages sandbox lifecycle/reuse.
+    image: public.ecr.aws/komodor-public/komodor-agent-sandbox:latest
+    # components.sandbox.pullPolicy -- Image pull policy for the sandbox API pod
     pullPolicy: IfNotPresent
-    # components.sandbox.command -- Container command for keeping the reusable sandbox pod warm
-    command: ["bash", "-lc"]
-    # components.sandbox.args -- Container args for keeping the reusable sandbox pod warm
-    args: ["trap : TERM INT; sleep infinity & wait"]
-    # components.sandbox.env -- Static environment variables for the sandbox pod
+    # components.sandbox.command -- Optional container command override for the sandbox API pod
+    command: []
+    # components.sandbox.args -- Optional container args override for the sandbox API pod
+    args: []
+    # components.sandbox.service -- Configure the sandbox API service
+    # @default -- See sub-values
+    service:
+      # components.sandbox.service.type -- Sandbox API service type
+      type: ClusterIP
+      # components.sandbox.service.port -- Sandbox API service port
+      port: 8080
+      # components.sandbox.service.targetPort -- Sandbox API container port
+      targetPort: 8080
+      # components.sandbox.service.annotations -- Set annotations for the sandbox API service
+      annotations: {}
+    # components.sandbox.env -- Static environment variables for the sandbox API pod
     env: {}
-    # components.sandbox.extraEnvVars -- List of additional environment variables for the sandbox pod
+    # components.sandbox.extraEnvVars -- List of additional environment variables for the sandbox API pod
     extraEnvVars: []
-    # components.sandbox.resources -- Set resources for the sandbox pod
+    # components.sandbox.resources -- Set resources for the sandbox API pod
     resources:
       limits:
         cpu: 500m
@@ -398,21 +411,21 @@ components:
       requests:
         cpu: 25m
         memory: 64Mi
-    # components.sandbox.annotations -- Set annotations for the sandbox deployment
+    # components.sandbox.annotations -- Set annotations for the sandbox API deployment
     annotations: {}
-    # components.sandbox.podAnnotations -- Set annotations for the sandbox pod
+    # components.sandbox.podAnnotations -- Set annotations for the sandbox API pod
     podAnnotations: {}
-    # components.sandbox.labels -- Set additional labels for the sandbox pod and deployment
+    # components.sandbox.labels -- Set additional labels for the sandbox API pod and deployment
     labels: {}
-    # components.sandbox.nodeSelector -- Set node selector for the sandbox pod
+    # components.sandbox.nodeSelector -- Set node selector for the sandbox API pod
     nodeSelector: {}
-    # components.sandbox.tolerations -- Set tolerations for the sandbox pod
+    # components.sandbox.tolerations -- Set tolerations for the sandbox API pod
     tolerations: []
-    # components.sandbox.affinity -- Set affinity for the sandbox pod
+    # components.sandbox.affinity -- Set affinity for the sandbox API pod
     affinity: {}
-    # components.sandbox.podSecurityContext -- Set custom pod-level securityContext for the sandbox pod. (use with caution)
+    # components.sandbox.podSecurityContext -- Set custom pod-level securityContext for the sandbox API pod. (use with caution)
     podSecurityContext: {}
-    # components.sandbox.containerSecurityContext -- Set container-level securityContext for the sandbox container. (use with caution)
+    # components.sandbox.containerSecurityContext -- Set container-level securityContext for the sandbox API container. (use with caution)
     containerSecurityContext:
       allowPrivilegeEscalation: false
 


### PR DESCRIPTION
## Motivation
Deploy a reusable sandbox pod from the agent chart when sandbox bash task execution is enabled.

## Changelog
**Backend Changes:**
- Added `capabilities.tasks.sandbox.enabled` to gate the sandbox workload.
- Added configurable `components.sandbox` image, command, env, resources, scheduling, annotations, and security context values.
- Added sandbox labels that match the agent task executor default selector and regenerated chart README values.

## Testing coverage
- [x] `make validate-readme`
- [x] `helm template komodor-agent charts/komodor-agent -f charts/komodor-agent/values.yaml --set apiKey=sanity --set clusterName=test-template --set capabilities.tasks.sandbox.enabled=true`
- [x] `helm lint charts/komodor-agent --set apiKey=sanity --set clusterName=test-template --set capabilities.tasks.sandbox.enabled=true`

Made with [Cursor](https://cursor.com)