### PR TITLE
CU-86ca60tr7 - feat(komodor-agent): enable telemetry for admission controller

### DIFF
--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -263,7 +263,7 @@ Relevant values:
 | capabilities.admissionController.binpacking.addNodeAffinityToMarkedPods | bool | `true` | Add node affinity to marked pods to prefer scheduling on nodes with already unevictable pods (requires enabling per cluster in UI in addition) |
 | capabilities.admissionController.rightsizing | object | See sub-values | Configure the rightsizing capabilities for the admission controller |
 | capabilities.admissionController.telemetry | object | See sub-values | Configure the telemetry capabilities for the admission controller |
-| capabilities.admissionController.telemetry.enabled | bool | `true` | Enable telemetry capabilities by the komodor admission controller |
+| capabilities.admissionController.telemetry.enabled | bool | `false` | Enable telemetry capabilities by the komodor admission controller |
 | components | object | See sub-values | Configure the agent components |
 | components.komodorAgent | object | See sub-values | Configure the komodor agent components |
 | components.komodorAgent.PriorityClassValue | int | `10000000` | Set the priority class value for the komodor agent deployment |

--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -262,6 +262,8 @@ Relevant values:
 | capabilities.admissionController.binpacking.markUnevictable | bool | `true` | Add a label to mark pods as unevictable (requires enabling per cluster in UI in addition) |
 | capabilities.admissionController.binpacking.addNodeAffinityToMarkedPods | bool | `true` | Add node affinity to marked pods to prefer scheduling on nodes with already unevictable pods (requires enabling per cluster in UI in addition) |
 | capabilities.admissionController.rightsizing | object | See sub-values | Configure the rightsizing capabilities for the admission controller |
+| capabilities.admissionController.telemetry | object | See sub-values | Configure the telemetry capabilities for the admission controller |
+| capabilities.admissionController.telemetry.enabled | bool | `true` | Enable telemetry capabilities by the komodor admission controller |
 | components | object | See sub-values | Configure the agent components |
 | components.komodorAgent | object | See sub-values | Configure the komodor agent components |
 | components.komodorAgent.PriorityClassValue | int | `10000000` | Set the priority class value for the komodor agent deployment |

--- a/charts/komodor-agent/templates/admission-controller/configmap.yaml
+++ b/charts/komodor-agent/templates/admission-controller/configmap.yaml
@@ -36,4 +36,11 @@ data:
       {{- if .Values.capabilities.admissionController.rightsizing.recommendationsSyncInterval }}
       recommendationsSyncInterval: {{ .Values.capabilities.admissionController.rightsizing.recommendationsSyncInterval }}
       {{- end }}
+    telemetry:
+      enable: {{ and .Values.capabilities.telemetry.enabled .Values.capabilities.admissionController.telemetry.enabled }}
+      {{- if .Values.capabilities.telemetry.deployOtelCollector }}
+      serverHost: {{ include "komodorAgent.openTelemetry.serviceFqdn" . }}
+      {{- else }}
+      serverHost: {{ include "communication.telemetryServerHost" . }}
+      {{- end }}
 {{- end }}

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -314,6 +314,12 @@ capabilities:
       # @default -- "1m"
       #recommendationsSyncInterval: "1m"
 
+    # capabilities.admissionController.telemetry -- Configure the telemetry capabilities for the admission controller
+    # @default -- See sub-values
+    telemetry:
+      # capabilities.admissionController.telemetry.enabled -- (bool) Enable telemetry capabilities by the komodor admission controller
+      enabled: true
+
 # components -- Configure the agent components
 # @default -- See sub-values
 components:

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -318,7 +318,7 @@ capabilities:
     # @default -- See sub-values
     telemetry:
       # capabilities.admissionController.telemetry.enabled -- (bool) Enable telemetry capabilities by the komodor admission controller
-      enabled: true
+      enabled: false
 
 # components -- Configure the agent components
 # @default -- See sub-values


### PR DESCRIPTION
## What

Enables telemetry for the komodor admission controller by setting the correct host for otel/backend, mirroring how it's configured for the agent/watcher.

## Changes

- **`values.yaml`**: Added `capabilities.admissionController.telemetry.enabled` (default `false`).
- **`admission-controller/configmap.yaml`**: Added a `telemetry` block to `komodor.yaml`:
  - `enable` requires **both** the global `capabilities.telemetry.enabled` **and** the AC-specific `capabilities.admissionController.telemetry.enabled` to be true.
  - `serverHost` is conditional on the shared `capabilities.telemetry.deployOtelCollector` flag — routes to the in-cluster OTel collector when deployed, otherwise the remote komodor telemetry endpoint. This matches the agent/watcher configmap pattern.
- **`README.md`**: Regenerated with the new value.

## Rendering verified

| Scenario | `enable` | `serverHost` |
|---|---|---|
| Default (otel collector on) | `true` | in-cluster otel collector |
| `deployOtelCollector=false` | `true` | `telemetry.komodor.com` |
| Global `telemetry.enabled=false` | `false` | — |