### PR TITLE
CU-86c9y1utw - ci: validate nginx version sync and auto-build on Dockerfile change

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,6 +31,32 @@ steps:
     if: build.message !~ /feat\(OSS.+\):/i
     retry: *retry
 
+  - label: ":eyeglasses: Validate nginx version sync (Dockerfile ↔ values.yaml)"
+    key: validate-nginx-version
+    command: ./scripts/nginx/validate-version.sh
+    agents:
+      builder: "builder-dind-agent"
+    if: build.message !~ /feat\(OSS.+\):/i
+    retry: *retry
+
+  - label: ":docker: Build & push nginx image (on Dockerfile change)"
+    key: build-push-nginx
+    depends_on: validate-nginx-version
+    commands:
+      - |
+        BASE_BRANCH="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-master}"
+        git fetch -q origin "${BASE_BRANCH}"
+        if git diff --name-only "origin/${BASE_BRANCH}...HEAD" | grep -qx 'scripts/nginx/Dockerfile'; then
+          echo "scripts/nginx/Dockerfile changed — building & pushing"
+          ./scripts/nginx/build-and-push.sh
+        else
+          echo "scripts/nginx/Dockerfile unchanged — skipping build & push"
+        fi
+    agents:
+      builder: "builder-dind-agent"
+    if: build.message !~ /feat\(OSS.+\):/i
+    retry: *retry
+
   - label: ":test_tube: Validations tests"
     commands:
       - cd .buildkite/tests

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,9 +44,10 @@ steps:
     depends_on: validate-nginx-version
     commands:
       - |
+        set -euo pipefail
         BASE_BRANCH="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-master}"
-        git fetch -q origin "${BASE_BRANCH}"
-        if git diff --name-only "origin/${BASE_BRANCH}...HEAD" | grep -qx 'scripts/nginx/Dockerfile'; then
+        git fetch -q origin "$$BASE_BRANCH"
+        if git diff --name-only "origin/$$BASE_BRANCH...HEAD" | grep -qx 'scripts/nginx/Dockerfile'; then
           echo "scripts/nginx/Dockerfile changed — building & pushing"
           ./scripts/nginx/build-and-push.sh
         else

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -47,7 +47,10 @@ steps:
         set -euo pipefail
         BASE_BRANCH="$${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-master}"
         git fetch -q origin "$$BASE_BRANCH"
-        if git diff --name-only "origin/$$BASE_BRANCH...HEAD" | grep -qx 'scripts/nginx/Dockerfile'; then
+        # Capture diff outside the `if` so `set -e` reaches a `git diff` failure
+        # (inside an `if` condition, set -e is disabled and the failure would be masked).
+        CHANGED="$$(git diff --name-only "origin/$$BASE_BRANCH...HEAD")"
+        if echo "$$CHANGED" | grep -qx 'scripts/nginx/Dockerfile'; then
           echo "scripts/nginx/Dockerfile changed — building & pushing"
           ./scripts/nginx/build-and-push.sh
         else

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -45,7 +45,7 @@ steps:
     commands:
       - |
         set -euo pipefail
-        BASE_BRANCH="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-master}"
+        BASE_BRANCH="$${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-master}"
         git fetch -q origin "$$BASE_BRANCH"
         if git diff --name-only "origin/$$BASE_BRANCH...HEAD" | grep -qx 'scripts/nginx/Dockerfile'; then
           echo "scripts/nginx/Dockerfile changed — building & pushing"

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -342,7 +342,7 @@ components:
     # @default -- see sub-values
     image:
       name: nginx
-      tag: 1.30.0-alpine3.23-slim
+      tag: 1.30.1-alpine3.23-slim
     # components.komodorKubectlProxy.resources -- Set custom resources to the komodor kubectl proxy container
     resources: {}
     # components.komodorKubectlProxy.PriorityClassValue -- Set the priority class value for the komodor kubectl proxy deployment

--- a/scripts/nginx/Dockerfile
+++ b/scripts/nginx/Dockerfile
@@ -1,4 +1,3 @@
-ARG NGINX_VERSION=1.30.0-alpine3.23-slim
-FROM nginx:${NGINX_VERSION}
+FROM nginx:1.30.1-alpine3.23-slim
 
 RUN apk add --no-cache openssl

--- a/scripts/nginx/README.md
+++ b/scripts/nginx/README.md
@@ -1,0 +1,34 @@
+# nginx (komodor-agent kubectl proxy)
+
+Build assets for the nginx image used by `komodor-agent`'s `komodorKubectlProxy` component.
+
+The image is multi-arch (`linux/amd64`, `linux/arm64`) and published to:
+
+- `public.ecr.aws/komodor-public/nginx`
+- `komodorio/nginx`
+
+## Prerequisites
+
+- Docker with `buildx` enabled
+- Authenticated to AWS ECR and Docker Hub (e.g. `komo ci docker-login`)
+
+## Build & push
+
+```bash
+bash scripts/nginx/build-and-push.sh
+```
+
+The script creates/uses a buildx builder named `nginx-multiarch`, then builds and pushes both tags in one step.
+
+## Updating the nginx version
+
+Update the version string in **two** places and keep them in sync:
+
+1. `scripts/nginx/Dockerfile` — the `FROM nginx:` line (source of truth at build time; `build-and-push.sh` reads from here)
+2. `charts/komodor-agent/values.yaml` — `components.komodorKubectlProxy.image.tag` (what the chart pulls)
+
+Then run the build script to publish the new image, and open a PR with the two file changes.
+
+Notes:
+
+- Prefer `-alpine*-slim` tags from the [official nginx repo on Docker Hub](https://hub.docker.com/_/nginx/tags).

--- a/scripts/nginx/README.md
+++ b/scripts/nginx/README.md
@@ -22,10 +22,10 @@ Prefer `-alpine*-slim` tags from the [official nginx repo on Docker Hub](https:/
 Prerequisites:
 
 - Docker with `buildx` enabled
-- Authenticated to AWS ECR and Docker Hub (`komo ci docker-login --hub-login true --ecr-login true`)
+- The `komo` CLI (used by the script to authenticate)
 
 ```bash
 bash scripts/nginx/build-and-push.sh
 ```
 
-The script reads the version from `Dockerfile`, creates/uses a buildx builder named `nginx-multiarch`, then builds and pushes both tags.
+The script reads the version from `Dockerfile`, runs `komo ci docker-login --hub-login true --ecr-login true` to authenticate against AWS ECR and Docker Hub, creates/uses a buildx builder named `nginx-multiarch`, then builds and pushes both tags.

--- a/scripts/nginx/README.md
+++ b/scripts/nginx/README.md
@@ -7,28 +7,25 @@ The image is multi-arch (`linux/amd64`, `linux/arm64`) and published to:
 - `public.ecr.aws/komodor-public/nginx`
 - `komodorio/nginx`
 
-## Prerequisites
+## Updating the nginx version
+
+CI publishes the image automatically. To bump the version:
+
+1. Edit `scripts/nginx/Dockerfile` — the `FROM nginx:` line. This is the single source of truth.
+2. Edit `charts/komodor-agent/values.yaml` — `components.komodorKubectlProxy.image.tag` must match the Dockerfile tag.
+3. Open a PR. CI runs `scripts/nginx/validate-version.sh` on every build and fails if the two files disagree. When the PR diff touches the Dockerfile, CI also runs `scripts/nginx/build-and-push.sh` and publishes the new image to both registries.
+
+Prefer `-alpine*-slim` tags from the [official nginx repo on Docker Hub](https://hub.docker.com/_/nginx/tags).
+
+## Local build (rarely needed — CI publishes for you)
+
+Prerequisites:
 
 - Docker with `buildx` enabled
-- Authenticated to AWS ECR and Docker Hub (e.g. `komo ci docker-login`)
-
-## Build & push
+- Authenticated to AWS ECR and Docker Hub (`komo ci docker-login --hub-login true --ecr-login true`)
 
 ```bash
 bash scripts/nginx/build-and-push.sh
 ```
 
-The script creates/uses a buildx builder named `nginx-multiarch`, then builds and pushes both tags in one step.
-
-## Updating the nginx version
-
-Update the version string in **two** places and keep them in sync:
-
-1. `scripts/nginx/Dockerfile` — the `FROM nginx:` line (source of truth at build time; `build-and-push.sh` reads from here)
-2. `charts/komodor-agent/values.yaml` — `components.komodorKubectlProxy.image.tag` (what the chart pulls)
-
-Then run the build script to publish the new image, and open a PR with the two file changes.
-
-Notes:
-
-- Prefer `-alpine*-slim` tags from the [official nginx repo on Docker Hub](https://hub.docker.com/_/nginx/tags).
+The script reads the version from `Dockerfile`, creates/uses a buildx builder named `nginx-multiarch`, then builds and pushes both tags.

--- a/scripts/nginx/build-and-push.sh
+++ b/scripts/nginx/build-and-push.sh
@@ -7,7 +7,7 @@ if ! docker buildx version &> /dev/null; then
 fi
 
 # Authenticate with AWS ECR & Docker Hub
-komo ci docker-login
+komo ci docker-login --hub-login true --ecr-login true
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/scripts/nginx/build-and-push.sh
+++ b/scripts/nginx/build-and-push.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 # check if docker buildx is available
 if ! docker buildx version &> /dev/null; then
@@ -10,11 +11,19 @@ fi
 komo ci docker-login --hub-login true --ecr-login true
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOCKERFILE="${SCRIPT_DIR}/Dockerfile"
 
 # Extract nginx version from the Dockerfile (single source of truth).
-NGINX_VERSION="$(awk -F: '/^FROM nginx:/ {print $2; exit}' "${SCRIPT_DIR}/Dockerfile")"
+# Reject multistage (>1 `FROM nginx:` lines) and unexpected suffixes
+# (` AS build`, `@sha256:...`, etc.).
+matches="$(grep -cE '^FROM[[:space:]]+nginx:' "${DOCKERFILE}")"
+if [ "${matches}" != "1" ]; then
+    echo "ERROR: expected exactly one 'FROM nginx:...' line in ${DOCKERFILE}, found ${matches}" >&2
+    exit 1
+fi
+NGINX_VERSION="$(sed -nE 's/^FROM[[:space:]]+nginx:([A-Za-z0-9._-]+)[[:space:]]*$/\1/p' "${DOCKERFILE}")"
 if [ -z "${NGINX_VERSION}" ]; then
-    echo "Failed to read nginx version from ${SCRIPT_DIR}/Dockerfile"
+    echo "ERROR: 'FROM nginx:' line in ${DOCKERFILE} has an unexpected suffix (e.g. ' AS <stage>' or '@sha256:...'). Use a bare 'FROM nginx:<tag>' line." >&2
     exit 1
 fi
 

--- a/scripts/nginx/build-and-push.sh
+++ b/scripts/nginx/build-and-push.sh
@@ -7,10 +7,16 @@ if ! docker buildx version &> /dev/null; then
 fi
 
 # Authenticate with AWS ECR & Docker Hub
-# komo ci docker-login
+komo ci docker-login
 
-NGINX_VERSION="1.29.8-alpine3.23-slim"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Extract nginx version from the Dockerfile (single source of truth).
+NGINX_VERSION="$(awk -F: '/^FROM nginx:/ {print $2; exit}' "${SCRIPT_DIR}/Dockerfile")"
+if [ -z "${NGINX_VERSION}" ]; then
+    echo "Failed to read nginx version from ${SCRIPT_DIR}/Dockerfile"
+    exit 1
+fi
 
 # Create/use buildx builder for multi-platform builds
 BUILDER_NAME="nginx-multiarch"
@@ -23,7 +29,6 @@ fi
 # Build and push multi-arch image to both registries
 docker buildx build \
     --platform linux/amd64,linux/arm64 \
-    --build-arg NGINX_VERSION=${NGINX_VERSION} \
     --tag public.ecr.aws/komodor-public/nginx:${NGINX_VERSION} \
     --tag komodorio/nginx:${NGINX_VERSION} \
     --push \

--- a/scripts/nginx/build-and-push.sh
+++ b/scripts/nginx/build-and-push.sh
@@ -16,7 +16,7 @@ DOCKERFILE="${SCRIPT_DIR}/Dockerfile"
 # Extract nginx version from the Dockerfile (single source of truth).
 # Reject multistage (>1 `FROM nginx:` lines) and unexpected suffixes
 # (` AS build`, `@sha256:...`, etc.).
-matches="$(grep -cE '^FROM[[:space:]]+nginx:' "${DOCKERFILE}")"
+matches="$(grep -cE '^FROM[[:space:]]+nginx:' "${DOCKERFILE}" || true)"
 if [ "${matches}" != "1" ]; then
     echo "ERROR: expected exactly one 'FROM nginx:...' line in ${DOCKERFILE}, found ${matches}" >&2
     exit 1
@@ -29,16 +29,16 @@ fi
 
 # Create/use buildx builder for multi-platform builds
 BUILDER_NAME="nginx-multiarch"
-if ! docker buildx inspect ${BUILDER_NAME} &> /dev/null; then
-    docker buildx create --name ${BUILDER_NAME} --use
+if ! docker buildx inspect "${BUILDER_NAME}" &> /dev/null; then
+    docker buildx create --name "${BUILDER_NAME}" --use
 else
-    docker buildx use ${BUILDER_NAME}
+    docker buildx use "${BUILDER_NAME}"
 fi
 
 # Build and push multi-arch image to both registries
 docker buildx build \
     --platform linux/amd64,linux/arm64 \
-    --tag public.ecr.aws/komodor-public/nginx:${NGINX_VERSION} \
-    --tag komodorio/nginx:${NGINX_VERSION} \
+    --tag "public.ecr.aws/komodor-public/nginx:${NGINX_VERSION}" \
+    --tag "komodorio/nginx:${NGINX_VERSION}" \
     --push \
     "${SCRIPT_DIR}"

--- a/scripts/nginx/validate-version.sh
+++ b/scripts/nginx/validate-version.sh
@@ -1,20 +1,33 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if ! command -v yq >/dev/null 2>&1; then
+    echo "ERROR: yq not installed; install mikefarah/yq v4+ (https://github.com/mikefarah/yq)" >&2
+    exit 1
+fi
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DOCKERFILE="${REPO_ROOT}/scripts/nginx/Dockerfile"
 VALUES="${REPO_ROOT}/charts/komodor-agent/values.yaml"
 
-dockerfile_version="$(awk -F: '/^FROM nginx:/ {print $2; exit}' "${DOCKERFILE}")"
+# Extract nginx version from the Dockerfile.
+# Reject multistage (>1 `FROM nginx:` lines) and unexpected suffixes
+# (` AS build`, `@sha256:...`, etc.).
+matches="$(grep -cE '^FROM[[:space:]]+nginx:' "${DOCKERFILE}")"
+if [ "${matches}" != "1" ]; then
+    echo "ERROR: expected exactly one 'FROM nginx:...' line in ${DOCKERFILE}, found ${matches}" >&2
+    exit 1
+fi
+dockerfile_version="$(sed -nE 's/^FROM[[:space:]]+nginx:([A-Za-z0-9._-]+)[[:space:]]*$/\1/p' "${DOCKERFILE}")"
+if [ -z "${dockerfile_version}" ]; then
+    echo "ERROR: 'FROM nginx:' line in ${DOCKERFILE} has an unexpected suffix (e.g. ' AS <stage>' or '@sha256:...'). Use a bare 'FROM nginx:<tag>' line." >&2
+    exit 1
+fi
 
 # `yq eval` is supported on every mikefarah-yq v4 release, including the
 # v4.2.0 on the CI builder image (which doesn't accept the implicit form).
 values_version="$(yq eval '.components.komodorKubectlProxy.image.tag' "${VALUES}")"
 
-if [ -z "${dockerfile_version}" ]; then
-    echo "ERROR: could not extract nginx version from ${DOCKERFILE}" >&2
-    exit 1
-fi
 if [ -z "${values_version}" ] || [ "${values_version}" = "null" ]; then
     echo "ERROR: could not extract .components.komodorKubectlProxy.image.tag from ${VALUES}" >&2
     exit 1

--- a/scripts/nginx/validate-version.sh
+++ b/scripts/nginx/validate-version.sh
@@ -5,16 +5,11 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DOCKERFILE="${REPO_ROOT}/scripts/nginx/Dockerfile"
 VALUES="${REPO_ROOT}/charts/komodor-agent/values.yaml"
 
-echo "yq: $(yq --version 2>&1 | head -1)"
-
 dockerfile_version="$(awk -F: '/^FROM nginx:/ {print $2; exit}' "${DOCKERFILE}")"
 
-# Try mikefarah-yq v4 / python-yq syntax first; fall back to mikefarah-yq v3
-# (which wants `yq r file '.path'` and errors on the v4 form).
-values_version="$(yq '.components.komodorKubectlProxy.image.tag' "${VALUES}" 2>/dev/null | tr -d '"')" || true
-if [ -z "${values_version}" ] || [ "${values_version}" = "null" ]; then
-    values_version="$(yq r "${VALUES}" '.components.komodorKubectlProxy.image.tag' 2>/dev/null)" || true
-fi
+# `yq eval` is supported on every mikefarah-yq v4 release, including the
+# v4.2.0 on the CI builder image (which doesn't accept the implicit form).
+values_version="$(yq eval '.components.komodorKubectlProxy.image.tag' "${VALUES}")"
 
 if [ -z "${dockerfile_version}" ]; then
     echo "ERROR: could not extract nginx version from ${DOCKERFILE}" >&2

--- a/scripts/nginx/validate-version.sh
+++ b/scripts/nginx/validate-version.sh
@@ -5,12 +5,15 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DOCKERFILE="${REPO_ROOT}/scripts/nginx/Dockerfile"
 VALUES="${REPO_ROOT}/charts/komodor-agent/values.yaml"
 
+echo "yq: $(yq --version 2>&1 | head -1)"
+
 dockerfile_version="$(awk -F: '/^FROM nginx:/ {print $2; exit}' "${DOCKERFILE}")"
-# mikefarah yq v3 wants `yq r file '.path'`; v4 (and python-yq) want `yq '.path' file`.
-if yq --version 2>&1 | grep -qE 'version[[:space:]]+v?3\.'; then
-    values_version="$(yq r "${VALUES}" '.components.komodorKubectlProxy.image.tag')"
-else
-    values_version="$(yq '.components.komodorKubectlProxy.image.tag' "${VALUES}" | tr -d '"')"
+
+# Try mikefarah-yq v4 / python-yq syntax first; fall back to mikefarah-yq v3
+# (which wants `yq r file '.path'` and errors on the v4 form).
+values_version="$(yq '.components.komodorKubectlProxy.image.tag' "${VALUES}" 2>/dev/null | tr -d '"')" || true
+if [ -z "${values_version}" ] || [ "${values_version}" = "null" ]; then
+    values_version="$(yq r "${VALUES}" '.components.komodorKubectlProxy.image.tag' 2>/dev/null)" || true
 fi
 
 if [ -z "${dockerfile_version}" ]; then

--- a/scripts/nginx/validate-version.sh
+++ b/scripts/nginx/validate-version.sh
@@ -13,7 +13,7 @@ VALUES="${REPO_ROOT}/charts/komodor-agent/values.yaml"
 # Extract nginx version from the Dockerfile.
 # Reject multistage (>1 `FROM nginx:` lines) and unexpected suffixes
 # (` AS build`, `@sha256:...`, etc.).
-matches="$(grep -cE '^FROM[[:space:]]+nginx:' "${DOCKERFILE}")"
+matches="$(grep -cE '^FROM[[:space:]]+nginx:' "${DOCKERFILE}" || true)"
 if [ "${matches}" != "1" ]; then
     echo "ERROR: expected exactly one 'FROM nginx:...' line in ${DOCKERFILE}, found ${matches}" >&2
     exit 1

--- a/scripts/nginx/validate-version.sh
+++ b/scripts/nginx/validate-version.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DOCKERFILE="${REPO_ROOT}/scripts/nginx/Dockerfile"
+VALUES="${REPO_ROOT}/charts/komodor-agent/values.yaml"
+
+dockerfile_version="$(awk -F: '/^FROM nginx:/ {print $2; exit}' "${DOCKERFILE}")"
+values_version="$(yq -r '.components.komodorKubectlProxy.image.tag' "${VALUES}")"
+
+if [ -z "${dockerfile_version}" ]; then
+    echo "ERROR: could not extract nginx version from ${DOCKERFILE}" >&2
+    exit 1
+fi
+if [ -z "${values_version}" ] || [ "${values_version}" = "null" ]; then
+    echo "ERROR: could not extract .components.komodorKubectlProxy.image.tag from ${VALUES}" >&2
+    exit 1
+fi
+
+if [ "${dockerfile_version}" != "${values_version}" ]; then
+    echo "ERROR: nginx version mismatch" >&2
+    echo "  ${DOCKERFILE}: ${dockerfile_version}" >&2
+    echo "  ${VALUES} (.components.komodorKubectlProxy.image.tag): ${values_version}" >&2
+    echo "Update both files to the same tag." >&2
+    exit 1
+fi
+
+echo "nginx version OK: ${dockerfile_version} (Dockerfile == values.yaml)"

--- a/scripts/nginx/validate-version.sh
+++ b/scripts/nginx/validate-version.sh
@@ -6,7 +6,12 @@ DOCKERFILE="${REPO_ROOT}/scripts/nginx/Dockerfile"
 VALUES="${REPO_ROOT}/charts/komodor-agent/values.yaml"
 
 dockerfile_version="$(awk -F: '/^FROM nginx:/ {print $2; exit}' "${DOCKERFILE}")"
-values_version="$(yq '.components.komodorKubectlProxy.image.tag' "${VALUES}" | tr -d '"')"
+# mikefarah yq v3 wants `yq r file '.path'`; v4 (and python-yq) want `yq '.path' file`.
+if yq --version 2>&1 | grep -qE 'version[[:space:]]+v?3\.'; then
+    values_version="$(yq r "${VALUES}" '.components.komodorKubectlProxy.image.tag')"
+else
+    values_version="$(yq '.components.komodorKubectlProxy.image.tag' "${VALUES}" | tr -d '"')"
+fi
 
 if [ -z "${dockerfile_version}" ]; then
     echo "ERROR: could not extract nginx version from ${DOCKERFILE}" >&2

--- a/scripts/nginx/validate-version.sh
+++ b/scripts/nginx/validate-version.sh
@@ -6,7 +6,7 @@ DOCKERFILE="${REPO_ROOT}/scripts/nginx/Dockerfile"
 VALUES="${REPO_ROOT}/charts/komodor-agent/values.yaml"
 
 dockerfile_version="$(awk -F: '/^FROM nginx:/ {print $2; exit}' "${DOCKERFILE}")"
-values_version="$(yq -r '.components.komodorKubectlProxy.image.tag' "${VALUES}")"
+values_version="$(yq '.components.komodorKubectlProxy.image.tag' "${VALUES}" | tr -d '"')"
 
 if [ -z "${dockerfile_version}" ]; then
     echo "ERROR: could not extract nginx version from ${DOCKERFILE}" >&2


### PR DESCRIPTION
## Summary

- Makes `scripts/nginx/Dockerfile` the single source of truth for the nginx version used by `komodor-agent`'s `komodorKubectlProxy`. `build-and-push.sh` now extracts the version from the Dockerfile and calls `komo ci docker-login` so it can run unattended in CI.
- Adds `scripts/nginx/validate-version.sh` — fails CI if the `FROM nginx:<tag>` in the Dockerfile drifts from `.components.komodorKubectlProxy.image.tag` in `charts/komodor-agent/values.yaml`.
- Wires two Buildkite steps into `.buildkite/pipeline.yml`:
  - **Validate nginx version sync** — runs on every build; cheap drift guard in both directions.
  - **Build & push nginx image** — `depends_on` the validator, only fires when the PR diff touches `scripts/nginx/Dockerfile`.

Future nginx bumps are one-line edits to `scripts/nginx/Dockerfile` + the matching `values.yaml` tag; CI publishes the image and fails if either side is forgotten.

## Note on publish scope

The `Build & push nginx image` step is **intentionally not gated on `build.branch == "master"`** — by design, a new nginx version is built and pushed **both** on the PR branch (every commit that touches `scripts/nginx/Dockerfile`) and on master after merge. This lets reviewers test the freshly published image during the PR cycle. The tag is immutable per-version, so re-pushing the same `1.30.x-alpine…` content is idempotent.

## Test plan

- [x] Buildkite: `Validate nginx version sync` step passes on this PR (Dockerfile and values.yaml both at `1.30.1-alpine3.23-slim`).
- [x] Buildkite: `Build & push nginx image` step triggers (Dockerfile is in the diff) and publishes `public.ecr.aws/komodor-public/nginx:1.30.1-alpine3.23-slim` + `komodorio/nginx:1.30.1-alpine3.23-slim`.
- [x] Manually verify negative case: push a follow-up commit that bumps the Dockerfile only — validator step should fail with a diagnostic naming both files.
- [x] Manually verify negative case (other direction): bump only `values.yaml` — validator should fail too.
- [x] Existing helm-template / readme / test suites still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
