### PR TITLE
CU-86ca7dxt8 - chore(komodor-agent): set GOMEMLIMIT to 90% of memory limit via helper

### DIFF
--- a/charts/komodor-agent/templates/_helpers.tpl
+++ b/charts/komodor-agent/templates/_helpers.tpl
@@ -162,6 +162,40 @@ Public API Key secret name
 {{- end -}}
 
 {{/*
+GOMEMLIMIT calculation — returns N% (default 90%) of a Kubernetes memory limit
+in Go-runtime units (MiB). Falls back to plain unit conversion if ratio is empty
+or input has no Ki/Mi/Gi/Ti suffix. Usage:
+  {{ include "komodorAgent.goMemLimit" (dict "mem" .Values.x.resources.limits.memory) }}
+  {{ include "komodorAgent.goMemLimit" (dict "mem" "8Gi" "ratio" "0.8") }}
+*/}}
+{{- define "komodorAgent.goMemLimit" -}}
+{{- $mem := .mem | toString -}}
+{{- $ratio := "0.9" -}}
+{{- if hasKey . "ratio" -}}
+{{- $ratio = .ratio | toString -}}
+{{- end -}}
+{{- if and (ne $ratio "") (ne $ratio "0") -}}
+  {{- $memMiB := 0.0 -}}
+  {{- if hasSuffix "Ti" $mem -}}
+  {{- $memMiB = mulf ($mem | trimSuffix "Ti" | float64) 1048576.0 -}}
+  {{- else if hasSuffix "Gi" $mem -}}
+  {{- $memMiB = mulf ($mem | trimSuffix "Gi" | float64) 1024.0 -}}
+  {{- else if hasSuffix "Mi" $mem -}}
+  {{- $memMiB = $mem | trimSuffix "Mi" | float64 -}}
+  {{- else if hasSuffix "Ki" $mem -}}
+  {{- $memMiB = divf ($mem | trimSuffix "Ki" | float64) 1024.0 -}}
+  {{- end -}}
+  {{- if gt $memMiB 0.0 -}}
+  {{- mulf $memMiB ($ratio | float64) | floor | printf "%.0fMiB" -}}
+  {{- else -}}
+  {{- $mem | replace "Ki" "KiB" | replace "Mi" "MiB" | replace "Gi" "GiB" | replace "Ti" "TiB" -}}
+  {{- end -}}
+{{- else -}}
+  {{- $mem | replace "Ki" "KiB" | replace "Mi" "MiB" | replace "Gi" "GiB" | replace "Ti" "TiB" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Public API Key secret reference - returns the entire valueFrom block
 */}}
 {{- define "komodorAgent.publicApiKeySecretRef" -}}

--- a/charts/komodor-agent/templates/admission-controller/deployment.yaml
+++ b/charts/komodor-agent/templates/admission-controller/deployment.yaml
@@ -55,8 +55,10 @@ spec:
           env:
             - name: KOMO_API_KEY
               {{- include "komodorAgent.apiKeySecretRef" . | nindent 14 }}
+            {{- with .Values.components.admissionController.resources.limits.memory }}
             - name: GOMEMLIMIT
-              value: {{ .Values.components.admissionController.resources.limits.memory | replace "Ki" "KiB" | replace "Mi" "MiB" | replace "Gi" "GiB" | replace "Ti" "TiB" | quote }}
+              value: {{ include "komodorAgent.goMemLimit" (dict "mem" .) | quote }}
+            {{- end }}
             - name: POD_IP
               valueFrom:
                 fieldRef:

--- a/charts/komodor-agent/templates/metrics/_containers_daemon.tpl
+++ b/charts/komodor-agent/templates/metrics/_containers_daemon.tpl
@@ -29,8 +29,10 @@
     value: {{ .Values.components.komodorDaemon.metrics.quiet | default false | quote }}
   - name: KOMODOR_SERVER_URL
     value: {{ include "communication.serverHost" . | quote }}
+  {{- with .Values.components.komodorDaemon.metrics.resources.limits.memory }}
   - name: GOMEMLIMIT
-    value: {{ .Values.components.komodorDaemon.metrics.resources.limits.memory | replace "Ki" "KiB" | replace "Mi" "MiB" | replace "Gi" "GiB" | replace "Ti" "TiB" | quote }}
+    value: {{ include "komodorAgent.goMemLimit" (dict "mem" .) | quote }}
+  {{- end }}
   {{- if .Values.components.komodorDaemon.disableHttp2 }}
   - name: GODEBUG
     value: http2client=0
@@ -76,8 +78,10 @@
         fieldPath: status.hostIP
   - name: KOMODOR_SERVER_URL
     value: {{ include "communication.serverHost" . | quote }}
+  {{- with .Values.components.komodorDaemonWindows.metrics.resources.limits.memory }}
   - name: GOMEMLIMIT
-    value: {{ .Values.components.komodorDaemonWindows.metrics.resources.limits.memory | replace "Ki" "KiB" | replace "Mi" "MiB" | replace "Gi" "GiB" | replace "Ti" "TiB" | quote }}
+    value: {{ include "komodorAgent.goMemLimit" (dict "mem" .) | quote }}
+  {{- end }}
   {{- if .Values.components.komodorDaemon.disableHttp2 }}
   - name: GODEBUG
     value: http2client=0

--- a/charts/komodor-agent/templates/metrics/_containers_deployment.tpl
+++ b/charts/komodor-agent/templates/metrics/_containers_deployment.tpl
@@ -25,8 +25,10 @@
     valueFrom:
       fieldRef:
         fieldPath: status.hostIP
+  {{- with .Values.components.komodorMetrics.metrics.resources.limits.memory }}
   - name: GOMEMLIMIT
-    value: {{ .Values.components.komodorMetrics.metrics.resources.limits.memory | replace "Ki" "KiB" | replace "Mi" "MiB" | replace "Gi" "GiB" | replace "Ti" "TiB" | quote }}
+    value: {{ include "komodorAgent.goMemLimit" (dict "mem" .) | quote }}
+  {{- end }}
   {{- if .Values.components.komodorMetrics.disableHttp2 }}
   - name: GODEBUG
     value: http2client=0

--- a/charts/komodor-agent/templates/opentelemetry/_containers.tpl
+++ b/charts/komodor-agent/templates/opentelemetry/_containers.tpl
@@ -76,8 +76,10 @@
     {{ include "komodorAgent.apiKeySecretRef" . | nindent 4 }}
   - name: KOMO_CLUSTER_NAME
     value: {{ .Values.clusterName }}
+  {{- with .Values.components.komodorDaemon.opentelemetry.resources.limits.memory }}
   - name: GOMEMLIMIT
-    value: {{ .Values.components.komodorDaemon.opentelemetry.resources.limits.memory | replace "Ki" "KiB" | replace "Mi" "MiB" | replace "Gi" "GiB" | replace "Ti" "TiB" | quote }}
+    value: {{ include "komodorAgent.goMemLimit" (dict "mem" .) | quote }}
+  {{- end }}
   - name: KOMODOR_SERVER_URL
     value: {{ include "communication.telemetryServerHost" . }}
   {{- include "komodorAgent.opentelemetry.healthEndpointsEnvironment" . | nindent 2 }}

--- a/charts/komodor-agent/templates/watcher/_containers.tpl
+++ b/charts/komodor-agent/templates/watcher/_containers.tpl
@@ -50,6 +50,10 @@
     value: /opt/watcher/helm/data
   - name: HOME
     value: /tmp/home
+  {{- with .Values.components.komodorAgent.watcher.resources.limits.memory }}
+  - name: GOMEMLIMIT
+    value: {{ include "komodorAgent.goMemLimit" (dict "mem" .) | quote }}
+  {{- end }}
   {{- if .Values.capabilities.tasks.httpRequests.skipTlsVerify }}
   - name: HTTP_REQUESTS_SKIP_TLS_VERIFY
     value: "true"


### PR DESCRIPTION
## Summary

- Add `komodorAgent.goMemLimit` helper that returns 90% of a container memory limit in MiB, with proper unit conversion (Ki/Mi/Gi/Ti). Default ratio is `0.9`, overridable per call.
- Add `GOMEMLIMIT` to the **watcher** container — previously absent despite an 8Gi limit. With defaults, renders as `"7372MiB"`.
- Refactor the 5 existing `GOMEMLIMIT` sites (metrics ×3, otel-collector, admission-controller) to use the new helper. They go from 100% (`replace "Gi" "GiB"`) to 90% (helper) and now gracefully omit the env var if the user removes the memory limit.

## Rendered values (defaults)

| Container | Limit | Before | After |
|---|---|---|---|
| watcher | 8Gi | — | **7372MiB** |
| admission-controller | 4Gi | 4GiB | **3686MiB** |
| komodorMetrics metrics | 4Gi | 4GiB | **3686MiB** |
| komodorDaemon metrics | 1Gi | 1GiB | **921MiB** |
| komodorDaemon otel | 512Mi | 512MiB | **460MiB** |
| komodorDaemonWindows metrics | 1Gi | 1GiB | **921MiB** |

## Test plan

- [x] \`helm lint charts/komodor-agent\` passes
- [x] \`helm template\` with defaults renders 6 expected GOMEMLIMIT values
- [x] Custom watcher limit override (2Gi) renders `"1843MiB"` (2048 × 0.9)
- [x] All memory limits set to `null` → 0 GOMEMLIMIT entries (conditional wrap works)
- [x] \`make -C charts/komodor-agent template\` regenerates cleanly
- [x] CI: helm template sanity, README validation, KIND pytest suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)