### PR TITLE
CU-86ca42vgd - feat: support static TLS cert data for admission controller off-cluster rendering

### DIFF
--- a/.buildkite/tests/values_admission_controller_test.py
+++ b/.buildkite/tests/values_admission_controller_test.py
@@ -1,0 +1,60 @@
+import base64
+
+from helpers.helm_helper import get_yaml_from_helm_template, helm_agent_template
+
+TLS_SECRET_NAME = "komodor-admission-controller-tls"
+
+FAKE_TLS_CERT = base64.b64encode(b"test-tls-cert").decode()
+FAKE_TLS_KEY = base64.b64encode(b"test-tls-key").decode()
+FAKE_CA_CERT = base64.b64encode(b"test-ca-cert").decode()
+
+
+def test_static_tls_cert_data_uses_provided_values():
+    values_file = f"""
+capabilities:
+  admissionController:
+    enabled: true
+    webhookServer:
+      staticTlsCertData:
+        tlsCert: "{FAKE_TLS_CERT}"
+        tlsKey: "{FAKE_TLS_KEY}"
+        caCert: "{FAKE_CA_CERT}"
+"""
+    secret_data = get_yaml_from_helm_template("test=test", "Secret", TLS_SECRET_NAME, ["data"], values_file=values_file)
+
+    assert secret_data["tls.crt"] == FAKE_TLS_CERT, f"Expected tls.crt={FAKE_TLS_CERT}, got: {secret_data['tls.crt']}"
+    assert secret_data["tls.key"] == FAKE_TLS_KEY, f"Expected tls.key={FAKE_TLS_KEY}, got: {secret_data['tls.key']}"
+    assert secret_data["ca.crt"] == FAKE_CA_CERT, f"Expected ca.crt={FAKE_CA_CERT}, got: {secret_data['ca.crt']}"
+
+
+def test_static_tls_cert_data_partial_falls_through_to_generation():
+    # Only one of three fields set — should fall through to cert generation without crashing
+    values_file = f"""
+capabilities:
+  admissionController:
+    enabled: true
+    webhookServer:
+      staticTlsCertData:
+        tlsCert: "{FAKE_TLS_CERT}"
+"""
+    secret_data = get_yaml_from_helm_template("test=test", "Secret", TLS_SECRET_NAME, ["data"], values_file=values_file)
+
+    assert secret_data["tls.crt"] != FAKE_TLS_CERT, "Expected tls.crt to be generated, not the fake value"
+    assert secret_data["tls.key"] != FAKE_TLS_KEY, "Expected tls.key to be generated, not the fake value"
+    assert secret_data["ca.crt"] != FAKE_CA_CERT, "Expected ca.crt to be generated, not the fake value"
+
+
+def test_static_tls_cert_data_null_does_not_crash():
+    # staticTlsCertData explicitly null — should fall through to cert generation without crashing
+    values_file = """
+capabilities:
+  admissionController:
+    enabled: true
+    webhookServer:
+      staticTlsCertData:
+"""
+    secret_data = get_yaml_from_helm_template("test=test", "Secret", TLS_SECRET_NAME, ["data"], values_file=values_file)
+
+    assert secret_data["tls.crt"] != FAKE_TLS_CERT, "Expected tls.crt to be generated, not the fake value"
+    assert secret_data["tls.key"] != FAKE_TLS_KEY, "Expected tls.key to be generated, not the fake value"
+    assert secret_data["ca.crt"] != FAKE_CA_CERT, "Expected ca.crt to be generated, not the fake value"

--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -245,6 +245,10 @@ Relevant values:
 | capabilities.admissionController.webhookServer.tlsCertFile | string | /etc/komodor/admission/tls/tls.crt | Path to the TLS certificate file for the webhook server. If set, overrides the default certificate generation |
 | capabilities.admissionController.webhookServer.tlsKeyFile | string | /etc/komodor/admission/tls/tls.key | Path to the TLS key file for the webhook server. If set, overrides the default certificate generation |
 | capabilities.admissionController.webhookServer.reuseGeneratedTlsSecret | bool | true | If true, the webhook server will reuse the generated TLS secret. If false, the webhook server will recreate a new TLS secret on every upgrade. |
+| capabilities.admissionController.webhookServer.staticTlsCertData | object | See sub-values | Provide static certificate data to use instead of generating. Useful when rendering the chart outside of a cluster. If all three fields are set, they take priority over cert regeneration but are still overridden by existing in-cluster secrets when reuseGeneratedTlsSecret is true. |
+| capabilities.admissionController.webhookServer.staticTlsCertData.tlsCert | string | `nil` | Base64-encoded TLS certificate (tls.crt) |
+| capabilities.admissionController.webhookServer.staticTlsCertData.tlsKey | string | `nil` | Base64-encoded TLS private key (tls.key) |
+| capabilities.admissionController.webhookServer.staticTlsCertData.caCert | string | `nil` | Base64-encoded CA certificate (ca.crt) |
 | capabilities.admissionController.mutatingWebhook | object | See sub-values | Configure the mutating webhook |
 | capabilities.admissionController.mutatingWebhook.selfManage | bool | `false` | If true, the mutating webhook will be managed by the chart. If false, the mutating webhook will be managed by the user. |
 | capabilities.admissionController.mutatingWebhook.timeoutSeconds | int | `5` | Timeout for the webhook call in seconds |

--- a/charts/komodor-agent/templates/admission-controller/_helpers.tpl
+++ b/charts/komodor-agent/templates/admission-controller/_helpers.tpl
@@ -38,7 +38,7 @@ Admission Controller selector labels
 */}}
 {{- define "komodorAgent.admissionController.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "komodorAgent.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/instance: {{ include "komodor.truncatedReleaseName" . }}
 app.kubernetes.io/component: admission-controller
 {{- with .Values.components.admissionController.labels }}
 {{ toYaml . }}

--- a/charts/komodor-agent/templates/admission-controller/_helpers.tpl
+++ b/charts/komodor-agent/templates/admission-controller/_helpers.tpl
@@ -97,8 +97,15 @@ In a SPECIFIC ORDER. TLS.CRT is first, then TLS.KEY, and finally CA.CRT.
     {{- $tlsSecret := lookup "v1" "Secret" .Release.Namespace $tlsSecretName -}}
     {{- $caSecret := lookup "v1" "Secret" .Release.Namespace $caSecretName -}}
 
+    {{- $staticTlsCertData := default dict .Values.capabilities.admissionController.webhookServer.staticTlsCertData -}}
+    {{- $providedTlsCert := get $staticTlsCertData "tlsCert" -}}
+    {{- $providedTlsKey := get $staticTlsCertData "tlsKey" -}}
+    {{- $providedCaCert := get $staticTlsCertData "caCert" -}}
+
     {{- if and .Values.capabilities.admissionController.webhookServer.reuseGeneratedTlsSecret (and (not (empty $tlsSecret)) (not (empty $caSecret))) -}}
         {{- printf "%s$%s$%s" (index $tlsSecret.data "tls.crt") (index $tlsSecret.data "tls.key") (index $caSecret.data "tls.crt") -}}
+    {{- else if and $providedTlsCert (and $providedTlsKey $providedCaCert) -}}
+        {{- printf "%s$%s$%s" $providedTlsCert $providedTlsKey $providedCaCert -}}
     {{- else -}}
         {{- $ca := genCA (print "*." .Release.Namespace ".svc") 3650 -}}
         {{- $cn := print (include "komodorAgent.admissionController.serviceName" .) "." .Release.Namespace ".svc" -}}

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -266,6 +266,15 @@ capabilities:
       # capabilities.admissionController.webhookServer.reuseGeneratedTlsSecret -- (bool) If true, the webhook server will reuse the generated TLS secret. If false, the webhook server will recreate a new TLS secret on every upgrade.
       # @default -- true
       reuseGeneratedTlsSecret: true
+      # capabilities.admissionController.webhookServer.staticTlsCertData -- Provide static certificate data to use instead of generating. Useful when rendering the chart outside of a cluster. If all three fields are set, they take priority over cert regeneration but are still overridden by existing in-cluster secrets when reuseGeneratedTlsSecret is true.
+      # @default -- See sub-values
+      staticTlsCertData:
+        # capabilities.admissionController.webhookServer.staticTlsCertData.tlsCert -- (string) Base64-encoded TLS certificate (tls.crt)
+        tlsCert:
+        # capabilities.admissionController.webhookServer.staticTlsCertData.tlsKey -- (string) Base64-encoded TLS private key (tls.key)
+        tlsKey:
+        # capabilities.admissionController.webhookServer.staticTlsCertData.caCert -- (string) Base64-encoded CA certificate (ca.crt)
+        caCert:
     # capabilities.admissionController.mutatingWebhook -- Configure the mutating webhook
     # @default -- See sub-values
     mutatingWebhook:


### PR DESCRIPTION
## Summary
- Adds `staticTlsCertData` values (`tlsCert`, `tlsKey`, `caCert`) under `capabilities.admissionController.webhookServer` to allow providing pre-existing base64-encoded cert data when rendering the chart outside a cluster where secret lookup is unavailable
- Priority order: existing in-cluster secrets (when `reuseGeneratedTlsSecret=true`) > static values > regenerate
- Fixes admission controller `selectorLabels` to use `komodor.truncatedReleaseName` consistently with all other components

## Test plan
- [x] `test_static_tls_cert_data_uses_provided_values` — all three static fields set → Secret contains exactly those values
- [x] `test_static_tls_cert_data_partial_falls_through_to_generation` — only one field set → Secret contains generated certs, not the fake values
- [x] `test_static_tls_cert_data_null_does_not_crash` — `staticTlsCertData` is null → template renders successfully with generated certs