### PR TITLE
chore(komodor-agent): remove enableAgentTaskExecutionV2 opt-in flag

### DIFF
--- a/charts/komodor-agent/templates/configmap.yaml
+++ b/charts/komodor-agent/templates/configmap.yaml
@@ -9,7 +9,6 @@ data:
     clusterName: {{ .Values.clusterName }}
     chartVersion: {{ .Chart.Version | quote }}
     enableAgentTaskExecution: true
-    enableAgentTaskExecutionV2: true
     allowReadingPodLogs: {{ .Values.capabilities.logs.enabled}}
     enableHelm: {{ .Values.capabilities.helm.enabled }}
     daemon:


### PR DESCRIPTION
## Motivation
`enableAgentTaskExecutionV2` was previously gated as an opt-in feature flag in the agent configmap. The feature is now considered stable and enabled by default — the explicit flag is no longer needed and should not be present as a configmap entry.

## Changelog
**Backend Changes:**
- Removed `enableAgentTaskExecutionV2: true` from `komodor-agent` configmap template

## Testing coverage
- [x] Manual testing
- [ ] Automated testing
- [ ] E2E testing