### PR TITLE
CU-86c9ubw69: admission-controller: support extraVolumes for custom mounts (CSI, etc)

### DIFF
--- a/.buildkite/tests/values_components_test.py
+++ b/.buildkite/tests/values_components_test.py
@@ -166,7 +166,7 @@ def test_extra_env_vars(component, location, container, container_index, deploym
     assert  any(env_var["name"] == "TEST_ENV_VAR" for env_var in deployment_env_vars), f"Expected TEST_ENV_VAR in deployment env vars {deployment_env_vars}"
 
 @pytest.mark.parametrize("component_name, resource_kind, deployment_name_suffix", [
-    ("admissionController",       "Deployment", "")
+    ("admissionController",       "Deployment", "-admission-controller")
 ])
 def test_extra_volumes(component_name, resource_kind, deployment_name_suffix):
     values_file = f"""
@@ -174,11 +174,12 @@ def test_extra_volumes(component_name, resource_kind, deployment_name_suffix):
       {component_name}:
         enabled: true
         extraVolumes:
-          - name: extra-volume
-            emptyDir: {{}}
-        extraVolumeMounts:
-          - name: extra-volume
-            mountPath: /extra
+          - volume:
+              name: extra-volume
+              emptyDir: {{}}
+            volumeMount:
+              name: extra-volume
+              mountPath: /extra
     """
     set_command = "test=test"
     resource_name = f"{RELEASE_NAME}-komodor-agent{deployment_name_suffix}"
@@ -187,10 +188,10 @@ def test_extra_volumes(component_name, resource_kind, deployment_name_suffix):
     volumes = get_yaml_from_helm_template(set_command, resource_kind, resource_name,
                                           "spec.template.spec.volumes", values_file=values_file)
 
-    assert len([vm["name"] == "extra-volume" and vm["mountPath"] == "/extra" for vm in volume_mounts]) > 0, \
+    assert any(vm["name"] == "extra-volume" and vm["mountPath"] == "/extra" for vm in volume_mounts), \
         f"Expected extra-volume mount in container volumeMounts {volume_mounts}"
 
-    assert len([v["name"] == "extra-volume" and "emptyDir" in v for v in volumes]) > 0, \
+    assert any(v["name"] == "extra-volume" and "emptyDir" in v for v in volumes), \
         f"Expected extra-volume in pod volumes {volumes}"
 
 @pytest.mark.parametrize("component_name, resource_kind, deployment_name_suffix, capability_to_enable", [

--- a/.buildkite/tests/values_components_test.py
+++ b/.buildkite/tests/values_components_test.py
@@ -61,7 +61,7 @@ def test_override_deployment_tolerations(component_name, deployment_name_suffix,
     set_command = "test=test"
     if capability_to_enable:
         set_command += f" --set capabilities.{capability_to_enable}=true"
-        
+
     deployment_name = f"{RELEASE_NAME}-komodor-agent{deployment_name_suffix}"
     deployment_tolerations = get_yaml_from_helm_template(set_command, "Deployment", deployment_name,
                                                          "spec.template.spec.tolerations", values_file=values_file)
@@ -164,6 +164,33 @@ def test_extra_env_vars(component, location, container, container_index, deploym
                                                       values_file=values_file)
 
     assert  any(env_var["name"] == "TEST_ENV_VAR" for env_var in deployment_env_vars), f"Expected TEST_ENV_VAR in deployment env vars {deployment_env_vars}"
+
+@pytest.mark.parametrize("component_name, resource_kind, deployment_name_suffix", [
+    ("admissionController",       "Deployment", "")
+])
+def test_extra_volumes(component_name, resource_kind, deployment_name_suffix):
+    values_file = f"""
+    components:
+      {component_name}:
+        extraVolumes:
+          - name: extra-volume
+            emptyDir: {{}}
+        extraVolumeMounts:
+          - name: extra-volume
+            mountPath: /extra
+    """
+    set_command = "test=test"
+    resource_name = f"{RELEASE_NAME}-komodor-agent{deployment_name_suffix}"
+    volume_mounts = get_yaml_from_helm_template(set_command, resource_kind, resource_name,
+                                                "spec.template.spec.containers.0.volumeMounts", values_file=values_file)
+    volumes = get_yaml_from_helm_template(set_command, resource_kind, resource_name,
+                                          "spec.template.spec.volumes", values_file=values_file)
+
+    assert any(vm["name"] == "extra-volume" and vm["mountPath"] == "/extra" for vm in volume_mounts), \
+        f"Expected extra-volume mount in container volumeMounts {volume_mounts}"
+
+    assert any(v["name"] == "extra-volume" and "emptyDir" in v for v in volumes), \
+        f"Expected extra-volume in pod volumes {volumes}"
 
 
 @pytest.mark.parametrize("component_name, resource_kind, deployment_name_suffix, capability_to_enable", [

--- a/.buildkite/tests/values_components_test.py
+++ b/.buildkite/tests/values_components_test.py
@@ -172,6 +172,7 @@ def test_extra_volumes(component_name, resource_kind, deployment_name_suffix):
     values_file = f"""
     components:
       {component_name}:
+        enabled: true
         extraVolumes:
           - name: extra-volume
             emptyDir: {{}}
@@ -186,12 +187,11 @@ def test_extra_volumes(component_name, resource_kind, deployment_name_suffix):
     volumes = get_yaml_from_helm_template(set_command, resource_kind, resource_name,
                                           "spec.template.spec.volumes", values_file=values_file)
 
-    assert any(vm["name"] == "extra-volume" and vm["mountPath"] == "/extra" for vm in volume_mounts), \
+    assert len([vm["name"] == "extra-volume" and vm["mountPath"] == "/extra" for vm in volume_mounts]) > 0, \
         f"Expected extra-volume mount in container volumeMounts {volume_mounts}"
 
-    assert any(v["name"] == "extra-volume" and "emptyDir" in v for v in volumes), \
+    assert len([v["name"] == "extra-volume" and "emptyDir" in v for v in volumes]) > 0, \
         f"Expected extra-volume in pod volumes {volumes}"
-
 
 @pytest.mark.parametrize("component_name, resource_kind, deployment_name_suffix, capability_to_enable", [
     ("komodorAgent",       "Deployment", "",       None),

--- a/charts/komodor-agent/templates/admission-controller/deployment.yaml
+++ b/charts/komodor-agent/templates/admission-controller/deployment.yaml
@@ -77,6 +77,9 @@ spec:
             - name: configuration
               mountPath: /etc/komodor
               readOnly: true
+          {{- range .Values.components.admissionController.extraVolumes  }}
+            - {{- toYaml .volumeMount | nindent 14 }}
+          {{- end }}
       volumes:
         - name: webhook-tls
           secret:
@@ -85,6 +88,9 @@ spec:
           configMap:
             name: {{ include "komodorAgent.admissionController.fullname" . }}
             defaultMode: 420
+      {{- range .Values.components.admissionController.extraVolumes }}
+        - {{- toYaml .volume | nindent 10 }}
+      {{- end }}
       {{- with .Values.components.admissionController.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
We have the `extraVolumes` defined in the `values.yaml` but never referenced in templates... this makes it difficult to use CSI Drivers to mount said volumes needed for secret/certificate management...

For example, with values such as:

```yaml
components:
  admissionController:
    extraVolumes:
      - volumeMount:
          name: secrets-store-inline
          mountPath: /mnt/secrets-store
          readOnly: true
        volume:
          name: secrets-store-inline
          csi:
            driver: secrets-store.csi.k8s.io
            readOnly: true
            volumeAttributes:
              secretProviderClass: komodor-api-key-spc
```              

Now Outputs:
```yaml
          volumeMounts:
            - name: webhook-tls
              mountPath: /etc/komodor/admission/tls
              readOnly: true
            - name: configuration
              mountPath: /etc/komodor
              readOnly: true
            -
              mountPath: /mnt/secrets-store
              name: secrets-store-inline
              readOnly: true
      volumes:
        - name: webhook-tls
          secret:
            secretName: komodor-admission-controller-tls
        - name: configuration
          configMap:
            name: release-name-komodor-agent-admission-controller
            defaultMode: 420
        -
          csi:
            driver: secrets-store.csi.k8s.io
            readOnly: true
            volumeAttributes:
              secretProviderClass: komodor-api-key-spc
          name: secrets-store-inline
```

This was also validated via:

```shell
➜  komodor-agent git:(bug/admission-controller-extravolumes) ✗ helm template --set=apiKey=testing-1234 --set=capabilities.admissionController.enabled=true --set=clusterName=bob . | k apply --dry-run=client -f -
priorityclass.scheduling.k8s.io/release-name-daemon-high-priority created (dry run)
priorityclass.scheduling.k8s.io/release-name-agent-high-priority created (dry run)
priorityclass.scheduling.k8s.io/release-name-metrics-high-priority created (dry run)
priorityclass.scheduling.k8s.io/release-name-admission-high-priority created (dry run)
resourcequota/komodor-critical-pods created (dry run)
poddisruptionbudget.policy/release-name-komodor-agent-admission-controller created (dry run)
serviceaccount/release-name-komodor-agent-admission-controller created (dry run)
serviceaccount/release-name-komodor-agent created (dry run)
secret/komodor-admission-controller-tls created (dry run)
secret/komodor-agent-secret created (dry run)
configmap/release-name-komodor-agent-admission-controller created (dry run)
configmap/komodor-agent-config created (dry run)
clusterrole.rbac.authorization.k8s.io/release-name-komodor-agent-admission-controller created (dry run)
clusterrole.rbac.authorization.k8s.io/release-name-komodor-agent-daemon-metrics created (dry run)
clusterrole.rbac.authorization.k8s.io/release-name-komodor-agent-k8s-watcher created (dry run)
clusterrole.rbac.authorization.k8s.io/release-name-komodor-agent-metrics-deployment created (dry run)
clusterrole.rbac.authorization.k8s.io/release-name-komodor-agent-node-enricher created (dry run)
clusterrolebinding.rbac.authorization.k8s.io/release-name-komodor-agent-admission-controller created (dry run)
clusterrolebinding.rbac.authorization.k8s.io/release-name-komodor-agent-daemon-metrics created (dry run)
clusterrolebinding.rbac.authorization.k8s.io/release-name-komodor-agent-k8s-watcher created (dry run)
clusterrolebinding.rbac.authorization.k8s.io/release-name-komodor-agent-metrics-deployment created (dry run)
clusterrolebinding.rbac.authorization.k8s.io/release-name-komodor-agent-node-enricher created (dry run)
service/komodor-admission-controller created (dry run)
service/release-name-komodor-agent-otel-collector created (dry run)
service/release-name-komodor-agent created (dry run)
daemonset.apps/release-name-komodor-agent-daemon created (dry run)
daemonset.apps/release-name-komodor-agent-daemon-windows created (dry run)
deployment.apps/release-name-komodor-agent-admission-controller created (dry run)
deployment.apps/release-name-komodor-agent created (dry run)
deployment.apps/release-name-komodor-agent-metrics created (dry run)
mutatingwebhookconfiguration.admissionregistration.k8s.io/release-name-komodor-agent-admission created (dry run)
```