### PR TITLE
CU-86c7vretk chore: refine AC readiness

### DIFF
--- a/charts/komodor-agent/templates/admission-controller/deployment.yaml
+++ b/charts/komodor-agent/templates/admission-controller/deployment.yaml
@@ -42,7 +42,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /healthz
+              path: /livez
               port: https
               scheme: HTTPS
             initialDelaySeconds: 60

--- a/charts/komodor-agent/templates/admission-controller/deployment.yaml
+++ b/charts/komodor-agent/templates/admission-controller/deployment.yaml
@@ -45,13 +45,17 @@ spec:
               path: /healthz
               port: https
               scheme: HTTPS
+            initialDelaySeconds: 60
+            periodSeconds: 600
+            timeoutSeconds: 5
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /readyz
               port: https
               scheme: HTTPS
             initialDelaySeconds: 30
-            periodSeconds: 10
+            periodSeconds: 30
             timeoutSeconds: 3
             failureThreshold: 2
           resources:

--- a/charts/komodor-agent/templates/admission-controller/deployment.yaml
+++ b/charts/komodor-agent/templates/admission-controller/deployment.yaml
@@ -47,9 +47,13 @@ spec:
               scheme: HTTPS
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /readyz
               port: https
               scheme: HTTPS
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 2
           resources:
             {{- toYaml .Values.components.admissionController.resources | nindent 12 }}
           env:


### PR DESCRIPTION
* split admission-controller probes per the [k8s convention](https://kubernetes.io/docs/reference/using-api/health-checks/):
  * **`livenessProbe`** → `/livez` (new endpoint backed by the v2 evaluator)
  * **`readinessProbe`** → `/readyz` (new endpoint backed by the v2 evaluator)
  * **`/healthz`** kept as-is on the AC side for backward compatibility with any existing manifests still pointing at it; this chart no longer references it
* probe timing aligned with the v2 escalation hierarchy (k8s probe cadence — not handler logic — differentiates liveness from readiness):
  * **readiness**: `periodSeconds=30`, `failureThreshold=2`, `initialDelaySeconds=30`, `timeoutSeconds=3` — ~1 min to remove from Service endpoints
  * **liveness**: `periodSeconds=600`, `failureThreshold=3`, `initialDelaySeconds=60`, `timeoutSeconds=5` — ~30 min to restart (last-resort recovery)
* readiness/liveness conditions evaluated by the AC (per the AC PR): leader = "recently synced with BE", follower = "recently synced with leader's state server", plus Komodor backend reachability and (V2-only) node-priorities sync freshness
* must merge AFTER the matching [admission-controller PR](https://github.com/komodorio/admission-controller/pull/291) is merged and a new AC image version is released — the chart points probes at `/livez` and `/readyz`, neither of which exists on prior AC images