### PR TITLE
CU-86c9wpx3t chore: bump admission-controller to 0.1.55

### DIFF
--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -157,7 +157,7 @@ Relevant values:
 | global.securityContext | object | `{}` | Set a container-level securityContext applied to all containers unless a container-specific securityContext is defined. Supports container fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
 | telegrafImageVersion | string | `"v2.0.53-alpine"` | Telegraf version to be used |
 | telegrafWindowsImageVersion | string | `"v2.0.53"` | Telegraf version to be used for windows |
-| admissionControllerVersion | string | `"0.1.54"` | Admission controller version to be used |
+| admissionControllerVersion | string | `"0.1.55"` | Admission controller version to be used |
 | serviceAccount | object | See sub-values | Configure service account for the agent |
 | serviceAccount.create | bool | `true` | Creates a service account for the agent |
 | serviceAccount.name | string | `nil` | Name of the service account, Required if `serviceAccount.create` is false |

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -28,7 +28,7 @@ telegrafImageVersion: &telegrafVersion v2.0.53-alpine
 # telegrafWindowsImageVersion -- (string) Telegraf version to be used for windows
 telegrafWindowsImageVersion: &telegrafWindowsVersion v2.0.53
 # admissionControllerVersion -- (string) Admission controller version to be used
-admissionControllerVersion: &acVersion 0.1.54
+admissionControllerVersion: &acVersion 0.1.55
 
 # serviceAccount -- Configure service account for the agent
 # @default -- See sub-values


### PR DESCRIPTION
## Motivation
Bump admission-controller image version from 0.1.54 to 0.1.55.

## Changelog
**Changes:**
- Bump `admissionControllerVersion` from `0.1.54` to `0.1.55` in `charts/komodor-agent/values.yaml`