### PR TITLE
CU-86ca3c887 - fix: hardcode KOMOKW_COMPONENT to match backend allowlist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ release_notes.txt
 venv/
 **/helm-docs
 .claude/**
+.devswarm-temp/

--- a/charts/komodor-agent/templates/metrics/_containers_daemon.tpl
+++ b/charts/komodor-agent/templates/metrics/_containers_daemon.tpl
@@ -108,7 +108,7 @@
   - name: KOMOKW_RUNTIME_MODE
     value: init
   - name: KOMOKW_COMPONENT
-    value: {{ .Chart.Name  }}-daemon
+    value: komodor-agent-daemon
   - name: NAMESPACE
     value: {{ .Release.Namespace }}
   - name: KOMOKW_API_KEY
@@ -139,7 +139,7 @@
   - name: KOMOKW_RUNTIME_MODE
     value: init
   - name: KOMOKW_COMPONENT
-    value: {{ .Chart.Name  }}-daemon-windows
+    value: komodor-agent-daemon-windows
   - name: NAMESPACE
     value: {{ .Release.Namespace }}
   - name: KOMOKW_API_KEY
@@ -180,7 +180,7 @@
   - name: KOMOKW_RUNTIME_MODE
     value: sidecar
   - name: KOMOKW_COMPONENT
-    value: {{ .Chart.Name  }}-daemon
+    value: komodor-agent-daemon
   - name: NAMESPACE
     value: {{ .Release.Namespace }}
   - name: KOMOKW_API_KEY
@@ -213,7 +213,7 @@
   - name: KOMOKW_RUNTIME_MODE
     value: sidecar
   - name: KOMOKW_COMPONENT
-    value: {{ .Chart.Name  }}-daemon-windows
+    value: komodor-agent-daemon-windows
   - name: NAMESPACE
     value: {{ .Release.Namespace }}
   - name: KOMOKW_API_KEY

--- a/charts/komodor-agent/templates/metrics/_containers_deployment.tpl
+++ b/charts/komodor-agent/templates/metrics/_containers_deployment.tpl
@@ -56,7 +56,7 @@
   - name: KOMOKW_RUNTIME_MODE
     value: sidecar
   - name: KOMOKW_COMPONENT
-    value: {{ .Chart.Name  }}-metrics
+    value: komodor-agent-metrics
   - name: NAMESPACE
     value: {{ .Release.Namespace }}
   - name: KOMOKW_API_KEY
@@ -88,7 +88,7 @@
   - name: KOMOKW_RUNTIME_MODE
     value: init
   - name: KOMOKW_COMPONENT
-    value: {{ .Chart.Name  }}-metrics
+    value: komodor-agent-metrics
   - name: NAMESPACE
     value: {{ .Release.Namespace }}
   - name: KOMOKW_API_KEY

--- a/charts/komodor-agent/templates/opentelemetry/_containers.tpl
+++ b/charts/komodor-agent/templates/opentelemetry/_containers.tpl
@@ -108,7 +108,7 @@
   - name: KOMOKW_RUNTIME_MODE
     value: sidecar
   - name: KOMOKW_COMPONENT
-    value: {{ .Chart.Name }}-opentelemetry
+    value: komodor-agent-opentelemetry
   - name: NAMESPACE
     value: {{ .Release.Namespace }}
   - name: KOMOKW_API_KEY
@@ -143,7 +143,7 @@
   - name: KOMOKW_RUNTIME_MODE
     value: init
   - name: KOMOKW_COMPONENT
-    value: {{ .Chart.Name }}-opentelemetry
+    value: komodor-agent-opentelemetry
   - name: NAMESPACE
     value: {{ .Release.Namespace }}
   - name: KOMOKW_API_KEY


### PR DESCRIPTION
## Summary

The `telegraf_init` binary uses the `KOMOKW_COMPONENT` env var to fetch its remote config from `agents-service`. The backend enforces a **closed allowlist** at the Gin binding level:

```go
Component string `json:"component" binding:"required,oneof=komodor-agent-metrics komodor-agent-daemon komodor-agent-daemon-windows"`
```

The chart templates derived `KOMOKW_COMPONENT` from `.Chart.Name`, so if a customer renamed the chart (fork, vendoring, or local rename), the agent would send something like `my-fork-daemon` and the backend would reject the request at validation — telegraf gets no remote config.

This PR hardcodes `KOMOKW_COMPONENT` to the canonical names in all 4 spots (daemon init/sidecar, daemon-windows init/sidecar, metrics sidecar/init). The opentelemetry KOMOKW_COMPONENT is included as well for consistency, though the otel endpoint (`remote_config_otel`) does not validate component name today.

Also bundles a `.gitignore` addition for `.devswarm-temp/`.

## Test plan

- [x] `helm template` renders the canonical component names regardless of `--name-template` / chart name override
- [x] Confirm with backend team that no other consumer of `KOMOKW_COMPONENT` relies on a chart-derived name
- [x] Verify telegraf can fetch remote config in a cluster installed from a renamed chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)