### PR TITLE
CU-86ca7x1rz - feat(komodor-agent): add tunnel.kubeapiserver.enabled config

### DIFF
--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -145,362 +145,362 @@ Relevant values:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| admissionControllerVersion | string | `"0.1.60"` | Admission controller version to be used |
-| allowedResources.admissionRegistrationResources | bool | `true` | Enables watching `admissionRegistrationResources` |
-| allowedResources.allowReadAll | bool | `true` | Allow reading all the resources in the cluster |
-| allowedResources.argoWorkflows | object | See sub-values | Enables watching argo resources |
-| allowedResources.argoWorkflows.clusterWorkflowTemplates | bool | `true` | Enables watching Argo `clusterWorkflowTemplates` |
-| allowedResources.argoWorkflows.cronWorkflows | bool | `true` | Enables watching Argo `cronWorkflows` |
-| allowedResources.argoWorkflows.workflowTemplates | bool | `true` | Enables watching Argo `workflowTemplates` |
-| allowedResources.argoWorkflows.workflows | bool | `true` | Enables watching Argo `workflows` |
-| allowedResources.authorizationResources | bool | `true` | Enables watching `authorizationResources` |
-| allowedResources.certificateSigningRequest | bool | `true` | Enables watching `certificateSigningRequest` |
-| allowedResources.clusterRole | bool | `true` | Enables watching `clusterRoles` |
-| allowedResources.clusterRoleBinding | bool | `true` | Enables watching `clusterRoleBinding` |
-| allowedResources.configMap | bool | `true` | Enables watching `configmaps` |
-| allowedResources.controllerRevision | bool | `true` | Enables watching `controllerRevision` |
-| allowedResources.cronjob | bool | `true` | Enables watching `cronjobs` |
-| allowedResources.csiDriver | bool | `true` | Enables watching `csiDriver` |
-| allowedResources.csiNode | bool | `true` | Enables watching `csiNode` |
-| allowedResources.csiStorageCapacity | bool | `true` | Enables watching `csiStorageCapacity` |
-| allowedResources.customReadAPIGroups | list | `[]` | A list of custom API groups to allow read access to - each array element should be a string which represents the group name |
-| allowedResources.daemonSet | bool | `true` | Enables watching `daemonSets` |
-| allowedResources.deployment | bool | `true` | Enables watching `deployments` |
-| allowedResources.endpointSlice | bool | `true` | Enables watching `endpointslice` |
-| allowedResources.endpoints | bool | `true` | Enables watching `endpoints` |
-| allowedResources.event | bool | `true` | Enables watching `event` |
-| allowedResources.flowControlResources | bool | `true` | Enables watching `flowControlResources` |
-| allowedResources.horizontalPodAutoscaler | bool | `true` | Enables watching `horizontalPodAutoscaler` |
-| allowedResources.ingress | bool | `true` | Enables watching `ingresses` |
-| allowedResources.ingressClass | bool | `true` | Enables watching `ingressClass` |
-| allowedResources.job | bool | `true` | Enables watching `jobs` |
-| allowedResources.lease | bool | `true` | Enables watching `lease` |
-| allowedResources.limitRange | bool | `true` | Enables watching `limitRange` |
-| allowedResources.metrics | bool | `true` | Enables watching `metrics` |
-| allowedResources.namespace | bool | `true` | Enables watching `namespaces` |
-| allowedResources.networkPolicy | bool | `true` | Enables watching `networkPolicy` |
-| allowedResources.node | bool | `true` | Enables watching `nodes` |
-| allowedResources.persistentVolume | bool | `true` | Enables watching `persistentVolumes` |
-| allowedResources.persistentVolumeClaim | bool | `true` | Enables watching `persistentVolumeClaims` |
-| allowedResources.pod | bool | `true` | Enables watching `pods` |
-| allowedResources.podDisruptionBudget | bool | `true` | Enables watching `podDisruptionBudgets` |
-| allowedResources.podTemplate | bool | `true` | Enables watching `podTemplate` |
-| allowedResources.policyResources | bool | `true` | Enables watching `policyResources` |
-| allowedResources.priorityClass | bool | `true` | Enables watching `priorityClass` |
-| allowedResources.replicaSet | bool | `true` | Enables watching `replicaSets` |
-| allowedResources.replicationController | bool | `true` | Enables watching `replicationControllers` |
-| allowedResources.resourceQuota | bool | `true` | Enables watching `resourceQuota` |
-| allowedResources.role | bool | `true` | Enables watching `role` |
-| allowedResources.roleBinding | bool | `true` | Enables watching `roleBinding` |
-| allowedResources.rollout | bool | `true` | Enables watching `rollouts` |
-| allowedResources.runtimeClass | bool | `true` | Enables watching `runtimeClass` |
-| allowedResources.secret | bool | `true` | Enables watching `secrets` |
-| allowedResources.service | bool | `true` | Enables watching `services` |
-| allowedResources.serviceAccount | bool | `true` | Enables watching `serviceAccounts` |
-| allowedResources.statefulSet | bool | `true` | Enables watching `statefulSets` |
-| allowedResources.storageClass | bool | `true` | Enables watching `storageClasses` |
-| allowedResources.volumeAttachment | bool | `true` | Enables watching `volumeAttachment` |
+| site | string | "us" | Komodor site, allowed values: "us", "eu" |
 | apiKey | guid | `nil` | **(*required*)** To be obtained from komodor app during onboarding |
 | apiKeySecret | string | `nil` | Secret name containing Komodor agent api key |
+| publicApiKey | guid | `nil` | Komodor public API key. Required when features that depend on it are enabled (currently capabilities.klaudiaIntegrationSync). |
+| publicApiKeySecret | string | `nil` | Existing Kubernetes secret containing the public API key |
+| publicApiKeySecretKey | string | `nil` | Key inside publicApiKeySecret (defaults to publicApiKey) |
+| createNamespace | bool | `true` | Creates the namespace |
+| tags | dict | `{}` | Tags the agent in order to identify it based on `key:value` properties separated by semicolon (`;`) example: `--set tags.env=staging,tags.team=payments` --- Can also be set in the values under `tags` as a dictionary of key:value strings |
+| clusterName | string | `nil` | **(*required*)** Name to be displayed in the Komodor web application |
+| createRbac | bool | `true` | Creates the necessary RBAC resources for the agent - use with caution! |
+| global | object | See sub-values | Global defaults applied across the chart. |
+| global.podSecurityContext | object | `{}` | Set a pod-level securityContext applied to all agent pods unless a component-specific podSecurityContext is defined. Supports pod-only fields: fsGroup, runAsUser, runAsGroup, runAsNonRoot, supplementalGroups, sysctls, seccompProfile. (use with caution) |
+| global.securityContext | object | `{}` | Set a container-level securityContext applied to all containers unless a container-specific securityContext is defined. Supports container fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
+| telegrafImageVersion | string | `"v2.0.56-alpine"` | Telegraf version to be used |
+| telegrafWindowsImageVersion | string | `"v2.0.56"` | Telegraf version to be used for windows |
+| admissionControllerVersion | string | `"0.1.60"` | Admission controller version to be used |
+| serviceAccount | object | See sub-values | Configure service account for the agent |
+| serviceAccount.create | bool | `true` | Creates a service account for the agent |
+| serviceAccount.name | string | `nil` | Name of the service account, Required if `serviceAccount.create` is false |
+| serviceAccount.annotations | object | `{}` | Add annotations to the service account |
+| proxy.enabled | bool | `false` | Enable proxy for the agent |
+| proxy.komodorOnly | bool | `true` | Configure proxy to be applied only on communication to Komodor servers (comms. to K8S API remains without proxy) |
+| proxy.http | string | `nil` | Configure Proxy setting (HTTP_PROXY) `eg. http://proxy.com:8080` |
+| proxy.https | string | `nil` | Configure Proxy setting (HTTPS_PROXY) `eg. https://proxy.com:8080` |
+| proxy.no_proxy | string | `nil` | Specify specific domains to ignore proxy for. eg. `komodor.com,google.com` |
+| proxy.no_proxy_local_addresses | bool | `false` | When true, prepends standard Kubernetes-internal addresses (localhost, 127.0.0.1, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, .cluster.local, .svc) to NO_PROXY so that in-cluster traffic (e.g. Kubernetes API server) bypasses the proxy. |
+| customCa | object | See sub-values | Configure custom CA for the agent (Not supported for windows) |
+| customCa.enabled | bool | `false` | Enable custom CA certificate for the agent |
+| customCa.secretName | string | `nil` | Name of the secret containing the CA |
+| customCa.resources | dict | `{"limits":{"cpu":"10m","memory":"100Mi"},"requests":{"cpu":"1m","memory":"10Mi"}}` | Set custom resources to the custom CA container |
+| customCa.securityContext | dict | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000}` | Set container-level securityContext for the custom CA init container. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
+| imageRepo | string | `"public.ecr.aws/komodor-public"` | Override the komodor agent image repository. |
+| pullPolicy | string | `"IfNotPresent"` | Default Image pull policy for the komodor agent image acceptable values <ifNotPresent\Always\Never>. |
+| imagePullSecret | string | `nil` | Set the image pull secret for the komodor agent |
 | capabilities | object | See sub-values | Configure the agent capabilities |
+| capabilities.metrics | bool | `true` | Fetch workload metrics and send them to komodor backend |
+| capabilities.nodeEnricher | bool | `true` | Enable node enricher capabilities by the komodor agent |
 | capabilities.actions | bool | `true` | Allow users to perform actions on the cluster, granular access control is defined in the application<boolean> |
-| capabilities.admissionController | object | See sub-values | Configure the komodor admission controller capabilities |
-| capabilities.admissionController.binpacking | object | See sub-values | Configure the binpacking capabilities for the admission controller |
-| capabilities.admissionController.binpacking.addNodeAffinityToMarkedPods | bool | `true` | Add node affinity to marked pods to prefer scheduling on nodes with already unevictable pods (requires enabling per cluster in UI in addition) |
-| capabilities.admissionController.binpacking.markUnevictable | bool | `true` | Add a label to mark pods as unevictable (requires enabling per cluster in UI in addition) |
-| capabilities.admissionController.enabled | bool | `true` | Enable the komodor admission controller |
-| capabilities.admissionController.logFormat | string | `"json"` | Log format for the admission controller |
-| capabilities.admissionController.logLevel | string | `"info"` | Log level for the admission controller |
-| capabilities.admissionController.mutatingWebhook | object | See sub-values | Configure the mutating webhook |
-| capabilities.admissionController.mutatingWebhook.allowOnAKSManagedNamespaces | bool | `true` | Allow mutating webhook to be called for pods in AKS-managed namespaces (See also: https://learn.microsoft.com/en-us/azure/aks/faq#can-admission-controller-webhooks-affect-kube-system-and-internal-aks-namespaces-) |
-| capabilities.admissionController.mutatingWebhook.caBundle | string | using the kube-root-ca.crt ConfigMap in the kube-system namespace | CA bundle for the mutating webhook configuration. It should match the webhook server CA. |
-| capabilities.admissionController.mutatingWebhook.hpaRightsizingWebhookPath | string | `"/webhook/rightsizing/hpa"` | Path for the HPA rightsizing webhook |
-| capabilities.admissionController.mutatingWebhook.podBinpackingWebhookPath | string | `"/webhook/binpacking/pod"` | Path for the pod binpacking webhook |
-| capabilities.admissionController.mutatingWebhook.podRightsizingWebhookPath | string | `"/webhook/rightsizing/pod"` | Path for the pod rightsizing webhook |
-| capabilities.admissionController.mutatingWebhook.scaledObjectRightsizingWebhookPath | string | `"/webhook/rightsizing/scaledobject"` | Path for the KEDA ScaledObject rightsizing webhook |
-| capabilities.admissionController.mutatingWebhook.selfManage | bool | `false` | If true, the mutating webhook will be managed by the chart. If false, the mutating webhook will be managed by the user. |
-| capabilities.admissionController.mutatingWebhook.timeoutSeconds | int | `5` | Timeout for the webhook call in seconds |
-| capabilities.admissionController.pdb | object | `{"enabled":true}` | Configure the PodDisruptionBudget for the admission controller |
-| capabilities.admissionController.pdb.enabled | bool | `true` | Enable PodDisruptionBudget for the admission controller |
-| capabilities.admissionController.rightsizing | object | See sub-values | Configure the rightsizing capabilities for the admission controller |
-| capabilities.admissionController.telemetry | object | See sub-values | Configure the telemetry capabilities for the admission controller |
-| capabilities.admissionController.telemetry.enabled | bool | `false` | Enable telemetry capabilities by the komodor admission controller |
-| capabilities.admissionController.webhookServer | object | See sub-values | Configure the webhook server for the admission controller |
-| capabilities.admissionController.webhookServer.port | int | `8443` | Port of the webhook server |
-| capabilities.admissionController.webhookServer.reuseGeneratedTlsSecret | bool | true | If true, the webhook server will reuse the generated TLS secret. If false, the webhook server will recreate a new TLS secret on every upgrade. |
-| capabilities.admissionController.webhookServer.serviceName | string | `"komodor-admission-controller"` | Name of the service for the webhook server |
-| capabilities.admissionController.webhookServer.staticTlsCertData | object | See sub-values | Provide static certificate data to use instead of generating. Useful when rendering the chart outside of a cluster. If all three fields are set, they take priority over cert regeneration but are still overridden by existing in-cluster secrets when reuseGeneratedTlsSecret is true. |
-| capabilities.admissionController.webhookServer.staticTlsCertData.caCert | string | `nil` | Base64-encoded CA certificate (ca.crt) |
-| capabilities.admissionController.webhookServer.staticTlsCertData.tlsCert | string | `nil` | Base64-encoded TLS certificate (tls.crt) |
-| capabilities.admissionController.webhookServer.staticTlsCertData.tlsKey | string | `nil` | Base64-encoded TLS private key (tls.key) |
-| capabilities.admissionController.webhookServer.tlsCertFile | string | /etc/komodor/admission/tls/tls.crt | Path to the TLS certificate file for the webhook server. If set, overrides the default certificate generation |
-| capabilities.admissionController.webhookServer.tlsKeyFile | string | /etc/komodor/admission/tls/tls.key | Path to the TLS key file for the webhook server. If set, overrides the default certificate generation |
+| capabilities.crActions | bool | `true` | Allow komodor service account to edit and delete custom resources in the cluster |
 | capabilities.cost | object | See sub-values | Configure the agent cost capabilities |
 | capabilities.cost.hpa | bool | `true` | Enable patch and update permissions for KEDA ScaledObjects and ScaledJobs |
-| capabilities.crActions | bool | `true` | Allow komodor service account to edit and delete custom resources in the cluster |
-| capabilities.events | object | See sub-values | Configure the agent events capabilities |
-| capabilities.events.create | bool | `true` | allow create kubernetes events for enrichment |
-| capabilities.events.enableRWCache | bool | `true` | Mounts a ReadWrite cache volume for the kubernetes api cache |
-| capabilities.events.namespacesDenylist | array of strings | `[]` | Do not watch events from these namespaces. eg. `["kube-system", "kube-public"]` |
-| capabilities.events.redact | list | `[]` | Redact workload names from the komodor events. eg. `["password", "token"]` |
-| capabilities.events.watchNamespace | string | all | Watch a specific namespace, or all namespaces ("", "all") |
 | capabilities.helm | object | `{"enabled":true,"readonly":false}` | Enable helm capabilities by the komodor agent |
 | capabilities.helm.enabled | bool | `true` | Enable helm capabilities by the komodor agent |
 | capabilities.helm.readonly | bool | `false` | Allow komodor to read helm resources only (remove create/update/delete permissions from secrets) |
-| capabilities.klaudiaIntegrationSync | object | See sub-values | Sync KomodorMCPIntegration and KomodorSkill CRs to the Klaudia API. CRs (and any Secrets they reference) must be created in the agent's release namespace; CRs in other namespaces are silently ignored by the sync controller. |
-| capabilities.klaudiaIntegrationSync.enabled | bool | `false` | Enable KomodorMCPIntegration and KomodorSkill CR sync controller |
-| capabilities.klaudiaIntegrationSync.httpTimeout | string | `"90s"` | HTTP timeout for Klaudia API calls |
-| capabilities.klaudiaIntegrationSync.resyncInterval | string | `"2m"` | How often to force-resync all CRs even if unchanged |
-| capabilities.klaudiaIntegrationSync.serverFetchInterval | string | `"10m"` | How often to refresh server-side status (tools/status) on otherwise unchanged CRs. Set to "0s" to fetch every reconcile. |
-| capabilities.kubectlProxy | object | See sub-values | Configure the komodor kubectl proxy capabilities |
-| capabilities.kubectlProxy.enabled | bool | `false` | Enable the komodor kubectl proxy |
-| capabilities.logs | object | See sub-values | Configure the agent logs capabilities |
-| capabilities.logs.enabled | bool | `true` | Fetch pod logs from komodor backend |
-| capabilities.logs.logsNamespacesAllowlist | list | `[]` | Only fetch logs from these namespaces. eg. `["kube-system", "kube-public"]` |
-| capabilities.logs.logsNamespacesDenylist | list | `[]` | Do not fetch logs from these namespaces. eg. `["kube-system", "kube-public"]` |
-| capabilities.logs.nameDenylist | list | `[]` | Do not fetch logs from these workloads. eg. `["supersecret-workload", "password-manager"]` |
-| capabilities.logs.redact | list | `[]` | Redact logs from the komodor logs. eg. `["password", "token"]` |
-| capabilities.metrics | bool | `true` | Fetch workload metrics and send them to komodor backend |
-| capabilities.nodeEnricher | bool | `true` | Enable node enricher capabilities by the komodor agent |
 | capabilities.rbac | bool | `true` | Allow komodor to create and manage serviceaccounts, roles and bindings in cluster |
+| capabilities.rbacTempTokens | bool | `true` | Allow komodor to create temporary tokens for service accounts |
 | capabilities.rbacClusterSyncParams | object | See sub-values | Configure the agent cluster sync capabilities |
-| capabilities.rbacClusterSyncParams.clusterURL | string | `nil` | URL of the cluster to sync with |
 | capabilities.rbacClusterSyncParams.enabled | bool | `false` | Enable cluster sync configuration from helm chart |
+| capabilities.rbacClusterSyncParams.clusterURL | string | `nil` | URL of the cluster to sync with |
 | capabilities.rbacClusterSyncParams.ingressCertConfiguration | dict | See sub-values | Configuration for the ingress certificate |
-| capabilities.rbacClusterSyncParams.ingressCertConfiguration.dataPath | string | `nil` | Path to the certificate data in the resource (crt.ca) |
+| capabilities.rbacClusterSyncParams.ingressCertConfiguration.namespace | string | `nil` | Namespace of the resource containing the certificate |
 | capabilities.rbacClusterSyncParams.ingressCertConfiguration.kind | string | `nil` | Kind of the resource containing the certificate (Secret/ConfigMap) |
 | capabilities.rbacClusterSyncParams.ingressCertConfiguration.name | string | `nil` | Name of the resource containing the certificate |
-| capabilities.rbacClusterSyncParams.ingressCertConfiguration.namespace | string | `nil` | Namespace of the resource containing the certificate |
-| capabilities.rbacTempTokens | bool | `true` | Allow komodor to create temporary tokens for service accounts |
+| capabilities.rbacClusterSyncParams.ingressCertConfiguration.dataPath | string | `nil` | Path to the certificate data in the resource (crt.ca) |
+| capabilities.events | object | See sub-values | Configure the agent events capabilities |
+| capabilities.events.watchNamespace | string | all | Watch a specific namespace, or all namespaces ("", "all") |
+| capabilities.events.namespacesDenylist | array of strings | `[]` | Do not watch events from these namespaces. eg. `["kube-system", "kube-public"]` |
+| capabilities.events.redact | list | `[]` | Redact workload names from the komodor events. eg. `["password", "token"]` |
+| capabilities.events.enableRWCache | bool | `true` | Mounts a ReadWrite cache volume for the kubernetes api cache |
+| capabilities.events.create | bool | `true` | allow create kubernetes events for enrichment |
+| capabilities.logs | object | See sub-values | Configure the agent logs capabilities |
+| capabilities.logs.enabled | bool | `true` | Fetch pod logs from komodor backend |
+| capabilities.logs.logsNamespacesDenylist | list | `[]` | Do not fetch logs from these namespaces. eg. `["kube-system", "kube-public"]` |
+| capabilities.logs.logsNamespacesAllowlist | list | `[]` | Only fetch logs from these namespaces. eg. `["kube-system", "kube-public"]` |
+| capabilities.logs.nameDenylist | list | `[]` | Do not fetch logs from these workloads. eg. `["supersecret-workload", "password-manager"]` |
+| capabilities.logs.redact | list | `[]` | Redact logs from the komodor logs. eg. `["password", "token"]` |
 | capabilities.redaction | object | See sub-values | Configure the agent data redaction capabilities |
-| capabilities.redaction.byKind | list | `[]` | Redact specific fields from resources by kind using jq field selectors. Each entry specifies a `kind`, optional `group` (for CRDs), and `fields` (list of jq expressions). Example: byKind:   - kind: ExternalSecret     group: external-secrets.io     fields:       - .spec.data[].remoteRef.key       - .spec.dataFrom[].extract.key |
 | capabilities.redaction.secret | object | `{"enable":true,"keepOnlyHelmReleases":false}` | Configuration for the "Secret" resource type |
 | capabilities.redaction.secret.enable | bool | `true` | Enable redaction for the "Secret" resource type |
 | capabilities.redaction.secret.keepOnlyHelmReleases | bool | `false` | Determine if only helm releases should be collected, if true - wipe and redact all other secrets data |
+| capabilities.redaction.byKind | list | `[]` | Redact specific fields from resources by kind using jq field selectors. Each entry specifies a `kind`, optional `group` (for CRDs), and `fields` (list of jq expressions). Example: byKind:   - kind: ExternalSecret     group: external-secrets.io     fields:       - .spec.data[].remoteRef.key       - .spec.dataFrom[].extract.key |
+| capabilities.telemetry | object | See sub-values | Configure the agent telemetry capabilities |
+| capabilities.telemetry.enabled | bool | `true` | Enable telemetry capabilities by the komodor agent |
+| capabilities.telemetry.collectApiServerMetrics | bool | `false` | Collect metrics from the api server (Should only be used for debugging purposes) |
+| capabilities.telemetry.deployOtelCollector | bool | `true` | Deploys OpenTelemetry collector daemonset sidecar |
+| capabilities.kubectlProxy | object | See sub-values | Configure the komodor kubectl proxy capabilities |
+| capabilities.kubectlProxy.enabled | bool | `false` | Enable the komodor kubectl proxy |
 | capabilities.tasks | object | See sub-values | Configure the agent task capabilities |
 | capabilities.tasks.httpRequests | object | See sub-values | Configure HTTP request capabilities |
 | capabilities.tasks.httpRequests.skipTlsVerify | bool | `false` | Skip TLS certificate verification for HTTP requests (sets HTTP_REQUESTS_SKIP_TLS_VERIFY environment variable) |
-| capabilities.telemetry | object | See sub-values | Configure the agent telemetry capabilities |
-| capabilities.telemetry.collectApiServerMetrics | bool | `false` | Collect metrics from the api server (Should only be used for debugging purposes) |
-| capabilities.telemetry.deployOtelCollector | bool | `true` | Deploys OpenTelemetry collector daemonset sidecar |
-| capabilities.telemetry.enabled | bool | `true` | Enable telemetry capabilities by the komodor agent |
 | capabilities.tunnel | object | See sub-values | Configure the WebSocket tunnel feature |
 | capabilities.tunnel.enabled | bool | `true` | Enable the network tunnel for remote WebSocket connections |
+| capabilities.tunnel.whitelist | list | `[]` | Allowed destinations for tunnel connections (empty = allow all) If no entries are configured, all destinations are allowed (default-allow). Entries can be:   - CIDR ranges (e.g. "10.0.0.0/8") — any port, matched against resolved IPs   - "host:port" pairs (e.g. "myservice:8080") — exact match   - plain hosts (e.g. "myservice") — any port on that host |
 | capabilities.tunnel.kubeapiserver | object | See sub-values | Configure Kubernetes API server tunneling |
 | capabilities.tunnel.kubeapiserver.enabled | bool | `true` | Enable tunneling to the Kubernetes API server |
-| capabilities.tunnel.whitelist | list | `[]` | Allowed destinations for tunnel connections (empty = allow all) If no entries are configured, all destinations are allowed (default-allow). Entries can be:   - CIDR ranges (e.g. "10.0.0.0/8") — any port, matched against resolved IPs   - "host:port" pairs (e.g. "myservice:8080") — exact match   - plain hosts (e.g. "myservice") — any port on that host |
-| clusterName | string | `nil` | **(*required*)** Name to be displayed in the Komodor web application |
+| capabilities.klaudiaIntegrationSync | object | See sub-values | Sync KomodorMCPIntegration and KomodorSkill CRs to the Klaudia API. CRs (and any Secrets they reference) must be created in the agent's release namespace; CRs in other namespaces are silently ignored by the sync controller. |
+| capabilities.klaudiaIntegrationSync.enabled | bool | `false` | Enable KomodorMCPIntegration and KomodorSkill CR sync controller |
+| capabilities.klaudiaIntegrationSync.resyncInterval | string | `"2m"` | How often to force-resync all CRs even if unchanged |
+| capabilities.klaudiaIntegrationSync.httpTimeout | string | `"90s"` | HTTP timeout for Klaudia API calls |
+| capabilities.klaudiaIntegrationSync.serverFetchInterval | string | `"10m"` | How often to refresh server-side status (tools/status) on otherwise unchanged CRs. Set to "0s" to fetch every reconcile. |
+| capabilities.admissionController | object | See sub-values | Configure the komodor admission controller capabilities |
+| capabilities.admissionController.enabled | bool | `true` | Enable the komodor admission controller |
+| capabilities.admissionController.pdb | object | `{"enabled":true}` | Configure the PodDisruptionBudget for the admission controller |
+| capabilities.admissionController.pdb.enabled | bool | `true` | Enable PodDisruptionBudget for the admission controller |
+| capabilities.admissionController.logLevel | string | `"info"` | Log level for the admission controller |
+| capabilities.admissionController.logFormat | string | `"json"` | Log format for the admission controller |
+| capabilities.admissionController.webhookServer | object | See sub-values | Configure the webhook server for the admission controller |
+| capabilities.admissionController.webhookServer.serviceName | string | `"komodor-admission-controller"` | Name of the service for the webhook server |
+| capabilities.admissionController.webhookServer.port | int | `8443` | Port of the webhook server |
+| capabilities.admissionController.webhookServer.tlsCertFile | string | /etc/komodor/admission/tls/tls.crt | Path to the TLS certificate file for the webhook server. If set, overrides the default certificate generation |
+| capabilities.admissionController.webhookServer.tlsKeyFile | string | /etc/komodor/admission/tls/tls.key | Path to the TLS key file for the webhook server. If set, overrides the default certificate generation |
+| capabilities.admissionController.webhookServer.reuseGeneratedTlsSecret | bool | true | If true, the webhook server will reuse the generated TLS secret. If false, the webhook server will recreate a new TLS secret on every upgrade. |
+| capabilities.admissionController.webhookServer.staticTlsCertData | object | See sub-values | Provide static certificate data to use instead of generating. Useful when rendering the chart outside of a cluster. If all three fields are set, they take priority over cert regeneration but are still overridden by existing in-cluster secrets when reuseGeneratedTlsSecret is true. |
+| capabilities.admissionController.webhookServer.staticTlsCertData.tlsCert | string | `nil` | Base64-encoded TLS certificate (tls.crt) |
+| capabilities.admissionController.webhookServer.staticTlsCertData.tlsKey | string | `nil` | Base64-encoded TLS private key (tls.key) |
+| capabilities.admissionController.webhookServer.staticTlsCertData.caCert | string | `nil` | Base64-encoded CA certificate (ca.crt) |
+| capabilities.admissionController.mutatingWebhook | object | See sub-values | Configure the mutating webhook |
+| capabilities.admissionController.mutatingWebhook.selfManage | bool | `false` | If true, the mutating webhook will be managed by the chart. If false, the mutating webhook will be managed by the user. |
+| capabilities.admissionController.mutatingWebhook.timeoutSeconds | int | `5` | Timeout for the webhook call in seconds |
+| capabilities.admissionController.mutatingWebhook.podBinpackingWebhookPath | string | `"/webhook/binpacking/pod"` | Path for the pod binpacking webhook |
+| capabilities.admissionController.mutatingWebhook.podRightsizingWebhookPath | string | `"/webhook/rightsizing/pod"` | Path for the pod rightsizing webhook |
+| capabilities.admissionController.mutatingWebhook.hpaRightsizingWebhookPath | string | `"/webhook/rightsizing/hpa"` | Path for the HPA rightsizing webhook |
+| capabilities.admissionController.mutatingWebhook.scaledObjectRightsizingWebhookPath | string | `"/webhook/rightsizing/scaledobject"` | Path for the KEDA ScaledObject rightsizing webhook |
+| capabilities.admissionController.mutatingWebhook.caBundle | string | using the kube-root-ca.crt ConfigMap in the kube-system namespace | CA bundle for the mutating webhook configuration. It should match the webhook server CA. |
+| capabilities.admissionController.mutatingWebhook.allowOnAKSManagedNamespaces | bool | `true` | Allow mutating webhook to be called for pods in AKS-managed namespaces (See also: https://learn.microsoft.com/en-us/azure/aks/faq#can-admission-controller-webhooks-affect-kube-system-and-internal-aks-namespaces-) |
+| capabilities.admissionController.binpacking | object | See sub-values | Configure the binpacking capabilities for the admission controller |
+| capabilities.admissionController.binpacking.markUnevictable | bool | `true` | Add a label to mark pods as unevictable (requires enabling per cluster in UI in addition) |
+| capabilities.admissionController.binpacking.addNodeAffinityToMarkedPods | bool | `true` | Add node affinity to marked pods to prefer scheduling on nodes with already unevictable pods (requires enabling per cluster in UI in addition) |
+| capabilities.admissionController.rightsizing | object | See sub-values | Configure the rightsizing capabilities for the admission controller |
+| capabilities.admissionController.telemetry | object | See sub-values | Configure the telemetry capabilities for the admission controller |
+| capabilities.admissionController.telemetry.enabled | bool | `false` | Enable telemetry capabilities by the komodor admission controller |
 | components | object | See sub-values | Configure the agent components |
+| components.komodorAgent | object | See sub-values | Configure the komodor agent components |
+| components.komodorAgent.PriorityClassValue | int | `10000000` | Set the priority class value for the komodor agent deployment |
+| components.komodorAgent.priorityClassName | string | `""` | Use an existing priority class for the komodor agent deployment. If not set, will create and use a priority class with PriorityClassValue. WARNING: priorityClassName is immutable and cannot be changed after initial deployment |
+| components.komodorAgent.affinity | object | `{}` | Set node affinity for the komodor agent deployment |
+| components.komodorAgent.annotations | object | `{}` | Set annotations for the komodor agent deployment |
+| components.komodorAgent.labels | object | `{}` | Set custom labels |
+| components.komodorAgent.nodeSelector | object | `{}` | Set node selectors for the komodor agent deployment |
+| components.komodorAgent.tolerations | list | `[]` | Set tolerations for the komodor agent deployment |
+| components.komodorAgent.podAnnotations | object | `{}` | Set pod annotations for the komodor agent deployment |
+| components.komodorAgent.podSecurityContext | object | `{}` | Set custom pod-level securityContext for the komodor agent deployment. Supports pod-only fields: fsGroup, runAsUser, runAsGroup, runAsNonRoot, supplementalGroups, sysctls, seccompProfile. (use with caution) |
+| components.komodorAgent.securityContext | object | `{}` | DEPRECATED: use podSecurityContext instead. Kept as a fallback for backward compatibility with pod-level securityContext. |
+| components.komodorAgent.strategy | object | `{}` | Set the rolling update strategy for the komodor agent deployment |
+| components.komodorAgent.watcher.image | object | `{ "name": "komodor-agent", "tag": .Chart.AppVersion }` | Override the komodor agent watcher image name or tag. |
+| components.komodorAgent.watcher.resources | object | `{"limits":{"cpu":2,"memory":"8Gi"},"requests":{"cpu":0.25,"memory":"256Mi"}}` | Set custom resources to the komodor agent watcher container |
+| components.komodorAgent.watcher.securityContext | object | `{}` | Set container-level securityContext for the komodor agent watcher container. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
+| components.komodorAgent.watcher.ports | object | `{"healthCheck":8090}` | Override the komodor agent watcher ports configuration |
+| components.komodorAgent.watcher.ports.healthCheck | int | `8090` | Override the health check port of the komodor agent watcher |
+| components.komodorAgent.watcher.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
+| components.komodorAgent.watcher.extraVolumes | list | `[]` | List of additional volumes and their mounts to add to the watcher container. Example (projected ServiceAccount token):      extraVolumes:        - volume:            name: workload-identity-token            projected:              sources:                - serviceAccountToken:                    path: token                    expirationSeconds: 3600                    audience: <token-exchange-audience>          volumeMount:            name: workload-identity-token            mountPath: /var/run/secrets/tokens            readOnly: true |
+| components.komodorAgent.supervisor.image | object | `{ "name": "supervisor", "tag": .Chart.AppVersion }` | Override the komodor agent supervisor image name or tag. |
+| components.komodorAgent.supervisor.resources | object | `{"requests":{"cpu":0.1,"memory":"256Mi"}}` | Set custom resources to the komodor agent supervisor container |
+| components.komodorAgent.supervisor.securityContext | object | `{}` | Set container-level securityContext for the komodor agent supervisor container. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
+| components.komodorAgent.supervisor.ports | object | `{"healthCheck":8089}` | Override the komodor agent supervisor ports configuration |
+| components.komodorAgent.supervisor.ports.healthCheck | int | `8089` | Override the health check port of the komodor agent supervisor |
+| components.komodorAgent.supervisor.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
+| components.komodorKubectlProxy | object | See sub-values | Configure the komodor kubectl proxy components |
+| components.komodorKubectlProxy.image | object | see sub-values | Override the komodor kubectl proxy image name or tag. |
+| components.komodorKubectlProxy.resources | object | `{}` | Set custom resources to the komodor kubectl proxy container |
+| components.komodorKubectlProxy.PriorityClassValue | int | `10000000` | Set the priority class value for the komodor kubectl proxy deployment |
+| components.komodorKubectlProxy.priorityClassName | string | `""` | Use an existing priority class for the komodor kubectl proxy deployment. If not set, will create and use a priority class with PriorityClassValue. WARNING: priorityClassName is immutable and cannot be changed after initial deployment |
+| components.komodorKubectlProxy.affinity | object | `{}` | Set node affinity for the komodor kubectl proxy deployment |
+| components.komodorKubectlProxy.annotations | object | `{}` | Set annotations for the komodor kubectl proxy deployment |
+| components.komodorKubectlProxy.podAnnotations | object | `{}` | Set pod annotations for the komodor kubectl proxy deployment |
+| components.komodorKubectlProxy.labels | object | `{}` | Set custom labels |
+| components.komodorKubectlProxy.nodeSelector | object | `{}` | Set node selectors for the komodor kubectl proxy deployment |
+| components.komodorKubectlProxy.tolerations | list | `[]` | Set tolerations for the komodor kubectl proxy deployment |
+| components.komodorKubectlProxy.podSecurityContext | object | `{}` | Set custom pod-level securityContext for the komodor kubectl proxy deployment. Supports pod-only fields: fsGroup, runAsUser, runAsGroup, runAsNonRoot, supplementalGroups, sysctls, seccompProfile. (use with caution) |
+| components.komodorKubectlProxy.securityContext | object | `{}` | DEPRECATED: use podSecurityContext instead. Kept as a fallback for backward compatibility with pod-level securityContext. |
+| components.komodorKubectlProxy.containerSecurityContext | object | `{}` | Set container-level securityContext for the komodor kubectl proxy container. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
+| components.komodorKubectlProxy.strategy | object | `{}` | Set the rolling update strategy for the komodor kubectl proxy deployment |
 | components.admissionController | object | See sub-values | Configure the komodor admission controller component |
+| components.admissionController.replicas | int | `2` | Number of replicas for the admission controller deployment |
+| components.admissionController.serviceAccount | object | see sub-values | Configure the service account for the admission controller |
+| components.admissionController.serviceAccount.create | bool | `true` | Creates a service account for the admission controller |
+| components.admissionController.serviceAccount.name | string | `nil` | Name of the service account, Required if `serviceAccount.create` is false |
+| components.admissionController.serviceAccount.annotations | object | `{}` | Add annotations to the service account |
+| components.admissionController.image | object | see sub-values | Override the komodor admission controller image name or tag. |
+| components.admissionController.resources | object | `{"limits":{"cpu":1,"memory":"4Gi"},"requests":{"cpu":"500m","memory":"1Gi"}}` | Set custom resources to the komodor admission controller container - Memory utilization is relative to the amount of: [pods, nodes, pvcs, pvs, pdbs] resources you have in the cluster. |
 | components.admissionController.PriorityClassValue | int | `10000000` | Set the priority class value for the komodor admission-controller deployment |
+| components.admissionController.priorityClassName | string | `""` | Use an existing priority class for the komodor admission-controller deployment. If not set, will create and use a priority class with PriorityClassValue. WARNING: priorityClassName is immutable and cannot be changed after initial deployment |
 | components.admissionController.affinity | object | `{"nodeAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"preference":{"matchExpressions":[{"key":"eks.amazonaws.com/capacityType","operator":"NotIn","values":["SPOT"]},{"key":"karpenter.sh/capacity-type","operator":"NotIn","values":["spot"]},{"key":"cloud.google.com/gke-spot","operator":"NotIn","values":["true"]},{"key":"cloud.google.com/gke-preemptible","operator":"NotIn","values":["true"]},{"key":"kubernetes.azure.com/scalesetpriority","operator":"NotIn","values":["spot"]}]},"weight":100}]},"podAffinity":{},"podAntiAffinity":{}}` | Set affinity rules for the komodor admission controller deployment. Split into nodeAffinity, podAffinity, and podAntiAffinity. If podAntiAffinity is not set, defaults to preferred pod anti-affinity on hostname |
 | components.admissionController.affinity.nodeAffinity | object | `{"preferredDuringSchedulingIgnoredDuringExecution":[{"preference":{"matchExpressions":[{"key":"eks.amazonaws.com/capacityType","operator":"NotIn","values":["SPOT"]},{"key":"karpenter.sh/capacity-type","operator":"NotIn","values":["spot"]},{"key":"cloud.google.com/gke-spot","operator":"NotIn","values":["true"]},{"key":"cloud.google.com/gke-preemptible","operator":"NotIn","values":["true"]},{"key":"kubernetes.azure.com/scalesetpriority","operator":"NotIn","values":["spot"]}]},"weight":100}]}` | Set node affinity for the komodor admission controller deployment |
 | components.admissionController.affinity.podAffinity | object | `{}` | Set pod affinity for the komodor admission controller deployment |
 | components.admissionController.affinity.podAntiAffinity | object | `{}` | Set pod anti-affinity for the komodor admission controller deployment. If not set, defaults to preferred pod anti-affinity on hostname |
 | components.admissionController.annotations | object | `{}` | Set annotations for the komodor admission controller deployment |
-| components.admissionController.containerSecurityContext | object | `{}` | Set container-level securityContext for the admission controller container. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
-| components.admissionController.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
-| components.admissionController.extraVolumes | list | `[]` | List of additional volumes to mount in the komodor admission controller deployment/pod      extraVolumes:        - volume:            name: webhook-tls            secret:              secretName: komodor-admission-controller-tls          volumeMount:            name: webhook-tls            mountPath: /etc/komodor/admission/tls            readOnly: true |
-| components.admissionController.image | object | see sub-values | Override the komodor admission controller image name or tag. |
-| components.admissionController.labels | object | `{}` | Set custom labels |
-| components.admissionController.leaderElectionLeaseName | string | `""` | The name to use for leader election leases. If not set, defaults to the admission controller deployment name |
-| components.admissionController.nodeSelector | object | `{}` | Set node selectors for the komodor admission controller deployment |
 | components.admissionController.podAnnotations | object | `{}` | Set pod annotations for the komodor admission controller deployment |
-| components.admissionController.podSecurityContext | object | `{}` | Set custom pod-level securityContext for the komodor admission controller deployment. Supports pod-only fields: fsGroup, runAsUser, runAsGroup, runAsNonRoot, supplementalGroups, sysctls, seccompProfile. (use with caution) |
-| components.admissionController.priorityClassName | string | `""` | Use an existing priority class for the komodor admission-controller deployment. If not set, will create and use a priority class with PriorityClassValue. WARNING: priorityClassName is immutable and cannot be changed after initial deployment |
-| components.admissionController.replicas | int | `2` | Number of replicas for the admission controller deployment |
-| components.admissionController.resources | object | `{"limits":{"cpu":1,"memory":"4Gi"},"requests":{"cpu":"500m","memory":"1Gi"}}` | Set custom resources to the komodor admission controller container - Memory utilization is relative to the amount of: [pods, nodes, pvcs, pvs, pdbs] resources you have in the cluster. |
-| components.admissionController.securityContext | object | `{}` | DEPRECATED: use podSecurityContext instead. Kept as a fallback for backward compatibility with pod-level securityContext. |
-| components.admissionController.serviceAccount | object | see sub-values | Configure the service account for the admission controller |
-| components.admissionController.serviceAccount.annotations | object | `{}` | Add annotations to the service account |
-| components.admissionController.serviceAccount.create | bool | `true` | Creates a service account for the admission controller |
-| components.admissionController.serviceAccount.name | string | `nil` | Name of the service account, Required if `serviceAccount.create` is false |
-| components.admissionController.strategy | object | `{}` | Set the rolling update strategy for the komodor admission controller |
+| components.admissionController.labels | object | `{}` | Set custom labels |
+| components.admissionController.nodeSelector | object | `{}` | Set node selectors for the komodor admission controller deployment |
 | components.admissionController.tolerations | list | `[]` | Set tolerations for the komodor admission controller deployment |
-| components.gpuAccess | object | `{"containerSecurityContext":{},"enabled":false,"image":"alpine:latest","labels":{},"nodeSelector":{},"podSecurityContext":{},"pullPolicy":"IfNotPresent","resources":{"limits":{"cpu":"250m","memory":"100Mi"},"requests":{"cpu":"100m","memory":"50Mi"}},"tolerations":[{"effect":"NoSchedule","key":"nvidia.com/gpu","operator":"Exists"}]}` | settings for GPU host diagnostics accessor DaemonSet |
-| components.gpuAccess.containerSecurityContext | object | `{}` | Set container-level securityContext for the GPU accessor container. When empty, defaults to privileged: true (matching gpuAccess.enabled). (use with caution) |
-| components.gpuAccess.enabled | bool | `false` | Enable creating privileged CUDA container with host mounts to access GPU info |
-| components.gpuAccess.image | string | `"alpine:latest"` | CUDA image to be used for GPU access container |
-| components.gpuAccess.labels | object | `{}` | Adds custom labels |
-| components.gpuAccess.nodeSelector | object | `{}` | Set node selectors for the komodor agent daemon |
-| components.gpuAccess.podSecurityContext | object | `{}` | Set custom pod-level securityContext for the GPU accessor DaemonSet. (use with caution) |
-| components.gpuAccess.pullPolicy | string | `"IfNotPresent"` | Default Image pull policy for the GPU accessor image acceptable values <ifNotPresent\Always\Never>. |
-| components.gpuAccess.resources | object | `{"limits":{"cpu":"250m","memory":"100Mi"},"requests":{"cpu":"100m","memory":"50Mi"}}` | Set custom resources to the GPU accessor container |
-| components.gpuAccess.tolerations | list | `[{"effect":"NoSchedule","key":"nvidia.com/gpu","operator":"Exists"}]` | Add tolerations to the komodor agent daemon |
-| components.komodorAgent | object | See sub-values | Configure the komodor agent components |
-| components.komodorAgent.PriorityClassValue | int | `10000000` | Set the priority class value for the komodor agent deployment |
-| components.komodorAgent.affinity | object | `{}` | Set node affinity for the komodor agent deployment |
-| components.komodorAgent.annotations | object | `{}` | Set annotations for the komodor agent deployment |
-| components.komodorAgent.labels | object | `{}` | Set custom labels |
-| components.komodorAgent.nodeSelector | object | `{}` | Set node selectors for the komodor agent deployment |
-| components.komodorAgent.podAnnotations | object | `{}` | Set pod annotations for the komodor agent deployment |
-| components.komodorAgent.podSecurityContext | object | `{}` | Set custom pod-level securityContext for the komodor agent deployment. Supports pod-only fields: fsGroup, runAsUser, runAsGroup, runAsNonRoot, supplementalGroups, sysctls, seccompProfile. (use with caution) |
-| components.komodorAgent.priorityClassName | string | `""` | Use an existing priority class for the komodor agent deployment. If not set, will create and use a priority class with PriorityClassValue. WARNING: priorityClassName is immutable and cannot be changed after initial deployment |
-| components.komodorAgent.securityContext | object | `{}` | DEPRECATED: use podSecurityContext instead. Kept as a fallback for backward compatibility with pod-level securityContext. |
-| components.komodorAgent.strategy | object | `{}` | Set the rolling update strategy for the komodor agent deployment |
-| components.komodorAgent.supervisor.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
-| components.komodorAgent.supervisor.image | object | `{ "name": "supervisor", "tag": .Chart.AppVersion }` | Override the komodor agent supervisor image name or tag. |
-| components.komodorAgent.supervisor.ports | object | `{"healthCheck":8089}` | Override the komodor agent supervisor ports configuration |
-| components.komodorAgent.supervisor.ports.healthCheck | int | `8089` | Override the health check port of the komodor agent supervisor |
-| components.komodorAgent.supervisor.resources | object | `{"requests":{"cpu":0.1,"memory":"256Mi"}}` | Set custom resources to the komodor agent supervisor container |
-| components.komodorAgent.supervisor.securityContext | object | `{}` | Set container-level securityContext for the komodor agent supervisor container. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
-| components.komodorAgent.tolerations | list | `[]` | Set tolerations for the komodor agent deployment |
-| components.komodorAgent.watcher.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
-| components.komodorAgent.watcher.extraVolumes | list | `[]` | List of additional volumes and their mounts to add to the watcher container. Example (projected ServiceAccount token):      extraVolumes:        - volume:            name: workload-identity-token            projected:              sources:                - serviceAccountToken:                    path: token                    expirationSeconds: 3600                    audience: <token-exchange-audience>          volumeMount:            name: workload-identity-token            mountPath: /var/run/secrets/tokens            readOnly: true |
-| components.komodorAgent.watcher.image | object | `{ "name": "komodor-agent", "tag": .Chart.AppVersion }` | Override the komodor agent watcher image name or tag. |
-| components.komodorAgent.watcher.ports | object | `{"healthCheck":8090}` | Override the komodor agent watcher ports configuration |
-| components.komodorAgent.watcher.ports.healthCheck | int | `8090` | Override the health check port of the komodor agent watcher |
-| components.komodorAgent.watcher.resources | object | `{"limits":{"cpu":2,"memory":"8Gi"},"requests":{"cpu":0.25,"memory":"256Mi"}}` | Set custom resources to the komodor agent watcher container |
-| components.komodorAgent.watcher.securityContext | object | `{}` | Set container-level securityContext for the komodor agent watcher container. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
+| components.admissionController.podSecurityContext | object | `{}` | Set custom pod-level securityContext for the komodor admission controller deployment. Supports pod-only fields: fsGroup, runAsUser, runAsGroup, runAsNonRoot, supplementalGroups, sysctls, seccompProfile. (use with caution) |
+| components.admissionController.securityContext | object | `{}` | DEPRECATED: use podSecurityContext instead. Kept as a fallback for backward compatibility with pod-level securityContext. |
+| components.admissionController.containerSecurityContext | object | `{}` | Set container-level securityContext for the admission controller container. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
+| components.admissionController.strategy | object | `{}` | Set the rolling update strategy for the komodor admission controller |
+| components.admissionController.extraVolumes | list | `[]` | List of additional volumes to mount in the komodor admission controller deployment/pod      extraVolumes:        - volume:            name: webhook-tls            secret:              secretName: komodor-admission-controller-tls          volumeMount:            name: webhook-tls            mountPath: /etc/komodor/admission/tls            readOnly: true |
+| components.admissionController.leaderElectionLeaseName | string | `""` | The name to use for leader election leases. If not set, defaults to the admission controller deployment name |
+| components.admissionController.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
+| components.komodorMetrics.PriorityClassValue | int | `10000000` | Set the priority class value for the komodor metrics agent deployment |
+| components.komodorMetrics.priorityClassName | string | `""` | Use an existing priority class for the komodor metrics agent deployment. If not set, will create and use a priority class with PriorityClassValue. WARNING: priorityClassName is immutable and cannot be changed after initial deployment |
+| components.komodorMetrics.disableHttp2 | bool | `false` | Disable HTTP/2 client by setting GODEBUG=http2client=0 for komodor-agent-metrics |
+| components.komodorMetrics.affinity | object | `{}` | Set node affinity for the komodor metrics agent deployment |
+| components.komodorMetrics.annotations | object | `{}` | Set annotations for the komodor metrics agent deployment |
+| components.komodorMetrics.labels | object | `{}` | Set custom labels |
+| components.komodorMetrics.nodeSelector | object | `{}` | Set node selectors for the komodor metrics agent deployment |
+| components.komodorMetrics.tolerations | list | `[]` | Set tolerations for the komodor metrics agent deployment |
+| components.komodorMetrics.podAnnotations | object | `{}` | Set pod annotations for the komodor metrics agent deployment |
+| components.komodorMetrics.podSecurityContext | object | `{}` | Set custom pod-level securityContext for the komodor metrics deployment. Supports pod-only fields: fsGroup, runAsUser, runAsGroup, runAsNonRoot, supplementalGroups, sysctls, seccompProfile. (use with caution) |
+| components.komodorMetrics.securityContext | object | `{}` | DEPRECATED: use podSecurityContext instead. Kept as a fallback for backward compatibility with pod-level securityContext. |
+| components.komodorMetrics.strategy | object | `{}` | Set the rolling update strategy for the komodor metrics agent deployment |
+| components.komodorMetrics.metricsInit | object | See sub-values | Configure the komodor metrics init container |
+| components.komodorMetrics.metricsInit.image | object | `{ "name": "komodor-agent", "tag": .Chart.AppVersion }` | Override the komodor agent metrics init image name or tag. |
+| components.komodorMetrics.metricsInit.resources | object | `{}` | Set custom resources to the komodor agent metrics init container |
+| components.komodorMetrics.metricsInit.securityContext | object | `{}` | Set container-level securityContext for the komodor metrics init and sidecar containers. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
+| components.komodorMetrics.metricsInit.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
+| components.komodorMetrics.metrics.image | object | `{"name":"telegraf","tag":"v2.0.56-alpine"}` | Override the komodor agent metrics image name or tag. |
+| components.komodorMetrics.metrics.resources | object | `{"limits":{"cpu":1,"memory":"4Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
+| components.komodorMetrics.metrics.securityContext | object | `{}` | Set container-level securityContext for the komodor metrics (telegraf) container. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
+| components.komodorMetrics.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
+| components.komodorMetrics.metrics.sidecar | object | `{"enabled":true}` | Configure the telegraf-init sidecar container |
+| components.komodorMetrics.metrics.sidecar.enabled | bool | `true` | Enable the telegraf-init sidecar container |
 | components.komodorDaemon | object | See sub-values | Configure the komodor agent components |
+| components.komodorDaemon.hostNetwork | bool | `false` | Set host network for the komodor agent daemon |
+| components.komodorDaemon.dnsPolicy | string | `"ClusterFirst"` | Set dns policy for the komodor agent daemon |
+| components.komodorDaemon.disableHttp2 | bool | `false` | Disable HTTP/2 client by setting GODEBUG=http2client=0 for komodor-agent-daemon |
 | components.komodorDaemon.PriorityClassValue | int | `10000000` | Set the priority class value for the komodor daemon deployment |
+| components.komodorDaemon.priorityClassName | string | `""` | Use an existing priority class for the komodor daemon deployment. If not set, will create and use a priority class with PriorityClassValue. WARNING: priorityClassName is immutable and cannot be changed after initial deployment |
 | components.komodorDaemon.affinity | object | `{}` | Set node affinity for the komodor agent daemon |
 | components.komodorDaemon.annotations | object | `{}` | Adds custom annotations - Example: `--set annotations."app\.komodor\.com/app"="komodor-agent"` |
-| components.komodorDaemon.disableHttp2 | bool | `false` | Disable HTTP/2 client by setting GODEBUG=http2client=0 for komodor-agent-daemon |
-| components.komodorDaemon.dnsPolicy | string | `"ClusterFirst"` | Set dns policy for the komodor agent daemon |
-| components.komodorDaemon.hostNetwork | bool | `false` | Set host network for the komodor agent daemon |
 | components.komodorDaemon.labels | object | `{}` | Adds custom labels |
-| components.komodorDaemon.metrics | object | `{"extraEnvVars":[],"image":{"name":"telegraf","tag":"v2.0.56-alpine"},"quiet":false,"resources":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"add":[],"drop":["ALL"]},"runAsNonRoot":true},"sidecar":{"enabled":true}}` | Configure the komodor daemon metrics components |
-| components.komodorDaemon.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
-| components.komodorDaemon.metrics.image | object | `{"name":"telegraf","tag":"v2.0.56-alpine"}` | Override the komodor agent metrics image name or tag. |
-| components.komodorDaemon.metrics.quiet | bool | `false` | Set the quiet mode for the komodor agent metrics |
-| components.komodorDaemon.metrics.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
-| components.komodorDaemon.metrics.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"add":[],"drop":["ALL"]},"runAsNonRoot":true}` | Set custom securityContext to the telegraf-init sidecar container |
-| components.komodorDaemon.metrics.sidecar | object | `{"enabled":true}` | Configure the telegraf-init sidecar container |
-| components.komodorDaemon.metrics.sidecar.enabled | bool | `true` | Enable the telegraf-init sidecar container |
+| components.komodorDaemon.nodeSelector | object | `{}` | Set node selectors for the komodor agent daemon |
+| components.komodorDaemon.tolerations | list | `[{"operator":"Exists"}]` | Add tolerations to the komodor agent daemon |
+| components.komodorDaemon.podAnnotations | object | `{}` | # Add annotations to the komodor agent watcher pod |
+| components.komodorDaemon.podSecurityContext | object | `{"fsGroup":1001,"runAsGroup":1001,"runAsNonRoot":true,"runAsUser":1001}` | Set custom pod-level securityContext for the komodor daemon. Supports pod-only fields: fsGroup, runAsUser, runAsGroup, runAsNonRoot, supplementalGroups, sysctls, seccompProfile. (use with caution) |
+| components.komodorDaemon.securityContext | object | `{}` | DEPRECATED: use podSecurityContext instead. Kept as a fallback for backward compatibility with pod-level securityContext. |
+| components.komodorDaemon.updateStrategy | object | `{}` | Set the rolling update strategy for the komodor agent daemon deployment |
 | components.komodorDaemon.metricsInit | object | See sub-values | Configure the komodor daemon metrics init container |
-| components.komodorDaemon.metricsInit.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemon.metricsInit.image | object | `{ "name": "init-daemon-agent", "tag": .Chart.AppVersion }` | Override the komodor agent metrics init image name or tag. |
 | components.komodorDaemon.metricsInit.resources | object | `{"limits":{"cpu":1,"memory":"100Mi"},"requests":{"cpu":0.1,"memory":"50Mi"}}` | Set custom resources to the komodor agent metrics init container |
+| components.komodorDaemon.metricsInit.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
+| components.komodorDaemon.metrics | object | `{"extraEnvVars":[],"image":{"name":"telegraf","tag":"v2.0.56-alpine"},"quiet":false,"resources":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"add":[],"drop":["ALL"]},"runAsNonRoot":true},"sidecar":{"enabled":true}}` | Configure the komodor daemon metrics components |
+| components.komodorDaemon.metrics.image | object | `{"name":"telegraf","tag":"v2.0.56-alpine"}` | Override the komodor agent metrics image name or tag. |
+| components.komodorDaemon.metrics.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
+| components.komodorDaemon.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
+| components.komodorDaemon.metrics.quiet | bool | `false` | Set the quiet mode for the komodor agent metrics |
+| components.komodorDaemon.metrics.sidecar | object | `{"enabled":true}` | Configure the telegraf-init sidecar container |
+| components.komodorDaemon.metrics.sidecar.enabled | bool | `true` | Enable the telegraf-init sidecar container |
+| components.komodorDaemon.metrics.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"add":[],"drop":["ALL"]},"runAsNonRoot":true}` | Set custom securityContext to the telegraf-init sidecar container |
 | components.komodorDaemon.nodeEnricher | object | See sub-values | Configure the komodor daemon node enricher components |
-| components.komodorDaemon.nodeEnricher.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemon.nodeEnricher.image | object | `{"name":"komodor-agent","tag":null}` | Override the komodor agent node enricher image name or tag. |
 | components.komodorDaemon.nodeEnricher.resources | object | `{"limits":{"cpu":"10m","memory":"100Mi"},"requests":{"cpu":"1m","memory":"10Mi"}}` | Set custom resources to the komodor agent node enricher container |
+| components.komodorDaemon.nodeEnricher.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemon.nodeEnricher.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"add":[],"drop":["ALL"]},"runAsNonRoot":true}` | Set custom securityContext to the komodor agent node enricher container |
-| components.komodorDaemon.nodeSelector | object | `{}` | Set node selectors for the komodor agent daemon |
 | components.komodorDaemon.opentelemetry | object | See sub-values | Configure the komodor daemon OpenTelemetry collector components |
-| components.komodorDaemon.opentelemetry.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemon.opentelemetry.image | object | `{"name":"komodor-otel-collector","tag":"0.1.10"}` | Override the OpenTelemetry collector image name or tag. |
+| components.komodorDaemon.opentelemetry.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Set custom resources to the OpenTelemetry collector container |
+| components.komodorDaemon.opentelemetry.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemon.opentelemetry.otelInit | object | See sub-values | Configure the OTel init/sidecar containers for remote configuration |
-| components.komodorDaemon.opentelemetry.otelInit.configFileName | string | `"otel-config.yaml"` | Name of the config file written to the shared volume |
 | components.komodorDaemon.opentelemetry.otelInit.enabled | bool | `true` | Enable remote configuration fetching via otel init |
-| components.komodorDaemon.opentelemetry.otelInit.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemon.opentelemetry.otelInit.image | object | `{ "name": "komodor-agent", "tag": .Chart.AppVersion }` | Override the otel init image name or tag. |
 | components.komodorDaemon.opentelemetry.otelInit.resources | object | `{"limits":{"cpu":1,"memory":"100Mi"},"requests":{"cpu":0.1,"memory":"50Mi"}}` | Set custom resources to the otel init containers |
-| components.komodorDaemon.opentelemetry.otelInit.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":0,"runAsNonRoot":false,"runAsUser":0}` | Set container-level securityContext for the OpenTelemetry init and sidecar containers. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
+| components.komodorDaemon.opentelemetry.otelInit.configFileName | string | `"otel-config.yaml"` | Name of the config file written to the shared volume |
+| components.komodorDaemon.opentelemetry.otelInit.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemon.opentelemetry.otelInit.sidecar | object | `{"autoReloadConfig":true,"enabled":true,"pollingIntervalSeconds":300}` | Configure the sidecar for continuous config polling |
-| components.komodorDaemon.opentelemetry.otelInit.sidecar.autoReloadConfig | bool | `true` | Automatically send SIGHUP to the OTel Collector to reload configuration on change (requires shareProcessNamespace) |
 | components.komodorDaemon.opentelemetry.otelInit.sidecar.enabled | bool | `true` | Enable the otel init sidecar for continuous config updates |
 | components.komodorDaemon.opentelemetry.otelInit.sidecar.pollingIntervalSeconds | int | `300` | Polling interval in seconds for config updates |
-| components.komodorDaemon.opentelemetry.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Set custom resources to the OpenTelemetry collector container |
+| components.komodorDaemon.opentelemetry.otelInit.sidecar.autoReloadConfig | bool | `true` | Automatically send SIGHUP to the OTel Collector to reload configuration on change (requires shareProcessNamespace) |
+| components.komodorDaemon.opentelemetry.otelInit.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":0,"runAsNonRoot":false,"runAsUser":0}` | Set container-level securityContext for the OpenTelemetry init and sidecar containers. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
 | components.komodorDaemon.opentelemetry.volumes | object | `{"varlibdockercontainers":{"hostPath":{"path":"/var/lib/docker/containers","type":""},"mountPath":"/var/lib/docker/containers"},"varlogpods":{"hostPath":{"path":"/var/log/pods","type":""},"mountPath":"/var/log/pods"}}` | Configure volumes for OpenTelemetry collector |
-| components.komodorDaemon.opentelemetry.volumes.varlibdockercontainers | object | `{"hostPath":{"path":"/var/lib/docker/containers","type":""},"mountPath":"/var/lib/docker/containers"}` | Configure docker containers volume |
-| components.komodorDaemon.opentelemetry.volumes.varlibdockercontainers.hostPath | object | `{"path":"/var/lib/docker/containers","type":""}` | Configure hostPath for docker containers volume |
-| components.komodorDaemon.opentelemetry.volumes.varlibdockercontainers.hostPath.path | string | `"/var/lib/docker/containers"` | Host path to mount for docker containers |
-| components.komodorDaemon.opentelemetry.volumes.varlibdockercontainers.hostPath.type | string | `""` | Type of hostPath ("" (Empty string, default = no checks), Directory, DirectoryOrCreate, File, FileOrCreate, Socket, CharDevice, BlockDevice) |
-| components.komodorDaemon.opentelemetry.volumes.varlibdockercontainers.mountPath | string | `"/var/lib/docker/containers"` | Mount path inside the container for docker containers |
 | components.komodorDaemon.opentelemetry.volumes.varlogpods | object | `{"hostPath":{"path":"/var/log/pods","type":""},"mountPath":"/var/log/pods"}` | Configure varlogpods volume |
 | components.komodorDaemon.opentelemetry.volumes.varlogpods.hostPath | object | `{"path":"/var/log/pods","type":""}` | Configure hostPath for varlogpods volume |
 | components.komodorDaemon.opentelemetry.volumes.varlogpods.hostPath.path | string | `"/var/log/pods"` | Host path to mount for pod logs |
 | components.komodorDaemon.opentelemetry.volumes.varlogpods.hostPath.type | string | `""` | Type of hostPath ("" (Empty string, default = no checks), Directory, DirectoryOrCreate, File, FileOrCreate, Socket, CharDevice, BlockDevice) |
 | components.komodorDaemon.opentelemetry.volumes.varlogpods.mountPath | string | `"/var/log/pods"` | Mount path inside the container for pod logs |
-| components.komodorDaemon.podAnnotations | object | `{}` | # Add annotations to the komodor agent watcher pod |
-| components.komodorDaemon.podSecurityContext | object | `{"fsGroup":1001,"runAsGroup":1001,"runAsNonRoot":true,"runAsUser":1001}` | Set custom pod-level securityContext for the komodor daemon. Supports pod-only fields: fsGroup, runAsUser, runAsGroup, runAsNonRoot, supplementalGroups, sysctls, seccompProfile. (use with caution) |
-| components.komodorDaemon.priorityClassName | string | `""` | Use an existing priority class for the komodor daemon deployment. If not set, will create and use a priority class with PriorityClassValue. WARNING: priorityClassName is immutable and cannot be changed after initial deployment |
-| components.komodorDaemon.securityContext | object | `{}` | DEPRECATED: use podSecurityContext instead. Kept as a fallback for backward compatibility with pod-level securityContext. |
-| components.komodorDaemon.tolerations | list | `[{"operator":"Exists"}]` | Add tolerations to the komodor agent daemon |
-| components.komodorDaemon.updateStrategy | object | `{}` | Set the rolling update strategy for the komodor agent daemon deployment |
+| components.komodorDaemon.opentelemetry.volumes.varlibdockercontainers | object | `{"hostPath":{"path":"/var/lib/docker/containers","type":""},"mountPath":"/var/lib/docker/containers"}` | Configure docker containers volume |
+| components.komodorDaemon.opentelemetry.volumes.varlibdockercontainers.hostPath | object | `{"path":"/var/lib/docker/containers","type":""}` | Configure hostPath for docker containers volume |
+| components.komodorDaemon.opentelemetry.volumes.varlibdockercontainers.hostPath.path | string | `"/var/lib/docker/containers"` | Host path to mount for docker containers |
+| components.komodorDaemon.opentelemetry.volumes.varlibdockercontainers.hostPath.type | string | `""` | Type of hostPath ("" (Empty string, default = no checks), Directory, DirectoryOrCreate, File, FileOrCreate, Socket, CharDevice, BlockDevice) |
+| components.komodorDaemon.opentelemetry.volumes.varlibdockercontainers.mountPath | string | `"/var/lib/docker/containers"` | Mount path inside the container for docker containers |
 | components.komodorDaemonWindows | object | See sub-values | Configure the komodor agent components |
+| components.komodorDaemonWindows.dnsPolicy | string | `"ClusterFirst"` | Set dns policy for the komodor agent daemon |
 | components.komodorDaemonWindows.affinity | object | `{}` | Set node affinity for the komodor agent daemon |
 | components.komodorDaemonWindows.annotations | object | `{}` | Adds custom annotations - Example: `--set annotations."app\.komodor\.com/app"="komodor-agent"` |
-| components.komodorDaemonWindows.dnsPolicy | string | `"ClusterFirst"` | Set dns policy for the komodor agent daemon |
 | components.komodorDaemonWindows.labels | object | `{}` | Adds custom labels |
-| components.komodorDaemonWindows.metrics | object | `{"extraEnvVars":[],"image":{"name":"telegraf-windows","tag":"v2.0.56"},"quiet":false,"resources":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}},"securityContext":{},"sidecar":{"enabled":true}}` | Configure the komodor daemon metrics components |
-| components.komodorDaemonWindows.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
-| components.komodorDaemonWindows.metrics.image | object | `{"name":"telegraf-windows","tag":"v2.0.56"}` | Override the komodor agent metrics image name or tag. |
-| components.komodorDaemonWindows.metrics.quiet | bool | `false` | Set the quiet mode for the komodor agent metrics |
-| components.komodorDaemonWindows.metrics.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
-| components.komodorDaemonWindows.metrics.securityContext | object | `{}` | Set container-level securityContext for the Windows daemon metrics container. Configure only fields supported by Windows containers. (use with caution) |
-| components.komodorDaemonWindows.metrics.sidecar | object | `{"enabled":true}` | Configure the telegraf-init sidecar container |
-| components.komodorDaemonWindows.metrics.sidecar.enabled | bool | `true` | Enable the telegraf-init sidecar container |
-| components.komodorDaemonWindows.metricsInit | object | See sub-values | Configure the komodor daemon metrics init container |
-| components.komodorDaemonWindows.metricsInit.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
-| components.komodorDaemonWindows.metricsInit.image | object | `{ "name": "init-daemon-agent", "tag": .Chart.AppVersion }` | Override the komodor agent metrics init image name or tag. |
-| components.komodorDaemonWindows.metricsInit.resources | object | `{"limits":{"cpu":1,"memory":"100Mi"},"requests":{"cpu":0.1,"memory":"50Mi"}}` | Set custom resources to the komodor agent metrics init container |
-| components.komodorDaemonWindows.metricsInit.securityContext | object | `{}` | Set container-level securityContext for the Windows daemon metrics init and sidecar containers. Configure only fields supported by Windows containers. (use with caution) |
 | components.komodorDaemonWindows.nodeSelector | object | `{}` | Set node selectors for the komodor agent daemon |
+| components.komodorDaemonWindows.tolerations | list | `[{"operator":"Exists"}]` | Add tolerations to the komodor agent daemon |
 | components.komodorDaemonWindows.podAnnotations | object | `{}` | # Add annotations to the komodor agent watcher pod |
 | components.komodorDaemonWindows.podSecurityContext | object | `{}` | Set custom pod-level securityContext for the komodor Windows daemon. Configure only fields supported by Windows pods. (use with caution) |
-| components.komodorDaemonWindows.tolerations | list | `[{"operator":"Exists"}]` | Add tolerations to the komodor agent daemon |
 | components.komodorDaemonWindows.updateStrategy | object | `{}` | Set the rolling update strategy for the komodor agent daemon deployment |
-| components.komodorKubectlProxy | object | See sub-values | Configure the komodor kubectl proxy components |
-| components.komodorKubectlProxy.PriorityClassValue | int | `10000000` | Set the priority class value for the komodor kubectl proxy deployment |
-| components.komodorKubectlProxy.affinity | object | `{}` | Set node affinity for the komodor kubectl proxy deployment |
-| components.komodorKubectlProxy.annotations | object | `{}` | Set annotations for the komodor kubectl proxy deployment |
-| components.komodorKubectlProxy.containerSecurityContext | object | `{}` | Set container-level securityContext for the komodor kubectl proxy container. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
-| components.komodorKubectlProxy.image | object | see sub-values | Override the komodor kubectl proxy image name or tag. |
-| components.komodorKubectlProxy.labels | object | `{}` | Set custom labels |
-| components.komodorKubectlProxy.nodeSelector | object | `{}` | Set node selectors for the komodor kubectl proxy deployment |
-| components.komodorKubectlProxy.podAnnotations | object | `{}` | Set pod annotations for the komodor kubectl proxy deployment |
-| components.komodorKubectlProxy.podSecurityContext | object | `{}` | Set custom pod-level securityContext for the komodor kubectl proxy deployment. Supports pod-only fields: fsGroup, runAsUser, runAsGroup, runAsNonRoot, supplementalGroups, sysctls, seccompProfile. (use with caution) |
-| components.komodorKubectlProxy.priorityClassName | string | `""` | Use an existing priority class for the komodor kubectl proxy deployment. If not set, will create and use a priority class with PriorityClassValue. WARNING: priorityClassName is immutable and cannot be changed after initial deployment |
-| components.komodorKubectlProxy.resources | object | `{}` | Set custom resources to the komodor kubectl proxy container |
-| components.komodorKubectlProxy.securityContext | object | `{}` | DEPRECATED: use podSecurityContext instead. Kept as a fallback for backward compatibility with pod-level securityContext. |
-| components.komodorKubectlProxy.strategy | object | `{}` | Set the rolling update strategy for the komodor kubectl proxy deployment |
-| components.komodorKubectlProxy.tolerations | list | `[]` | Set tolerations for the komodor kubectl proxy deployment |
-| components.komodorMetrics.PriorityClassValue | int | `10000000` | Set the priority class value for the komodor metrics agent deployment |
-| components.komodorMetrics.affinity | object | `{}` | Set node affinity for the komodor metrics agent deployment |
-| components.komodorMetrics.annotations | object | `{}` | Set annotations for the komodor metrics agent deployment |
-| components.komodorMetrics.disableHttp2 | bool | `false` | Disable HTTP/2 client by setting GODEBUG=http2client=0 for komodor-agent-metrics |
-| components.komodorMetrics.labels | object | `{}` | Set custom labels |
-| components.komodorMetrics.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
-| components.komodorMetrics.metrics.image | object | `{"name":"telegraf","tag":"v2.0.56-alpine"}` | Override the komodor agent metrics image name or tag. |
-| components.komodorMetrics.metrics.resources | object | `{"limits":{"cpu":1,"memory":"4Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
-| components.komodorMetrics.metrics.securityContext | object | `{}` | Set container-level securityContext for the komodor metrics (telegraf) container. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
-| components.komodorMetrics.metrics.sidecar | object | `{"enabled":true}` | Configure the telegraf-init sidecar container |
-| components.komodorMetrics.metrics.sidecar.enabled | bool | `true` | Enable the telegraf-init sidecar container |
-| components.komodorMetrics.metricsInit | object | See sub-values | Configure the komodor metrics init container |
-| components.komodorMetrics.metricsInit.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
-| components.komodorMetrics.metricsInit.image | object | `{ "name": "komodor-agent", "tag": .Chart.AppVersion }` | Override the komodor agent metrics init image name or tag. |
-| components.komodorMetrics.metricsInit.resources | object | `{}` | Set custom resources to the komodor agent metrics init container |
-| components.komodorMetrics.metricsInit.securityContext | object | `{}` | Set container-level securityContext for the komodor metrics init and sidecar containers. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
-| components.komodorMetrics.nodeSelector | object | `{}` | Set node selectors for the komodor metrics agent deployment |
-| components.komodorMetrics.podAnnotations | object | `{}` | Set pod annotations for the komodor metrics agent deployment |
-| components.komodorMetrics.podSecurityContext | object | `{}` | Set custom pod-level securityContext for the komodor metrics deployment. Supports pod-only fields: fsGroup, runAsUser, runAsGroup, runAsNonRoot, supplementalGroups, sysctls, seccompProfile. (use with caution) |
-| components.komodorMetrics.priorityClassName | string | `""` | Use an existing priority class for the komodor metrics agent deployment. If not set, will create and use a priority class with PriorityClassValue. WARNING: priorityClassName is immutable and cannot be changed after initial deployment |
-| components.komodorMetrics.securityContext | object | `{}` | DEPRECATED: use podSecurityContext instead. Kept as a fallback for backward compatibility with pod-level securityContext. |
-| components.komodorMetrics.strategy | object | `{}` | Set the rolling update strategy for the komodor metrics agent deployment |
-| components.komodorMetrics.tolerations | list | `[]` | Set tolerations for the komodor metrics agent deployment |
-| createNamespace | bool | `true` | Creates the namespace |
-| createRbac | bool | `true` | Creates the necessary RBAC resources for the agent - use with caution! |
-| customCa | object | See sub-values | Configure custom CA for the agent (Not supported for windows) |
-| customCa.enabled | bool | `false` | Enable custom CA certificate for the agent |
-| customCa.resources | dict | `{"limits":{"cpu":"10m","memory":"100Mi"},"requests":{"cpu":"1m","memory":"10Mi"}}` | Set custom resources to the custom CA container |
-| customCa.secretName | string | `nil` | Name of the secret containing the CA |
-| customCa.securityContext | dict | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000}` | Set container-level securityContext for the custom CA init container. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
-| global | object | See sub-values | Global defaults applied across the chart. |
-| global.podSecurityContext | object | `{}` | Set a pod-level securityContext applied to all agent pods unless a component-specific podSecurityContext is defined. Supports pod-only fields: fsGroup, runAsUser, runAsGroup, runAsNonRoot, supplementalGroups, sysctls, seccompProfile. (use with caution) |
-| global.securityContext | object | `{}` | Set a container-level securityContext applied to all containers unless a container-specific securityContext is defined. Supports container fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
-| imagePullSecret | string | `nil` | Set the image pull secret for the komodor agent |
-| imageRepo | string | `"public.ecr.aws/komodor-public"` | Override the komodor agent image repository. |
-| proxy.enabled | bool | `false` | Enable proxy for the agent |
-| proxy.http | string | `nil` | Configure Proxy setting (HTTP_PROXY) `eg. http://proxy.com:8080` |
-| proxy.https | string | `nil` | Configure Proxy setting (HTTPS_PROXY) `eg. https://proxy.com:8080` |
-| proxy.komodorOnly | bool | `true` | Configure proxy to be applied only on communication to Komodor servers (comms. to K8S API remains without proxy) |
-| proxy.no_proxy | string | `nil` | Specify specific domains to ignore proxy for. eg. `komodor.com,google.com` |
-| proxy.no_proxy_local_addresses | bool | `false` | When true, prepends standard Kubernetes-internal addresses (localhost, 127.0.0.1, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, .cluster.local, .svc) to NO_PROXY so that in-cluster traffic (e.g. Kubernetes API server) bypasses the proxy. |
-| publicApiKey | guid | `nil` | Komodor public API key. Required when features that depend on it are enabled (currently capabilities.klaudiaIntegrationSync). |
-| publicApiKeySecret | string | `nil` | Existing Kubernetes secret containing the public API key |
-| publicApiKeySecretKey | string | `nil` | Key inside publicApiKeySecret (defaults to publicApiKey) |
-| pullPolicy | string | `"IfNotPresent"` | Default Image pull policy for the komodor agent image acceptable values <ifNotPresent\Always\Never>. |
-| serviceAccount | object | See sub-values | Configure service account for the agent |
-| serviceAccount.annotations | object | `{}` | Add annotations to the service account |
-| serviceAccount.create | bool | `true` | Creates a service account for the agent |
-| serviceAccount.name | string | `nil` | Name of the service account, Required if `serviceAccount.create` is false |
-| site | string | "us" | Komodor site, allowed values: "us", "eu" |
-| tags | dict | `{}` | Tags the agent in order to identify it based on `key:value` properties separated by semicolon (`;`) example: `--set tags.env=staging,tags.team=payments` --- Can also be set in the values under `tags` as a dictionary of key:value strings |
-| telegrafImageVersion | string | `"v2.0.56-alpine"` | Telegraf version to be used |
-| telegrafWindowsImageVersion | string | `"v2.0.56"` | Telegraf version to be used for windows |
+| components.komodorDaemonWindows.metricsInit | object | See sub-values | Configure the komodor daemon metrics init container |
+| components.komodorDaemonWindows.metricsInit.image | object | `{ "name": "init-daemon-agent", "tag": .Chart.AppVersion }` | Override the komodor agent metrics init image name or tag. |
+| components.komodorDaemonWindows.metricsInit.resources | object | `{"limits":{"cpu":1,"memory":"100Mi"},"requests":{"cpu":0.1,"memory":"50Mi"}}` | Set custom resources to the komodor agent metrics init container |
+| components.komodorDaemonWindows.metricsInit.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
+| components.komodorDaemonWindows.metricsInit.securityContext | object | `{}` | Set container-level securityContext for the Windows daemon metrics init and sidecar containers. Configure only fields supported by Windows containers. (use with caution) |
+| components.komodorDaemonWindows.metrics | object | `{"extraEnvVars":[],"image":{"name":"telegraf-windows","tag":"v2.0.56"},"quiet":false,"resources":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}},"securityContext":{},"sidecar":{"enabled":true}}` | Configure the komodor daemon metrics components |
+| components.komodorDaemonWindows.metrics.image | object | `{"name":"telegraf-windows","tag":"v2.0.56"}` | Override the komodor agent metrics image name or tag. |
+| components.komodorDaemonWindows.metrics.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
+| components.komodorDaemonWindows.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
+| components.komodorDaemonWindows.metrics.securityContext | object | `{}` | Set container-level securityContext for the Windows daemon metrics container. Configure only fields supported by Windows containers. (use with caution) |
+| components.komodorDaemonWindows.metrics.quiet | bool | `false` | Set the quiet mode for the komodor agent metrics |
+| components.komodorDaemonWindows.metrics.sidecar | object | `{"enabled":true}` | Configure the telegraf-init sidecar container |
+| components.komodorDaemonWindows.metrics.sidecar.enabled | bool | `true` | Enable the telegraf-init sidecar container |
+| components.gpuAccess | object | `{"containerSecurityContext":{},"enabled":false,"image":"alpine:latest","labels":{},"nodeSelector":{},"podSecurityContext":{},"pullPolicy":"IfNotPresent","resources":{"limits":{"cpu":"250m","memory":"100Mi"},"requests":{"cpu":"100m","memory":"50Mi"}},"tolerations":[{"effect":"NoSchedule","key":"nvidia.com/gpu","operator":"Exists"}]}` | settings for GPU host diagnostics accessor DaemonSet |
+| components.gpuAccess.enabled | bool | `false` | Enable creating privileged CUDA container with host mounts to access GPU info |
+| components.gpuAccess.image | string | `"alpine:latest"` | CUDA image to be used for GPU access container |
+| components.gpuAccess.pullPolicy | string | `"IfNotPresent"` | Default Image pull policy for the GPU accessor image acceptable values <ifNotPresent\Always\Never>. |
+| components.gpuAccess.resources | object | `{"limits":{"cpu":"250m","memory":"100Mi"},"requests":{"cpu":"100m","memory":"50Mi"}}` | Set custom resources to the GPU accessor container |
+| components.gpuAccess.labels | object | `{}` | Adds custom labels |
+| components.gpuAccess.nodeSelector | object | `{}` | Set node selectors for the komodor agent daemon |
+| components.gpuAccess.tolerations | list | `[{"effect":"NoSchedule","key":"nvidia.com/gpu","operator":"Exists"}]` | Add tolerations to the komodor agent daemon |
+| components.gpuAccess.podSecurityContext | object | `{}` | Set custom pod-level securityContext for the GPU accessor DaemonSet. (use with caution) |
+| components.gpuAccess.containerSecurityContext | object | `{}` | Set container-level securityContext for the GPU accessor container. When empty, defaults to privileged: true (matching gpuAccess.enabled). (use with caution) |
+| allowedResources.event | bool | `true` | Enables watching `event` |
+| allowedResources.deployment | bool | `true` | Enables watching `deployments` |
+| allowedResources.replicationController | bool | `true` | Enables watching `replicationControllers` |
+| allowedResources.replicaSet | bool | `true` | Enables watching `replicaSets` |
+| allowedResources.daemonSet | bool | `true` | Enables watching `daemonSets` |
+| allowedResources.statefulSet | bool | `true` | Enables watching `statefulSets` |
+| allowedResources.service | bool | `true` | Enables watching `services` |
+| allowedResources.pod | bool | `true` | Enables watching `pods` |
+| allowedResources.job | bool | `true` | Enables watching `jobs` |
+| allowedResources.cronjob | bool | `true` | Enables watching `cronjobs` |
+| allowedResources.node | bool | `true` | Enables watching `nodes` |
+| allowedResources.clusterRole | bool | `true` | Enables watching `clusterRoles` |
+| allowedResources.serviceAccount | bool | `true` | Enables watching `serviceAccounts` |
+| allowedResources.persistentVolume | bool | `true` | Enables watching `persistentVolumes` |
+| allowedResources.persistentVolumeClaim | bool | `true` | Enables watching `persistentVolumeClaims` |
+| allowedResources.namespace | bool | `true` | Enables watching `namespaces` |
+| allowedResources.secret | bool | `true` | Enables watching `secrets` |
+| allowedResources.configMap | bool | `true` | Enables watching `configmaps` |
+| allowedResources.ingress | bool | `true` | Enables watching `ingresses` |
+| allowedResources.endpoints | bool | `true` | Enables watching `endpoints` |
+| allowedResources.storageClass | bool | `true` | Enables watching `storageClasses` |
+| allowedResources.rollout | bool | `true` | Enables watching `rollouts` |
+| allowedResources.metrics | bool | `true` | Enables watching `metrics` |
+| allowedResources.limitRange | bool | `true` | Enables watching `limitRange` |
+| allowedResources.podTemplate | bool | `true` | Enables watching `podTemplate` |
+| allowedResources.resourceQuota | bool | `true` | Enables watching `resourceQuota` |
+| allowedResources.admissionRegistrationResources | bool | `true` | Enables watching `admissionRegistrationResources` |
+| allowedResources.controllerRevision | bool | `true` | Enables watching `controllerRevision` |
+| allowedResources.authorizationResources | bool | `true` | Enables watching `authorizationResources` |
+| allowedResources.horizontalPodAutoscaler | bool | `true` | Enables watching `horizontalPodAutoscaler` |
+| allowedResources.certificateSigningRequest | bool | `true` | Enables watching `certificateSigningRequest` |
+| allowedResources.lease | bool | `true` | Enables watching `lease` |
+| allowedResources.endpointSlice | bool | `true` | Enables watching `endpointslice` |
+| allowedResources.flowControlResources | bool | `true` | Enables watching `flowControlResources` |
+| allowedResources.ingressClass | bool | `true` | Enables watching `ingressClass` |
+| allowedResources.networkPolicy | bool | `true` | Enables watching `networkPolicy` |
+| allowedResources.runtimeClass | bool | `true` | Enables watching `runtimeClass` |
+| allowedResources.podDisruptionBudget | bool | `true` | Enables watching `podDisruptionBudgets` |
+| allowedResources.policyResources | bool | `true` | Enables watching `policyResources` |
+| allowedResources.clusterRoleBinding | bool | `true` | Enables watching `clusterRoleBinding` |
+| allowedResources.roleBinding | bool | `true` | Enables watching `roleBinding` |
+| allowedResources.role | bool | `true` | Enables watching `role` |
+| allowedResources.priorityClass | bool | `true` | Enables watching `priorityClass` |
+| allowedResources.csiDriver | bool | `true` | Enables watching `csiDriver` |
+| allowedResources.csiNode | bool | `true` | Enables watching `csiNode` |
+| allowedResources.csiStorageCapacity | bool | `true` | Enables watching `csiStorageCapacity` |
+| allowedResources.volumeAttachment | bool | `true` | Enables watching `volumeAttachment` |
+| allowedResources.argoWorkflows | object | See sub-values | Enables watching argo resources |
+| allowedResources.argoWorkflows.workflows | bool | `true` | Enables watching Argo `workflows` |
+| allowedResources.argoWorkflows.workflowTemplates | bool | `true` | Enables watching Argo `workflowTemplates` |
+| allowedResources.argoWorkflows.clusterWorkflowTemplates | bool | `true` | Enables watching Argo `clusterWorkflowTemplates` |
+| allowedResources.argoWorkflows.cronWorkflows | bool | `true` | Enables watching Argo `cronWorkflows` |
+| allowedResources.customReadAPIGroups | list | `[]` | A list of custom API groups to allow read access to - each array element should be a string which represents the group name |
+| allowedResources.allowReadAll | bool | `true` | Allow reading all the resources in the cluster |
 
 [README.md](README.md)
 > **Tip**: You can use the default [values.yaml](values.yaml)

--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -145,360 +145,362 @@ Relevant values:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| site | string | "us" | Komodor site, allowed values: "us", "eu" |
+| admissionControllerVersion | string | `"0.1.60"` | Admission controller version to be used |
+| allowedResources.admissionRegistrationResources | bool | `true` | Enables watching `admissionRegistrationResources` |
+| allowedResources.allowReadAll | bool | `true` | Allow reading all the resources in the cluster |
+| allowedResources.argoWorkflows | object | See sub-values | Enables watching argo resources |
+| allowedResources.argoWorkflows.clusterWorkflowTemplates | bool | `true` | Enables watching Argo `clusterWorkflowTemplates` |
+| allowedResources.argoWorkflows.cronWorkflows | bool | `true` | Enables watching Argo `cronWorkflows` |
+| allowedResources.argoWorkflows.workflowTemplates | bool | `true` | Enables watching Argo `workflowTemplates` |
+| allowedResources.argoWorkflows.workflows | bool | `true` | Enables watching Argo `workflows` |
+| allowedResources.authorizationResources | bool | `true` | Enables watching `authorizationResources` |
+| allowedResources.certificateSigningRequest | bool | `true` | Enables watching `certificateSigningRequest` |
+| allowedResources.clusterRole | bool | `true` | Enables watching `clusterRoles` |
+| allowedResources.clusterRoleBinding | bool | `true` | Enables watching `clusterRoleBinding` |
+| allowedResources.configMap | bool | `true` | Enables watching `configmaps` |
+| allowedResources.controllerRevision | bool | `true` | Enables watching `controllerRevision` |
+| allowedResources.cronjob | bool | `true` | Enables watching `cronjobs` |
+| allowedResources.csiDriver | bool | `true` | Enables watching `csiDriver` |
+| allowedResources.csiNode | bool | `true` | Enables watching `csiNode` |
+| allowedResources.csiStorageCapacity | bool | `true` | Enables watching `csiStorageCapacity` |
+| allowedResources.customReadAPIGroups | list | `[]` | A list of custom API groups to allow read access to - each array element should be a string which represents the group name |
+| allowedResources.daemonSet | bool | `true` | Enables watching `daemonSets` |
+| allowedResources.deployment | bool | `true` | Enables watching `deployments` |
+| allowedResources.endpointSlice | bool | `true` | Enables watching `endpointslice` |
+| allowedResources.endpoints | bool | `true` | Enables watching `endpoints` |
+| allowedResources.event | bool | `true` | Enables watching `event` |
+| allowedResources.flowControlResources | bool | `true` | Enables watching `flowControlResources` |
+| allowedResources.horizontalPodAutoscaler | bool | `true` | Enables watching `horizontalPodAutoscaler` |
+| allowedResources.ingress | bool | `true` | Enables watching `ingresses` |
+| allowedResources.ingressClass | bool | `true` | Enables watching `ingressClass` |
+| allowedResources.job | bool | `true` | Enables watching `jobs` |
+| allowedResources.lease | bool | `true` | Enables watching `lease` |
+| allowedResources.limitRange | bool | `true` | Enables watching `limitRange` |
+| allowedResources.metrics | bool | `true` | Enables watching `metrics` |
+| allowedResources.namespace | bool | `true` | Enables watching `namespaces` |
+| allowedResources.networkPolicy | bool | `true` | Enables watching `networkPolicy` |
+| allowedResources.node | bool | `true` | Enables watching `nodes` |
+| allowedResources.persistentVolume | bool | `true` | Enables watching `persistentVolumes` |
+| allowedResources.persistentVolumeClaim | bool | `true` | Enables watching `persistentVolumeClaims` |
+| allowedResources.pod | bool | `true` | Enables watching `pods` |
+| allowedResources.podDisruptionBudget | bool | `true` | Enables watching `podDisruptionBudgets` |
+| allowedResources.podTemplate | bool | `true` | Enables watching `podTemplate` |
+| allowedResources.policyResources | bool | `true` | Enables watching `policyResources` |
+| allowedResources.priorityClass | bool | `true` | Enables watching `priorityClass` |
+| allowedResources.replicaSet | bool | `true` | Enables watching `replicaSets` |
+| allowedResources.replicationController | bool | `true` | Enables watching `replicationControllers` |
+| allowedResources.resourceQuota | bool | `true` | Enables watching `resourceQuota` |
+| allowedResources.role | bool | `true` | Enables watching `role` |
+| allowedResources.roleBinding | bool | `true` | Enables watching `roleBinding` |
+| allowedResources.rollout | bool | `true` | Enables watching `rollouts` |
+| allowedResources.runtimeClass | bool | `true` | Enables watching `runtimeClass` |
+| allowedResources.secret | bool | `true` | Enables watching `secrets` |
+| allowedResources.service | bool | `true` | Enables watching `services` |
+| allowedResources.serviceAccount | bool | `true` | Enables watching `serviceAccounts` |
+| allowedResources.statefulSet | bool | `true` | Enables watching `statefulSets` |
+| allowedResources.storageClass | bool | `true` | Enables watching `storageClasses` |
+| allowedResources.volumeAttachment | bool | `true` | Enables watching `volumeAttachment` |
 | apiKey | guid | `nil` | **(*required*)** To be obtained from komodor app during onboarding |
 | apiKeySecret | string | `nil` | Secret name containing Komodor agent api key |
-| publicApiKey | guid | `nil` | Komodor public API key. Required when features that depend on it are enabled (currently capabilities.klaudiaIntegrationSync). |
-| publicApiKeySecret | string | `nil` | Existing Kubernetes secret containing the public API key |
-| publicApiKeySecretKey | string | `nil` | Key inside publicApiKeySecret (defaults to publicApiKey) |
-| createNamespace | bool | `true` | Creates the namespace |
-| tags | dict | `{}` | Tags the agent in order to identify it based on `key:value` properties separated by semicolon (`;`) example: `--set tags.env=staging,tags.team=payments` --- Can also be set in the values under `tags` as a dictionary of key:value strings |
-| clusterName | string | `nil` | **(*required*)** Name to be displayed in the Komodor web application |
-| createRbac | bool | `true` | Creates the necessary RBAC resources for the agent - use with caution! |
-| global | object | See sub-values | Global defaults applied across the chart. |
-| global.podSecurityContext | object | `{}` | Set a pod-level securityContext applied to all agent pods unless a component-specific podSecurityContext is defined. Supports pod-only fields: fsGroup, runAsUser, runAsGroup, runAsNonRoot, supplementalGroups, sysctls, seccompProfile. (use with caution) |
-| global.securityContext | object | `{}` | Set a container-level securityContext applied to all containers unless a container-specific securityContext is defined. Supports container fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
-| telegrafImageVersion | string | `"v2.0.56-alpine"` | Telegraf version to be used |
-| telegrafWindowsImageVersion | string | `"v2.0.56"` | Telegraf version to be used for windows |
-| admissionControllerVersion | string | `"0.1.60"` | Admission controller version to be used |
-| serviceAccount | object | See sub-values | Configure service account for the agent |
-| serviceAccount.create | bool | `true` | Creates a service account for the agent |
-| serviceAccount.name | string | `nil` | Name of the service account, Required if `serviceAccount.create` is false |
-| serviceAccount.annotations | object | `{}` | Add annotations to the service account |
-| proxy.enabled | bool | `false` | Enable proxy for the agent |
-| proxy.komodorOnly | bool | `true` | Configure proxy to be applied only on communication to Komodor servers (comms. to K8S API remains without proxy) |
-| proxy.http | string | `nil` | Configure Proxy setting (HTTP_PROXY) `eg. http://proxy.com:8080` |
-| proxy.https | string | `nil` | Configure Proxy setting (HTTPS_PROXY) `eg. https://proxy.com:8080` |
-| proxy.no_proxy | string | `nil` | Specify specific domains to ignore proxy for. eg. `komodor.com,google.com` |
-| proxy.no_proxy_local_addresses | bool | `false` | When true, prepends standard Kubernetes-internal addresses (localhost, 127.0.0.1, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, .cluster.local, .svc) to NO_PROXY so that in-cluster traffic (e.g. Kubernetes API server) bypasses the proxy. |
-| customCa | object | See sub-values | Configure custom CA for the agent (Not supported for windows) |
-| customCa.enabled | bool | `false` | Enable custom CA certificate for the agent |
-| customCa.secretName | string | `nil` | Name of the secret containing the CA |
-| customCa.resources | dict | `{"limits":{"cpu":"10m","memory":"100Mi"},"requests":{"cpu":"1m","memory":"10Mi"}}` | Set custom resources to the custom CA container |
-| customCa.securityContext | dict | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000}` | Set container-level securityContext for the custom CA init container. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
-| imageRepo | string | `"public.ecr.aws/komodor-public"` | Override the komodor agent image repository. |
-| pullPolicy | string | `"IfNotPresent"` | Default Image pull policy for the komodor agent image acceptable values <ifNotPresent\Always\Never>. |
-| imagePullSecret | string | `nil` | Set the image pull secret for the komodor agent |
 | capabilities | object | See sub-values | Configure the agent capabilities |
-| capabilities.metrics | bool | `true` | Fetch workload metrics and send them to komodor backend |
-| capabilities.nodeEnricher | bool | `true` | Enable node enricher capabilities by the komodor agent |
 | capabilities.actions | bool | `true` | Allow users to perform actions on the cluster, granular access control is defined in the application<boolean> |
-| capabilities.crActions | bool | `true` | Allow komodor service account to edit and delete custom resources in the cluster |
-| capabilities.cost | object | See sub-values | Configure the agent cost capabilities |
-| capabilities.cost.hpa | bool | `true` | Enable patch and update permissions for KEDA ScaledObjects and ScaledJobs |
-| capabilities.helm | object | `{"enabled":true,"readonly":false}` | Enable helm capabilities by the komodor agent |
-| capabilities.helm.enabled | bool | `true` | Enable helm capabilities by the komodor agent |
-| capabilities.helm.readonly | bool | `false` | Allow komodor to read helm resources only (remove create/update/delete permissions from secrets) |
-| capabilities.rbac | bool | `true` | Allow komodor to create and manage serviceaccounts, roles and bindings in cluster |
-| capabilities.rbacTempTokens | bool | `true` | Allow komodor to create temporary tokens for service accounts |
-| capabilities.rbacClusterSyncParams | object | See sub-values | Configure the agent cluster sync capabilities |
-| capabilities.rbacClusterSyncParams.enabled | bool | `false` | Enable cluster sync configuration from helm chart |
-| capabilities.rbacClusterSyncParams.clusterURL | string | `nil` | URL of the cluster to sync with |
-| capabilities.rbacClusterSyncParams.ingressCertConfiguration | dict | See sub-values | Configuration for the ingress certificate |
-| capabilities.rbacClusterSyncParams.ingressCertConfiguration.namespace | string | `nil` | Namespace of the resource containing the certificate |
-| capabilities.rbacClusterSyncParams.ingressCertConfiguration.kind | string | `nil` | Kind of the resource containing the certificate (Secret/ConfigMap) |
-| capabilities.rbacClusterSyncParams.ingressCertConfiguration.name | string | `nil` | Name of the resource containing the certificate |
-| capabilities.rbacClusterSyncParams.ingressCertConfiguration.dataPath | string | `nil` | Path to the certificate data in the resource (crt.ca) |
-| capabilities.events | object | See sub-values | Configure the agent events capabilities |
-| capabilities.events.watchNamespace | string | all | Watch a specific namespace, or all namespaces ("", "all") |
-| capabilities.events.namespacesDenylist | array of strings | `[]` | Do not watch events from these namespaces. eg. `["kube-system", "kube-public"]` |
-| capabilities.events.redact | list | `[]` | Redact workload names from the komodor events. eg. `["password", "token"]` |
-| capabilities.events.enableRWCache | bool | `true` | Mounts a ReadWrite cache volume for the kubernetes api cache |
-| capabilities.events.create | bool | `true` | allow create kubernetes events for enrichment |
-| capabilities.logs | object | See sub-values | Configure the agent logs capabilities |
-| capabilities.logs.enabled | bool | `true` | Fetch pod logs from komodor backend |
-| capabilities.logs.logsNamespacesDenylist | list | `[]` | Do not fetch logs from these namespaces. eg. `["kube-system", "kube-public"]` |
-| capabilities.logs.logsNamespacesAllowlist | list | `[]` | Only fetch logs from these namespaces. eg. `["kube-system", "kube-public"]` |
-| capabilities.logs.nameDenylist | list | `[]` | Do not fetch logs from these workloads. eg. `["supersecret-workload", "password-manager"]` |
-| capabilities.logs.redact | list | `[]` | Redact logs from the komodor logs. eg. `["password", "token"]` |
-| capabilities.redaction | object | See sub-values | Configure the agent data redaction capabilities |
-| capabilities.redaction.secret | object | `{"enable":true,"keepOnlyHelmReleases":false}` | Configuration for the "Secret" resource type |
-| capabilities.redaction.secret.enable | bool | `true` | Enable redaction for the "Secret" resource type |
-| capabilities.redaction.secret.keepOnlyHelmReleases | bool | `false` | Determine if only helm releases should be collected, if true - wipe and redact all other secrets data |
-| capabilities.redaction.byKind | list | `[]` | Redact specific fields from resources by kind using jq field selectors. Each entry specifies a `kind`, optional `group` (for CRDs), and `fields` (list of jq expressions). Example: byKind:   - kind: ExternalSecret     group: external-secrets.io     fields:       - .spec.data[].remoteRef.key       - .spec.dataFrom[].extract.key |
-| capabilities.telemetry | object | See sub-values | Configure the agent telemetry capabilities |
-| capabilities.telemetry.enabled | bool | `true` | Enable telemetry capabilities by the komodor agent |
-| capabilities.telemetry.collectApiServerMetrics | bool | `false` | Collect metrics from the api server (Should only be used for debugging purposes) |
-| capabilities.telemetry.deployOtelCollector | bool | `true` | Deploys OpenTelemetry collector daemonset sidecar |
-| capabilities.kubectlProxy | object | See sub-values | Configure the komodor kubectl proxy capabilities |
-| capabilities.kubectlProxy.enabled | bool | `false` | Enable the komodor kubectl proxy |
-| capabilities.tasks | object | See sub-values | Configure the agent task capabilities |
-| capabilities.tasks.httpRequests | object | See sub-values | Configure HTTP request capabilities |
-| capabilities.tasks.httpRequests.skipTlsVerify | bool | `false` | Skip TLS certificate verification for HTTP requests (sets HTTP_REQUESTS_SKIP_TLS_VERIFY environment variable) |
-| capabilities.tunnel | object | See sub-values | Configure the WebSocket tunnel feature |
-| capabilities.tunnel.enabled | bool | `true` | Enable the network tunnel for remote WebSocket connections |
-| capabilities.tunnel.whitelist | list | `[]` | Allowed destinations for tunnel connections (empty = allow all) If no entries are configured, all destinations are allowed (default-allow). Entries can be:   - CIDR ranges (e.g. "10.0.0.0/8") — any port, matched against resolved IPs   - "host:port" pairs (e.g. "myservice:8080") — exact match   - plain hosts (e.g. "myservice") — any port on that host |
-| capabilities.klaudiaIntegrationSync | object | See sub-values | Sync KomodorMCPIntegration and KomodorSkill CRs to the Klaudia API. CRs (and any Secrets they reference) must be created in the agent's release namespace; CRs in other namespaces are silently ignored by the sync controller. |
-| capabilities.klaudiaIntegrationSync.enabled | bool | `false` | Enable KomodorMCPIntegration and KomodorSkill CR sync controller |
-| capabilities.klaudiaIntegrationSync.resyncInterval | string | `"2m"` | How often to force-resync all CRs even if unchanged |
-| capabilities.klaudiaIntegrationSync.httpTimeout | string | `"90s"` | HTTP timeout for Klaudia API calls |
-| capabilities.klaudiaIntegrationSync.serverFetchInterval | string | `"10m"` | How often to refresh server-side status (tools/status) on otherwise unchanged CRs. Set to "0s" to fetch every reconcile. |
 | capabilities.admissionController | object | See sub-values | Configure the komodor admission controller capabilities |
+| capabilities.admissionController.binpacking | object | See sub-values | Configure the binpacking capabilities for the admission controller |
+| capabilities.admissionController.binpacking.addNodeAffinityToMarkedPods | bool | `true` | Add node affinity to marked pods to prefer scheduling on nodes with already unevictable pods (requires enabling per cluster in UI in addition) |
+| capabilities.admissionController.binpacking.markUnevictable | bool | `true` | Add a label to mark pods as unevictable (requires enabling per cluster in UI in addition) |
 | capabilities.admissionController.enabled | bool | `true` | Enable the komodor admission controller |
-| capabilities.admissionController.pdb | object | `{"enabled":true}` | Configure the PodDisruptionBudget for the admission controller |
-| capabilities.admissionController.pdb.enabled | bool | `true` | Enable PodDisruptionBudget for the admission controller |
-| capabilities.admissionController.logLevel | string | `"info"` | Log level for the admission controller |
 | capabilities.admissionController.logFormat | string | `"json"` | Log format for the admission controller |
-| capabilities.admissionController.webhookServer | object | See sub-values | Configure the webhook server for the admission controller |
-| capabilities.admissionController.webhookServer.serviceName | string | `"komodor-admission-controller"` | Name of the service for the webhook server |
-| capabilities.admissionController.webhookServer.port | int | `8443` | Port of the webhook server |
-| capabilities.admissionController.webhookServer.tlsCertFile | string | /etc/komodor/admission/tls/tls.crt | Path to the TLS certificate file for the webhook server. If set, overrides the default certificate generation |
-| capabilities.admissionController.webhookServer.tlsKeyFile | string | /etc/komodor/admission/tls/tls.key | Path to the TLS key file for the webhook server. If set, overrides the default certificate generation |
-| capabilities.admissionController.webhookServer.reuseGeneratedTlsSecret | bool | true | If true, the webhook server will reuse the generated TLS secret. If false, the webhook server will recreate a new TLS secret on every upgrade. |
-| capabilities.admissionController.webhookServer.staticTlsCertData | object | See sub-values | Provide static certificate data to use instead of generating. Useful when rendering the chart outside of a cluster. If all three fields are set, they take priority over cert regeneration but are still overridden by existing in-cluster secrets when reuseGeneratedTlsSecret is true. |
-| capabilities.admissionController.webhookServer.staticTlsCertData.tlsCert | string | `nil` | Base64-encoded TLS certificate (tls.crt) |
-| capabilities.admissionController.webhookServer.staticTlsCertData.tlsKey | string | `nil` | Base64-encoded TLS private key (tls.key) |
-| capabilities.admissionController.webhookServer.staticTlsCertData.caCert | string | `nil` | Base64-encoded CA certificate (ca.crt) |
+| capabilities.admissionController.logLevel | string | `"info"` | Log level for the admission controller |
 | capabilities.admissionController.mutatingWebhook | object | See sub-values | Configure the mutating webhook |
-| capabilities.admissionController.mutatingWebhook.selfManage | bool | `false` | If true, the mutating webhook will be managed by the chart. If false, the mutating webhook will be managed by the user. |
-| capabilities.admissionController.mutatingWebhook.timeoutSeconds | int | `5` | Timeout for the webhook call in seconds |
+| capabilities.admissionController.mutatingWebhook.allowOnAKSManagedNamespaces | bool | `true` | Allow mutating webhook to be called for pods in AKS-managed namespaces (See also: https://learn.microsoft.com/en-us/azure/aks/faq#can-admission-controller-webhooks-affect-kube-system-and-internal-aks-namespaces-) |
+| capabilities.admissionController.mutatingWebhook.caBundle | string | using the kube-root-ca.crt ConfigMap in the kube-system namespace | CA bundle for the mutating webhook configuration. It should match the webhook server CA. |
+| capabilities.admissionController.mutatingWebhook.hpaRightsizingWebhookPath | string | `"/webhook/rightsizing/hpa"` | Path for the HPA rightsizing webhook |
 | capabilities.admissionController.mutatingWebhook.podBinpackingWebhookPath | string | `"/webhook/binpacking/pod"` | Path for the pod binpacking webhook |
 | capabilities.admissionController.mutatingWebhook.podRightsizingWebhookPath | string | `"/webhook/rightsizing/pod"` | Path for the pod rightsizing webhook |
-| capabilities.admissionController.mutatingWebhook.hpaRightsizingWebhookPath | string | `"/webhook/rightsizing/hpa"` | Path for the HPA rightsizing webhook |
 | capabilities.admissionController.mutatingWebhook.scaledObjectRightsizingWebhookPath | string | `"/webhook/rightsizing/scaledobject"` | Path for the KEDA ScaledObject rightsizing webhook |
-| capabilities.admissionController.mutatingWebhook.caBundle | string | using the kube-root-ca.crt ConfigMap in the kube-system namespace | CA bundle for the mutating webhook configuration. It should match the webhook server CA. |
-| capabilities.admissionController.mutatingWebhook.allowOnAKSManagedNamespaces | bool | `true` | Allow mutating webhook to be called for pods in AKS-managed namespaces (See also: https://learn.microsoft.com/en-us/azure/aks/faq#can-admission-controller-webhooks-affect-kube-system-and-internal-aks-namespaces-) |
-| capabilities.admissionController.binpacking | object | See sub-values | Configure the binpacking capabilities for the admission controller |
-| capabilities.admissionController.binpacking.markUnevictable | bool | `true` | Add a label to mark pods as unevictable (requires enabling per cluster in UI in addition) |
-| capabilities.admissionController.binpacking.addNodeAffinityToMarkedPods | bool | `true` | Add node affinity to marked pods to prefer scheduling on nodes with already unevictable pods (requires enabling per cluster in UI in addition) |
+| capabilities.admissionController.mutatingWebhook.selfManage | bool | `false` | If true, the mutating webhook will be managed by the chart. If false, the mutating webhook will be managed by the user. |
+| capabilities.admissionController.mutatingWebhook.timeoutSeconds | int | `5` | Timeout for the webhook call in seconds |
+| capabilities.admissionController.pdb | object | `{"enabled":true}` | Configure the PodDisruptionBudget for the admission controller |
+| capabilities.admissionController.pdb.enabled | bool | `true` | Enable PodDisruptionBudget for the admission controller |
 | capabilities.admissionController.rightsizing | object | See sub-values | Configure the rightsizing capabilities for the admission controller |
 | capabilities.admissionController.telemetry | object | See sub-values | Configure the telemetry capabilities for the admission controller |
 | capabilities.admissionController.telemetry.enabled | bool | `false` | Enable telemetry capabilities by the komodor admission controller |
+| capabilities.admissionController.webhookServer | object | See sub-values | Configure the webhook server for the admission controller |
+| capabilities.admissionController.webhookServer.port | int | `8443` | Port of the webhook server |
+| capabilities.admissionController.webhookServer.reuseGeneratedTlsSecret | bool | true | If true, the webhook server will reuse the generated TLS secret. If false, the webhook server will recreate a new TLS secret on every upgrade. |
+| capabilities.admissionController.webhookServer.serviceName | string | `"komodor-admission-controller"` | Name of the service for the webhook server |
+| capabilities.admissionController.webhookServer.staticTlsCertData | object | See sub-values | Provide static certificate data to use instead of generating. Useful when rendering the chart outside of a cluster. If all three fields are set, they take priority over cert regeneration but are still overridden by existing in-cluster secrets when reuseGeneratedTlsSecret is true. |
+| capabilities.admissionController.webhookServer.staticTlsCertData.caCert | string | `nil` | Base64-encoded CA certificate (ca.crt) |
+| capabilities.admissionController.webhookServer.staticTlsCertData.tlsCert | string | `nil` | Base64-encoded TLS certificate (tls.crt) |
+| capabilities.admissionController.webhookServer.staticTlsCertData.tlsKey | string | `nil` | Base64-encoded TLS private key (tls.key) |
+| capabilities.admissionController.webhookServer.tlsCertFile | string | /etc/komodor/admission/tls/tls.crt | Path to the TLS certificate file for the webhook server. If set, overrides the default certificate generation |
+| capabilities.admissionController.webhookServer.tlsKeyFile | string | /etc/komodor/admission/tls/tls.key | Path to the TLS key file for the webhook server. If set, overrides the default certificate generation |
+| capabilities.cost | object | See sub-values | Configure the agent cost capabilities |
+| capabilities.cost.hpa | bool | `true` | Enable patch and update permissions for KEDA ScaledObjects and ScaledJobs |
+| capabilities.crActions | bool | `true` | Allow komodor service account to edit and delete custom resources in the cluster |
+| capabilities.events | object | See sub-values | Configure the agent events capabilities |
+| capabilities.events.create | bool | `true` | allow create kubernetes events for enrichment |
+| capabilities.events.enableRWCache | bool | `true` | Mounts a ReadWrite cache volume for the kubernetes api cache |
+| capabilities.events.namespacesDenylist | array of strings | `[]` | Do not watch events from these namespaces. eg. `["kube-system", "kube-public"]` |
+| capabilities.events.redact | list | `[]` | Redact workload names from the komodor events. eg. `["password", "token"]` |
+| capabilities.events.watchNamespace | string | all | Watch a specific namespace, or all namespaces ("", "all") |
+| capabilities.helm | object | `{"enabled":true,"readonly":false}` | Enable helm capabilities by the komodor agent |
+| capabilities.helm.enabled | bool | `true` | Enable helm capabilities by the komodor agent |
+| capabilities.helm.readonly | bool | `false` | Allow komodor to read helm resources only (remove create/update/delete permissions from secrets) |
+| capabilities.klaudiaIntegrationSync | object | See sub-values | Sync KomodorMCPIntegration and KomodorSkill CRs to the Klaudia API. CRs (and any Secrets they reference) must be created in the agent's release namespace; CRs in other namespaces are silently ignored by the sync controller. |
+| capabilities.klaudiaIntegrationSync.enabled | bool | `false` | Enable KomodorMCPIntegration and KomodorSkill CR sync controller |
+| capabilities.klaudiaIntegrationSync.httpTimeout | string | `"90s"` | HTTP timeout for Klaudia API calls |
+| capabilities.klaudiaIntegrationSync.resyncInterval | string | `"2m"` | How often to force-resync all CRs even if unchanged |
+| capabilities.klaudiaIntegrationSync.serverFetchInterval | string | `"10m"` | How often to refresh server-side status (tools/status) on otherwise unchanged CRs. Set to "0s" to fetch every reconcile. |
+| capabilities.kubectlProxy | object | See sub-values | Configure the komodor kubectl proxy capabilities |
+| capabilities.kubectlProxy.enabled | bool | `false` | Enable the komodor kubectl proxy |
+| capabilities.logs | object | See sub-values | Configure the agent logs capabilities |
+| capabilities.logs.enabled | bool | `true` | Fetch pod logs from komodor backend |
+| capabilities.logs.logsNamespacesAllowlist | list | `[]` | Only fetch logs from these namespaces. eg. `["kube-system", "kube-public"]` |
+| capabilities.logs.logsNamespacesDenylist | list | `[]` | Do not fetch logs from these namespaces. eg. `["kube-system", "kube-public"]` |
+| capabilities.logs.nameDenylist | list | `[]` | Do not fetch logs from these workloads. eg. `["supersecret-workload", "password-manager"]` |
+| capabilities.logs.redact | list | `[]` | Redact logs from the komodor logs. eg. `["password", "token"]` |
+| capabilities.metrics | bool | `true` | Fetch workload metrics and send them to komodor backend |
+| capabilities.nodeEnricher | bool | `true` | Enable node enricher capabilities by the komodor agent |
+| capabilities.rbac | bool | `true` | Allow komodor to create and manage serviceaccounts, roles and bindings in cluster |
+| capabilities.rbacClusterSyncParams | object | See sub-values | Configure the agent cluster sync capabilities |
+| capabilities.rbacClusterSyncParams.clusterURL | string | `nil` | URL of the cluster to sync with |
+| capabilities.rbacClusterSyncParams.enabled | bool | `false` | Enable cluster sync configuration from helm chart |
+| capabilities.rbacClusterSyncParams.ingressCertConfiguration | dict | See sub-values | Configuration for the ingress certificate |
+| capabilities.rbacClusterSyncParams.ingressCertConfiguration.dataPath | string | `nil` | Path to the certificate data in the resource (crt.ca) |
+| capabilities.rbacClusterSyncParams.ingressCertConfiguration.kind | string | `nil` | Kind of the resource containing the certificate (Secret/ConfigMap) |
+| capabilities.rbacClusterSyncParams.ingressCertConfiguration.name | string | `nil` | Name of the resource containing the certificate |
+| capabilities.rbacClusterSyncParams.ingressCertConfiguration.namespace | string | `nil` | Namespace of the resource containing the certificate |
+| capabilities.rbacTempTokens | bool | `true` | Allow komodor to create temporary tokens for service accounts |
+| capabilities.redaction | object | See sub-values | Configure the agent data redaction capabilities |
+| capabilities.redaction.byKind | list | `[]` | Redact specific fields from resources by kind using jq field selectors. Each entry specifies a `kind`, optional `group` (for CRDs), and `fields` (list of jq expressions). Example: byKind:   - kind: ExternalSecret     group: external-secrets.io     fields:       - .spec.data[].remoteRef.key       - .spec.dataFrom[].extract.key |
+| capabilities.redaction.secret | object | `{"enable":true,"keepOnlyHelmReleases":false}` | Configuration for the "Secret" resource type |
+| capabilities.redaction.secret.enable | bool | `true` | Enable redaction for the "Secret" resource type |
+| capabilities.redaction.secret.keepOnlyHelmReleases | bool | `false` | Determine if only helm releases should be collected, if true - wipe and redact all other secrets data |
+| capabilities.tasks | object | See sub-values | Configure the agent task capabilities |
+| capabilities.tasks.httpRequests | object | See sub-values | Configure HTTP request capabilities |
+| capabilities.tasks.httpRequests.skipTlsVerify | bool | `false` | Skip TLS certificate verification for HTTP requests (sets HTTP_REQUESTS_SKIP_TLS_VERIFY environment variable) |
+| capabilities.telemetry | object | See sub-values | Configure the agent telemetry capabilities |
+| capabilities.telemetry.collectApiServerMetrics | bool | `false` | Collect metrics from the api server (Should only be used for debugging purposes) |
+| capabilities.telemetry.deployOtelCollector | bool | `true` | Deploys OpenTelemetry collector daemonset sidecar |
+| capabilities.telemetry.enabled | bool | `true` | Enable telemetry capabilities by the komodor agent |
+| capabilities.tunnel | object | See sub-values | Configure the WebSocket tunnel feature |
+| capabilities.tunnel.enabled | bool | `true` | Enable the network tunnel for remote WebSocket connections |
+| capabilities.tunnel.kubeapiserver | object | See sub-values | Configure Kubernetes API server tunneling |
+| capabilities.tunnel.kubeapiserver.enabled | bool | `true` | Enable tunneling to the Kubernetes API server |
+| capabilities.tunnel.whitelist | list | `[]` | Allowed destinations for tunnel connections (empty = allow all) If no entries are configured, all destinations are allowed (default-allow). Entries can be:   - CIDR ranges (e.g. "10.0.0.0/8") — any port, matched against resolved IPs   - "host:port" pairs (e.g. "myservice:8080") — exact match   - plain hosts (e.g. "myservice") — any port on that host |
+| clusterName | string | `nil` | **(*required*)** Name to be displayed in the Komodor web application |
 | components | object | See sub-values | Configure the agent components |
-| components.komodorAgent | object | See sub-values | Configure the komodor agent components |
-| components.komodorAgent.PriorityClassValue | int | `10000000` | Set the priority class value for the komodor agent deployment |
-| components.komodorAgent.priorityClassName | string | `""` | Use an existing priority class for the komodor agent deployment. If not set, will create and use a priority class with PriorityClassValue. WARNING: priorityClassName is immutable and cannot be changed after initial deployment |
-| components.komodorAgent.affinity | object | `{}` | Set node affinity for the komodor agent deployment |
-| components.komodorAgent.annotations | object | `{}` | Set annotations for the komodor agent deployment |
-| components.komodorAgent.labels | object | `{}` | Set custom labels |
-| components.komodorAgent.nodeSelector | object | `{}` | Set node selectors for the komodor agent deployment |
-| components.komodorAgent.tolerations | list | `[]` | Set tolerations for the komodor agent deployment |
-| components.komodorAgent.podAnnotations | object | `{}` | Set pod annotations for the komodor agent deployment |
-| components.komodorAgent.podSecurityContext | object | `{}` | Set custom pod-level securityContext for the komodor agent deployment. Supports pod-only fields: fsGroup, runAsUser, runAsGroup, runAsNonRoot, supplementalGroups, sysctls, seccompProfile. (use with caution) |
-| components.komodorAgent.securityContext | object | `{}` | DEPRECATED: use podSecurityContext instead. Kept as a fallback for backward compatibility with pod-level securityContext. |
-| components.komodorAgent.strategy | object | `{}` | Set the rolling update strategy for the komodor agent deployment |
-| components.komodorAgent.watcher.image | object | `{ "name": "komodor-agent", "tag": .Chart.AppVersion }` | Override the komodor agent watcher image name or tag. |
-| components.komodorAgent.watcher.resources | object | `{"limits":{"cpu":2,"memory":"8Gi"},"requests":{"cpu":0.25,"memory":"256Mi"}}` | Set custom resources to the komodor agent watcher container |
-| components.komodorAgent.watcher.securityContext | object | `{}` | Set container-level securityContext for the komodor agent watcher container. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
-| components.komodorAgent.watcher.ports | object | `{"healthCheck":8090}` | Override the komodor agent watcher ports configuration |
-| components.komodorAgent.watcher.ports.healthCheck | int | `8090` | Override the health check port of the komodor agent watcher |
-| components.komodorAgent.watcher.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
-| components.komodorAgent.watcher.extraVolumes | list | `[]` | List of additional volumes and their mounts to add to the watcher container. Example (projected ServiceAccount token):      extraVolumes:        - volume:            name: workload-identity-token            projected:              sources:                - serviceAccountToken:                    path: token                    expirationSeconds: 3600                    audience: <token-exchange-audience>          volumeMount:            name: workload-identity-token            mountPath: /var/run/secrets/tokens            readOnly: true |
-| components.komodorAgent.supervisor.image | object | `{ "name": "supervisor", "tag": .Chart.AppVersion }` | Override the komodor agent supervisor image name or tag. |
-| components.komodorAgent.supervisor.resources | object | `{"requests":{"cpu":0.1,"memory":"256Mi"}}` | Set custom resources to the komodor agent supervisor container |
-| components.komodorAgent.supervisor.securityContext | object | `{}` | Set container-level securityContext for the komodor agent supervisor container. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
-| components.komodorAgent.supervisor.ports | object | `{"healthCheck":8089}` | Override the komodor agent supervisor ports configuration |
-| components.komodorAgent.supervisor.ports.healthCheck | int | `8089` | Override the health check port of the komodor agent supervisor |
-| components.komodorAgent.supervisor.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
-| components.komodorKubectlProxy | object | See sub-values | Configure the komodor kubectl proxy components |
-| components.komodorKubectlProxy.image | object | see sub-values | Override the komodor kubectl proxy image name or tag. |
-| components.komodorKubectlProxy.resources | object | `{}` | Set custom resources to the komodor kubectl proxy container |
-| components.komodorKubectlProxy.PriorityClassValue | int | `10000000` | Set the priority class value for the komodor kubectl proxy deployment |
-| components.komodorKubectlProxy.priorityClassName | string | `""` | Use an existing priority class for the komodor kubectl proxy deployment. If not set, will create and use a priority class with PriorityClassValue. WARNING: priorityClassName is immutable and cannot be changed after initial deployment |
-| components.komodorKubectlProxy.affinity | object | `{}` | Set node affinity for the komodor kubectl proxy deployment |
-| components.komodorKubectlProxy.annotations | object | `{}` | Set annotations for the komodor kubectl proxy deployment |
-| components.komodorKubectlProxy.podAnnotations | object | `{}` | Set pod annotations for the komodor kubectl proxy deployment |
-| components.komodorKubectlProxy.labels | object | `{}` | Set custom labels |
-| components.komodorKubectlProxy.nodeSelector | object | `{}` | Set node selectors for the komodor kubectl proxy deployment |
-| components.komodorKubectlProxy.tolerations | list | `[]` | Set tolerations for the komodor kubectl proxy deployment |
-| components.komodorKubectlProxy.podSecurityContext | object | `{}` | Set custom pod-level securityContext for the komodor kubectl proxy deployment. Supports pod-only fields: fsGroup, runAsUser, runAsGroup, runAsNonRoot, supplementalGroups, sysctls, seccompProfile. (use with caution) |
-| components.komodorKubectlProxy.securityContext | object | `{}` | DEPRECATED: use podSecurityContext instead. Kept as a fallback for backward compatibility with pod-level securityContext. |
-| components.komodorKubectlProxy.containerSecurityContext | object | `{}` | Set container-level securityContext for the komodor kubectl proxy container. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
-| components.komodorKubectlProxy.strategy | object | `{}` | Set the rolling update strategy for the komodor kubectl proxy deployment |
 | components.admissionController | object | See sub-values | Configure the komodor admission controller component |
-| components.admissionController.replicas | int | `2` | Number of replicas for the admission controller deployment |
-| components.admissionController.serviceAccount | object | see sub-values | Configure the service account for the admission controller |
-| components.admissionController.serviceAccount.create | bool | `true` | Creates a service account for the admission controller |
-| components.admissionController.serviceAccount.name | string | `nil` | Name of the service account, Required if `serviceAccount.create` is false |
-| components.admissionController.serviceAccount.annotations | object | `{}` | Add annotations to the service account |
-| components.admissionController.image | object | see sub-values | Override the komodor admission controller image name or tag. |
-| components.admissionController.resources | object | `{"limits":{"cpu":1,"memory":"4Gi"},"requests":{"cpu":"500m","memory":"1Gi"}}` | Set custom resources to the komodor admission controller container - Memory utilization is relative to the amount of: [pods, nodes, pvcs, pvs, pdbs] resources you have in the cluster. |
 | components.admissionController.PriorityClassValue | int | `10000000` | Set the priority class value for the komodor admission-controller deployment |
-| components.admissionController.priorityClassName | string | `""` | Use an existing priority class for the komodor admission-controller deployment. If not set, will create and use a priority class with PriorityClassValue. WARNING: priorityClassName is immutable and cannot be changed after initial deployment |
 | components.admissionController.affinity | object | `{"nodeAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"preference":{"matchExpressions":[{"key":"eks.amazonaws.com/capacityType","operator":"NotIn","values":["SPOT"]},{"key":"karpenter.sh/capacity-type","operator":"NotIn","values":["spot"]},{"key":"cloud.google.com/gke-spot","operator":"NotIn","values":["true"]},{"key":"cloud.google.com/gke-preemptible","operator":"NotIn","values":["true"]},{"key":"kubernetes.azure.com/scalesetpriority","operator":"NotIn","values":["spot"]}]},"weight":100}]},"podAffinity":{},"podAntiAffinity":{}}` | Set affinity rules for the komodor admission controller deployment. Split into nodeAffinity, podAffinity, and podAntiAffinity. If podAntiAffinity is not set, defaults to preferred pod anti-affinity on hostname |
 | components.admissionController.affinity.nodeAffinity | object | `{"preferredDuringSchedulingIgnoredDuringExecution":[{"preference":{"matchExpressions":[{"key":"eks.amazonaws.com/capacityType","operator":"NotIn","values":["SPOT"]},{"key":"karpenter.sh/capacity-type","operator":"NotIn","values":["spot"]},{"key":"cloud.google.com/gke-spot","operator":"NotIn","values":["true"]},{"key":"cloud.google.com/gke-preemptible","operator":"NotIn","values":["true"]},{"key":"kubernetes.azure.com/scalesetpriority","operator":"NotIn","values":["spot"]}]},"weight":100}]}` | Set node affinity for the komodor admission controller deployment |
 | components.admissionController.affinity.podAffinity | object | `{}` | Set pod affinity for the komodor admission controller deployment |
 | components.admissionController.affinity.podAntiAffinity | object | `{}` | Set pod anti-affinity for the komodor admission controller deployment. If not set, defaults to preferred pod anti-affinity on hostname |
 | components.admissionController.annotations | object | `{}` | Set annotations for the komodor admission controller deployment |
-| components.admissionController.podAnnotations | object | `{}` | Set pod annotations for the komodor admission controller deployment |
-| components.admissionController.labels | object | `{}` | Set custom labels |
-| components.admissionController.nodeSelector | object | `{}` | Set node selectors for the komodor admission controller deployment |
-| components.admissionController.tolerations | list | `[]` | Set tolerations for the komodor admission controller deployment |
-| components.admissionController.podSecurityContext | object | `{}` | Set custom pod-level securityContext for the komodor admission controller deployment. Supports pod-only fields: fsGroup, runAsUser, runAsGroup, runAsNonRoot, supplementalGroups, sysctls, seccompProfile. (use with caution) |
-| components.admissionController.securityContext | object | `{}` | DEPRECATED: use podSecurityContext instead. Kept as a fallback for backward compatibility with pod-level securityContext. |
 | components.admissionController.containerSecurityContext | object | `{}` | Set container-level securityContext for the admission controller container. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
-| components.admissionController.strategy | object | `{}` | Set the rolling update strategy for the komodor admission controller |
-| components.admissionController.extraVolumes | list | `[]` | List of additional volumes to mount in the komodor admission controller deployment/pod      extraVolumes:        - volume:            name: webhook-tls            secret:              secretName: komodor-admission-controller-tls          volumeMount:            name: webhook-tls            mountPath: /etc/komodor/admission/tls            readOnly: true |
-| components.admissionController.leaderElectionLeaseName | string | `""` | The name to use for leader election leases. If not set, defaults to the admission controller deployment name |
 | components.admissionController.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
-| components.komodorMetrics.PriorityClassValue | int | `10000000` | Set the priority class value for the komodor metrics agent deployment |
-| components.komodorMetrics.priorityClassName | string | `""` | Use an existing priority class for the komodor metrics agent deployment. If not set, will create and use a priority class with PriorityClassValue. WARNING: priorityClassName is immutable and cannot be changed after initial deployment |
-| components.komodorMetrics.disableHttp2 | bool | `false` | Disable HTTP/2 client by setting GODEBUG=http2client=0 for komodor-agent-metrics |
-| components.komodorMetrics.affinity | object | `{}` | Set node affinity for the komodor metrics agent deployment |
-| components.komodorMetrics.annotations | object | `{}` | Set annotations for the komodor metrics agent deployment |
-| components.komodorMetrics.labels | object | `{}` | Set custom labels |
-| components.komodorMetrics.nodeSelector | object | `{}` | Set node selectors for the komodor metrics agent deployment |
-| components.komodorMetrics.tolerations | list | `[]` | Set tolerations for the komodor metrics agent deployment |
-| components.komodorMetrics.podAnnotations | object | `{}` | Set pod annotations for the komodor metrics agent deployment |
-| components.komodorMetrics.podSecurityContext | object | `{}` | Set custom pod-level securityContext for the komodor metrics deployment. Supports pod-only fields: fsGroup, runAsUser, runAsGroup, runAsNonRoot, supplementalGroups, sysctls, seccompProfile. (use with caution) |
-| components.komodorMetrics.securityContext | object | `{}` | DEPRECATED: use podSecurityContext instead. Kept as a fallback for backward compatibility with pod-level securityContext. |
-| components.komodorMetrics.strategy | object | `{}` | Set the rolling update strategy for the komodor metrics agent deployment |
-| components.komodorMetrics.metricsInit | object | See sub-values | Configure the komodor metrics init container |
-| components.komodorMetrics.metricsInit.image | object | `{ "name": "komodor-agent", "tag": .Chart.AppVersion }` | Override the komodor agent metrics init image name or tag. |
-| components.komodorMetrics.metricsInit.resources | object | `{}` | Set custom resources to the komodor agent metrics init container |
-| components.komodorMetrics.metricsInit.securityContext | object | `{}` | Set container-level securityContext for the komodor metrics init and sidecar containers. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
-| components.komodorMetrics.metricsInit.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
-| components.komodorMetrics.metrics.image | object | `{"name":"telegraf","tag":"v2.0.56-alpine"}` | Override the komodor agent metrics image name or tag. |
-| components.komodorMetrics.metrics.resources | object | `{"limits":{"cpu":1,"memory":"4Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
-| components.komodorMetrics.metrics.securityContext | object | `{}` | Set container-level securityContext for the komodor metrics (telegraf) container. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
-| components.komodorMetrics.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
-| components.komodorMetrics.metrics.sidecar | object | `{"enabled":true}` | Configure the telegraf-init sidecar container |
-| components.komodorMetrics.metrics.sidecar.enabled | bool | `true` | Enable the telegraf-init sidecar container |
+| components.admissionController.extraVolumes | list | `[]` | List of additional volumes to mount in the komodor admission controller deployment/pod      extraVolumes:        - volume:            name: webhook-tls            secret:              secretName: komodor-admission-controller-tls          volumeMount:            name: webhook-tls            mountPath: /etc/komodor/admission/tls            readOnly: true |
+| components.admissionController.image | object | see sub-values | Override the komodor admission controller image name or tag. |
+| components.admissionController.labels | object | `{}` | Set custom labels |
+| components.admissionController.leaderElectionLeaseName | string | `""` | The name to use for leader election leases. If not set, defaults to the admission controller deployment name |
+| components.admissionController.nodeSelector | object | `{}` | Set node selectors for the komodor admission controller deployment |
+| components.admissionController.podAnnotations | object | `{}` | Set pod annotations for the komodor admission controller deployment |
+| components.admissionController.podSecurityContext | object | `{}` | Set custom pod-level securityContext for the komodor admission controller deployment. Supports pod-only fields: fsGroup, runAsUser, runAsGroup, runAsNonRoot, supplementalGroups, sysctls, seccompProfile. (use with caution) |
+| components.admissionController.priorityClassName | string | `""` | Use an existing priority class for the komodor admission-controller deployment. If not set, will create and use a priority class with PriorityClassValue. WARNING: priorityClassName is immutable and cannot be changed after initial deployment |
+| components.admissionController.replicas | int | `2` | Number of replicas for the admission controller deployment |
+| components.admissionController.resources | object | `{"limits":{"cpu":1,"memory":"4Gi"},"requests":{"cpu":"500m","memory":"1Gi"}}` | Set custom resources to the komodor admission controller container - Memory utilization is relative to the amount of: [pods, nodes, pvcs, pvs, pdbs] resources you have in the cluster. |
+| components.admissionController.securityContext | object | `{}` | DEPRECATED: use podSecurityContext instead. Kept as a fallback for backward compatibility with pod-level securityContext. |
+| components.admissionController.serviceAccount | object | see sub-values | Configure the service account for the admission controller |
+| components.admissionController.serviceAccount.annotations | object | `{}` | Add annotations to the service account |
+| components.admissionController.serviceAccount.create | bool | `true` | Creates a service account for the admission controller |
+| components.admissionController.serviceAccount.name | string | `nil` | Name of the service account, Required if `serviceAccount.create` is false |
+| components.admissionController.strategy | object | `{}` | Set the rolling update strategy for the komodor admission controller |
+| components.admissionController.tolerations | list | `[]` | Set tolerations for the komodor admission controller deployment |
+| components.gpuAccess | object | `{"containerSecurityContext":{},"enabled":false,"image":"alpine:latest","labels":{},"nodeSelector":{},"podSecurityContext":{},"pullPolicy":"IfNotPresent","resources":{"limits":{"cpu":"250m","memory":"100Mi"},"requests":{"cpu":"100m","memory":"50Mi"}},"tolerations":[{"effect":"NoSchedule","key":"nvidia.com/gpu","operator":"Exists"}]}` | settings for GPU host diagnostics accessor DaemonSet |
+| components.gpuAccess.containerSecurityContext | object | `{}` | Set container-level securityContext for the GPU accessor container. When empty, defaults to privileged: true (matching gpuAccess.enabled). (use with caution) |
+| components.gpuAccess.enabled | bool | `false` | Enable creating privileged CUDA container with host mounts to access GPU info |
+| components.gpuAccess.image | string | `"alpine:latest"` | CUDA image to be used for GPU access container |
+| components.gpuAccess.labels | object | `{}` | Adds custom labels |
+| components.gpuAccess.nodeSelector | object | `{}` | Set node selectors for the komodor agent daemon |
+| components.gpuAccess.podSecurityContext | object | `{}` | Set custom pod-level securityContext for the GPU accessor DaemonSet. (use with caution) |
+| components.gpuAccess.pullPolicy | string | `"IfNotPresent"` | Default Image pull policy for the GPU accessor image acceptable values <ifNotPresent\Always\Never>. |
+| components.gpuAccess.resources | object | `{"limits":{"cpu":"250m","memory":"100Mi"},"requests":{"cpu":"100m","memory":"50Mi"}}` | Set custom resources to the GPU accessor container |
+| components.gpuAccess.tolerations | list | `[{"effect":"NoSchedule","key":"nvidia.com/gpu","operator":"Exists"}]` | Add tolerations to the komodor agent daemon |
+| components.komodorAgent | object | See sub-values | Configure the komodor agent components |
+| components.komodorAgent.PriorityClassValue | int | `10000000` | Set the priority class value for the komodor agent deployment |
+| components.komodorAgent.affinity | object | `{}` | Set node affinity for the komodor agent deployment |
+| components.komodorAgent.annotations | object | `{}` | Set annotations for the komodor agent deployment |
+| components.komodorAgent.labels | object | `{}` | Set custom labels |
+| components.komodorAgent.nodeSelector | object | `{}` | Set node selectors for the komodor agent deployment |
+| components.komodorAgent.podAnnotations | object | `{}` | Set pod annotations for the komodor agent deployment |
+| components.komodorAgent.podSecurityContext | object | `{}` | Set custom pod-level securityContext for the komodor agent deployment. Supports pod-only fields: fsGroup, runAsUser, runAsGroup, runAsNonRoot, supplementalGroups, sysctls, seccompProfile. (use with caution) |
+| components.komodorAgent.priorityClassName | string | `""` | Use an existing priority class for the komodor agent deployment. If not set, will create and use a priority class with PriorityClassValue. WARNING: priorityClassName is immutable and cannot be changed after initial deployment |
+| components.komodorAgent.securityContext | object | `{}` | DEPRECATED: use podSecurityContext instead. Kept as a fallback for backward compatibility with pod-level securityContext. |
+| components.komodorAgent.strategy | object | `{}` | Set the rolling update strategy for the komodor agent deployment |
+| components.komodorAgent.supervisor.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
+| components.komodorAgent.supervisor.image | object | `{ "name": "supervisor", "tag": .Chart.AppVersion }` | Override the komodor agent supervisor image name or tag. |
+| components.komodorAgent.supervisor.ports | object | `{"healthCheck":8089}` | Override the komodor agent supervisor ports configuration |
+| components.komodorAgent.supervisor.ports.healthCheck | int | `8089` | Override the health check port of the komodor agent supervisor |
+| components.komodorAgent.supervisor.resources | object | `{"requests":{"cpu":0.1,"memory":"256Mi"}}` | Set custom resources to the komodor agent supervisor container |
+| components.komodorAgent.supervisor.securityContext | object | `{}` | Set container-level securityContext for the komodor agent supervisor container. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
+| components.komodorAgent.tolerations | list | `[]` | Set tolerations for the komodor agent deployment |
+| components.komodorAgent.watcher.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
+| components.komodorAgent.watcher.extraVolumes | list | `[]` | List of additional volumes and their mounts to add to the watcher container. Example (projected ServiceAccount token):      extraVolumes:        - volume:            name: workload-identity-token            projected:              sources:                - serviceAccountToken:                    path: token                    expirationSeconds: 3600                    audience: <token-exchange-audience>          volumeMount:            name: workload-identity-token            mountPath: /var/run/secrets/tokens            readOnly: true |
+| components.komodorAgent.watcher.image | object | `{ "name": "komodor-agent", "tag": .Chart.AppVersion }` | Override the komodor agent watcher image name or tag. |
+| components.komodorAgent.watcher.ports | object | `{"healthCheck":8090}` | Override the komodor agent watcher ports configuration |
+| components.komodorAgent.watcher.ports.healthCheck | int | `8090` | Override the health check port of the komodor agent watcher |
+| components.komodorAgent.watcher.resources | object | `{"limits":{"cpu":2,"memory":"8Gi"},"requests":{"cpu":0.25,"memory":"256Mi"}}` | Set custom resources to the komodor agent watcher container |
+| components.komodorAgent.watcher.securityContext | object | `{}` | Set container-level securityContext for the komodor agent watcher container. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
 | components.komodorDaemon | object | See sub-values | Configure the komodor agent components |
-| components.komodorDaemon.hostNetwork | bool | `false` | Set host network for the komodor agent daemon |
-| components.komodorDaemon.dnsPolicy | string | `"ClusterFirst"` | Set dns policy for the komodor agent daemon |
-| components.komodorDaemon.disableHttp2 | bool | `false` | Disable HTTP/2 client by setting GODEBUG=http2client=0 for komodor-agent-daemon |
 | components.komodorDaemon.PriorityClassValue | int | `10000000` | Set the priority class value for the komodor daemon deployment |
-| components.komodorDaemon.priorityClassName | string | `""` | Use an existing priority class for the komodor daemon deployment. If not set, will create and use a priority class with PriorityClassValue. WARNING: priorityClassName is immutable and cannot be changed after initial deployment |
 | components.komodorDaemon.affinity | object | `{}` | Set node affinity for the komodor agent daemon |
 | components.komodorDaemon.annotations | object | `{}` | Adds custom annotations - Example: `--set annotations."app\.komodor\.com/app"="komodor-agent"` |
+| components.komodorDaemon.disableHttp2 | bool | `false` | Disable HTTP/2 client by setting GODEBUG=http2client=0 for komodor-agent-daemon |
+| components.komodorDaemon.dnsPolicy | string | `"ClusterFirst"` | Set dns policy for the komodor agent daemon |
+| components.komodorDaemon.hostNetwork | bool | `false` | Set host network for the komodor agent daemon |
 | components.komodorDaemon.labels | object | `{}` | Adds custom labels |
-| components.komodorDaemon.nodeSelector | object | `{}` | Set node selectors for the komodor agent daemon |
-| components.komodorDaemon.tolerations | list | `[{"operator":"Exists"}]` | Add tolerations to the komodor agent daemon |
-| components.komodorDaemon.podAnnotations | object | `{}` | # Add annotations to the komodor agent watcher pod |
-| components.komodorDaemon.podSecurityContext | object | `{"fsGroup":1001,"runAsGroup":1001,"runAsNonRoot":true,"runAsUser":1001}` | Set custom pod-level securityContext for the komodor daemon. Supports pod-only fields: fsGroup, runAsUser, runAsGroup, runAsNonRoot, supplementalGroups, sysctls, seccompProfile. (use with caution) |
-| components.komodorDaemon.securityContext | object | `{}` | DEPRECATED: use podSecurityContext instead. Kept as a fallback for backward compatibility with pod-level securityContext. |
-| components.komodorDaemon.updateStrategy | object | `{}` | Set the rolling update strategy for the komodor agent daemon deployment |
-| components.komodorDaemon.metricsInit | object | See sub-values | Configure the komodor daemon metrics init container |
-| components.komodorDaemon.metricsInit.image | object | `{ "name": "init-daemon-agent", "tag": .Chart.AppVersion }` | Override the komodor agent metrics init image name or tag. |
-| components.komodorDaemon.metricsInit.resources | object | `{"limits":{"cpu":1,"memory":"100Mi"},"requests":{"cpu":0.1,"memory":"50Mi"}}` | Set custom resources to the komodor agent metrics init container |
-| components.komodorDaemon.metricsInit.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemon.metrics | object | `{"extraEnvVars":[],"image":{"name":"telegraf","tag":"v2.0.56-alpine"},"quiet":false,"resources":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"add":[],"drop":["ALL"]},"runAsNonRoot":true},"sidecar":{"enabled":true}}` | Configure the komodor daemon metrics components |
-| components.komodorDaemon.metrics.image | object | `{"name":"telegraf","tag":"v2.0.56-alpine"}` | Override the komodor agent metrics image name or tag. |
-| components.komodorDaemon.metrics.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
 | components.komodorDaemon.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
+| components.komodorDaemon.metrics.image | object | `{"name":"telegraf","tag":"v2.0.56-alpine"}` | Override the komodor agent metrics image name or tag. |
 | components.komodorDaemon.metrics.quiet | bool | `false` | Set the quiet mode for the komodor agent metrics |
+| components.komodorDaemon.metrics.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
+| components.komodorDaemon.metrics.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"add":[],"drop":["ALL"]},"runAsNonRoot":true}` | Set custom securityContext to the telegraf-init sidecar container |
 | components.komodorDaemon.metrics.sidecar | object | `{"enabled":true}` | Configure the telegraf-init sidecar container |
 | components.komodorDaemon.metrics.sidecar.enabled | bool | `true` | Enable the telegraf-init sidecar container |
-| components.komodorDaemon.metrics.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"add":[],"drop":["ALL"]},"runAsNonRoot":true}` | Set custom securityContext to the telegraf-init sidecar container |
+| components.komodorDaemon.metricsInit | object | See sub-values | Configure the komodor daemon metrics init container |
+| components.komodorDaemon.metricsInit.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
+| components.komodorDaemon.metricsInit.image | object | `{ "name": "init-daemon-agent", "tag": .Chart.AppVersion }` | Override the komodor agent metrics init image name or tag. |
+| components.komodorDaemon.metricsInit.resources | object | `{"limits":{"cpu":1,"memory":"100Mi"},"requests":{"cpu":0.1,"memory":"50Mi"}}` | Set custom resources to the komodor agent metrics init container |
 | components.komodorDaemon.nodeEnricher | object | See sub-values | Configure the komodor daemon node enricher components |
+| components.komodorDaemon.nodeEnricher.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemon.nodeEnricher.image | object | `{"name":"komodor-agent","tag":null}` | Override the komodor agent node enricher image name or tag. |
 | components.komodorDaemon.nodeEnricher.resources | object | `{"limits":{"cpu":"10m","memory":"100Mi"},"requests":{"cpu":"1m","memory":"10Mi"}}` | Set custom resources to the komodor agent node enricher container |
-| components.komodorDaemon.nodeEnricher.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemon.nodeEnricher.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"add":[],"drop":["ALL"]},"runAsNonRoot":true}` | Set custom securityContext to the komodor agent node enricher container |
+| components.komodorDaemon.nodeSelector | object | `{}` | Set node selectors for the komodor agent daemon |
 | components.komodorDaemon.opentelemetry | object | See sub-values | Configure the komodor daemon OpenTelemetry collector components |
-| components.komodorDaemon.opentelemetry.image | object | `{"name":"komodor-otel-collector","tag":"0.1.10"}` | Override the OpenTelemetry collector image name or tag. |
-| components.komodorDaemon.opentelemetry.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Set custom resources to the OpenTelemetry collector container |
 | components.komodorDaemon.opentelemetry.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
+| components.komodorDaemon.opentelemetry.image | object | `{"name":"komodor-otel-collector","tag":"0.1.10"}` | Override the OpenTelemetry collector image name or tag. |
 | components.komodorDaemon.opentelemetry.otelInit | object | See sub-values | Configure the OTel init/sidecar containers for remote configuration |
+| components.komodorDaemon.opentelemetry.otelInit.configFileName | string | `"otel-config.yaml"` | Name of the config file written to the shared volume |
 | components.komodorDaemon.opentelemetry.otelInit.enabled | bool | `true` | Enable remote configuration fetching via otel init |
+| components.komodorDaemon.opentelemetry.otelInit.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemon.opentelemetry.otelInit.image | object | `{ "name": "komodor-agent", "tag": .Chart.AppVersion }` | Override the otel init image name or tag. |
 | components.komodorDaemon.opentelemetry.otelInit.resources | object | `{"limits":{"cpu":1,"memory":"100Mi"},"requests":{"cpu":0.1,"memory":"50Mi"}}` | Set custom resources to the otel init containers |
-| components.komodorDaemon.opentelemetry.otelInit.configFileName | string | `"otel-config.yaml"` | Name of the config file written to the shared volume |
-| components.komodorDaemon.opentelemetry.otelInit.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
+| components.komodorDaemon.opentelemetry.otelInit.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":0,"runAsNonRoot":false,"runAsUser":0}` | Set container-level securityContext for the OpenTelemetry init and sidecar containers. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
 | components.komodorDaemon.opentelemetry.otelInit.sidecar | object | `{"autoReloadConfig":true,"enabled":true,"pollingIntervalSeconds":300}` | Configure the sidecar for continuous config polling |
+| components.komodorDaemon.opentelemetry.otelInit.sidecar.autoReloadConfig | bool | `true` | Automatically send SIGHUP to the OTel Collector to reload configuration on change (requires shareProcessNamespace) |
 | components.komodorDaemon.opentelemetry.otelInit.sidecar.enabled | bool | `true` | Enable the otel init sidecar for continuous config updates |
 | components.komodorDaemon.opentelemetry.otelInit.sidecar.pollingIntervalSeconds | int | `300` | Polling interval in seconds for config updates |
-| components.komodorDaemon.opentelemetry.otelInit.sidecar.autoReloadConfig | bool | `true` | Automatically send SIGHUP to the OTel Collector to reload configuration on change (requires shareProcessNamespace) |
-| components.komodorDaemon.opentelemetry.otelInit.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":0,"runAsNonRoot":false,"runAsUser":0}` | Set container-level securityContext for the OpenTelemetry init and sidecar containers. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
+| components.komodorDaemon.opentelemetry.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Set custom resources to the OpenTelemetry collector container |
 | components.komodorDaemon.opentelemetry.volumes | object | `{"varlibdockercontainers":{"hostPath":{"path":"/var/lib/docker/containers","type":""},"mountPath":"/var/lib/docker/containers"},"varlogpods":{"hostPath":{"path":"/var/log/pods","type":""},"mountPath":"/var/log/pods"}}` | Configure volumes for OpenTelemetry collector |
-| components.komodorDaemon.opentelemetry.volumes.varlogpods | object | `{"hostPath":{"path":"/var/log/pods","type":""},"mountPath":"/var/log/pods"}` | Configure varlogpods volume |
-| components.komodorDaemon.opentelemetry.volumes.varlogpods.hostPath | object | `{"path":"/var/log/pods","type":""}` | Configure hostPath for varlogpods volume |
-| components.komodorDaemon.opentelemetry.volumes.varlogpods.hostPath.path | string | `"/var/log/pods"` | Host path to mount for pod logs |
-| components.komodorDaemon.opentelemetry.volumes.varlogpods.hostPath.type | string | `""` | Type of hostPath ("" (Empty string, default = no checks), Directory, DirectoryOrCreate, File, FileOrCreate, Socket, CharDevice, BlockDevice) |
-| components.komodorDaemon.opentelemetry.volumes.varlogpods.mountPath | string | `"/var/log/pods"` | Mount path inside the container for pod logs |
 | components.komodorDaemon.opentelemetry.volumes.varlibdockercontainers | object | `{"hostPath":{"path":"/var/lib/docker/containers","type":""},"mountPath":"/var/lib/docker/containers"}` | Configure docker containers volume |
 | components.komodorDaemon.opentelemetry.volumes.varlibdockercontainers.hostPath | object | `{"path":"/var/lib/docker/containers","type":""}` | Configure hostPath for docker containers volume |
 | components.komodorDaemon.opentelemetry.volumes.varlibdockercontainers.hostPath.path | string | `"/var/lib/docker/containers"` | Host path to mount for docker containers |
 | components.komodorDaemon.opentelemetry.volumes.varlibdockercontainers.hostPath.type | string | `""` | Type of hostPath ("" (Empty string, default = no checks), Directory, DirectoryOrCreate, File, FileOrCreate, Socket, CharDevice, BlockDevice) |
 | components.komodorDaemon.opentelemetry.volumes.varlibdockercontainers.mountPath | string | `"/var/lib/docker/containers"` | Mount path inside the container for docker containers |
+| components.komodorDaemon.opentelemetry.volumes.varlogpods | object | `{"hostPath":{"path":"/var/log/pods","type":""},"mountPath":"/var/log/pods"}` | Configure varlogpods volume |
+| components.komodorDaemon.opentelemetry.volumes.varlogpods.hostPath | object | `{"path":"/var/log/pods","type":""}` | Configure hostPath for varlogpods volume |
+| components.komodorDaemon.opentelemetry.volumes.varlogpods.hostPath.path | string | `"/var/log/pods"` | Host path to mount for pod logs |
+| components.komodorDaemon.opentelemetry.volumes.varlogpods.hostPath.type | string | `""` | Type of hostPath ("" (Empty string, default = no checks), Directory, DirectoryOrCreate, File, FileOrCreate, Socket, CharDevice, BlockDevice) |
+| components.komodorDaemon.opentelemetry.volumes.varlogpods.mountPath | string | `"/var/log/pods"` | Mount path inside the container for pod logs |
+| components.komodorDaemon.podAnnotations | object | `{}` | # Add annotations to the komodor agent watcher pod |
+| components.komodorDaemon.podSecurityContext | object | `{"fsGroup":1001,"runAsGroup":1001,"runAsNonRoot":true,"runAsUser":1001}` | Set custom pod-level securityContext for the komodor daemon. Supports pod-only fields: fsGroup, runAsUser, runAsGroup, runAsNonRoot, supplementalGroups, sysctls, seccompProfile. (use with caution) |
+| components.komodorDaemon.priorityClassName | string | `""` | Use an existing priority class for the komodor daemon deployment. If not set, will create and use a priority class with PriorityClassValue. WARNING: priorityClassName is immutable and cannot be changed after initial deployment |
+| components.komodorDaemon.securityContext | object | `{}` | DEPRECATED: use podSecurityContext instead. Kept as a fallback for backward compatibility with pod-level securityContext. |
+| components.komodorDaemon.tolerations | list | `[{"operator":"Exists"}]` | Add tolerations to the komodor agent daemon |
+| components.komodorDaemon.updateStrategy | object | `{}` | Set the rolling update strategy for the komodor agent daemon deployment |
 | components.komodorDaemonWindows | object | See sub-values | Configure the komodor agent components |
-| components.komodorDaemonWindows.dnsPolicy | string | `"ClusterFirst"` | Set dns policy for the komodor agent daemon |
 | components.komodorDaemonWindows.affinity | object | `{}` | Set node affinity for the komodor agent daemon |
 | components.komodorDaemonWindows.annotations | object | `{}` | Adds custom annotations - Example: `--set annotations."app\.komodor\.com/app"="komodor-agent"` |
+| components.komodorDaemonWindows.dnsPolicy | string | `"ClusterFirst"` | Set dns policy for the komodor agent daemon |
 | components.komodorDaemonWindows.labels | object | `{}` | Adds custom labels |
-| components.komodorDaemonWindows.nodeSelector | object | `{}` | Set node selectors for the komodor agent daemon |
-| components.komodorDaemonWindows.tolerations | list | `[{"operator":"Exists"}]` | Add tolerations to the komodor agent daemon |
-| components.komodorDaemonWindows.podAnnotations | object | `{}` | # Add annotations to the komodor agent watcher pod |
-| components.komodorDaemonWindows.podSecurityContext | object | `{}` | Set custom pod-level securityContext for the komodor Windows daemon. Configure only fields supported by Windows pods. (use with caution) |
-| components.komodorDaemonWindows.updateStrategy | object | `{}` | Set the rolling update strategy for the komodor agent daemon deployment |
-| components.komodorDaemonWindows.metricsInit | object | See sub-values | Configure the komodor daemon metrics init container |
-| components.komodorDaemonWindows.metricsInit.image | object | `{ "name": "init-daemon-agent", "tag": .Chart.AppVersion }` | Override the komodor agent metrics init image name or tag. |
-| components.komodorDaemonWindows.metricsInit.resources | object | `{"limits":{"cpu":1,"memory":"100Mi"},"requests":{"cpu":0.1,"memory":"50Mi"}}` | Set custom resources to the komodor agent metrics init container |
-| components.komodorDaemonWindows.metricsInit.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
-| components.komodorDaemonWindows.metricsInit.securityContext | object | `{}` | Set container-level securityContext for the Windows daemon metrics init and sidecar containers. Configure only fields supported by Windows containers. (use with caution) |
 | components.komodorDaemonWindows.metrics | object | `{"extraEnvVars":[],"image":{"name":"telegraf-windows","tag":"v2.0.56"},"quiet":false,"resources":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}},"securityContext":{},"sidecar":{"enabled":true}}` | Configure the komodor daemon metrics components |
-| components.komodorDaemonWindows.metrics.image | object | `{"name":"telegraf-windows","tag":"v2.0.56"}` | Override the komodor agent metrics image name or tag. |
-| components.komodorDaemonWindows.metrics.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
 | components.komodorDaemonWindows.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
-| components.komodorDaemonWindows.metrics.securityContext | object | `{}` | Set container-level securityContext for the Windows daemon metrics container. Configure only fields supported by Windows containers. (use with caution) |
+| components.komodorDaemonWindows.metrics.image | object | `{"name":"telegraf-windows","tag":"v2.0.56"}` | Override the komodor agent metrics image name or tag. |
 | components.komodorDaemonWindows.metrics.quiet | bool | `false` | Set the quiet mode for the komodor agent metrics |
+| components.komodorDaemonWindows.metrics.resources | object | `{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
+| components.komodorDaemonWindows.metrics.securityContext | object | `{}` | Set container-level securityContext for the Windows daemon metrics container. Configure only fields supported by Windows containers. (use with caution) |
 | components.komodorDaemonWindows.metrics.sidecar | object | `{"enabled":true}` | Configure the telegraf-init sidecar container |
 | components.komodorDaemonWindows.metrics.sidecar.enabled | bool | `true` | Enable the telegraf-init sidecar container |
-| components.gpuAccess | object | `{"containerSecurityContext":{},"enabled":false,"image":"alpine:latest","labels":{},"nodeSelector":{},"podSecurityContext":{},"pullPolicy":"IfNotPresent","resources":{"limits":{"cpu":"250m","memory":"100Mi"},"requests":{"cpu":"100m","memory":"50Mi"}},"tolerations":[{"effect":"NoSchedule","key":"nvidia.com/gpu","operator":"Exists"}]}` | settings for GPU host diagnostics accessor DaemonSet |
-| components.gpuAccess.enabled | bool | `false` | Enable creating privileged CUDA container with host mounts to access GPU info |
-| components.gpuAccess.image | string | `"alpine:latest"` | CUDA image to be used for GPU access container |
-| components.gpuAccess.pullPolicy | string | `"IfNotPresent"` | Default Image pull policy for the GPU accessor image acceptable values <ifNotPresent\Always\Never>. |
-| components.gpuAccess.resources | object | `{"limits":{"cpu":"250m","memory":"100Mi"},"requests":{"cpu":"100m","memory":"50Mi"}}` | Set custom resources to the GPU accessor container |
-| components.gpuAccess.labels | object | `{}` | Adds custom labels |
-| components.gpuAccess.nodeSelector | object | `{}` | Set node selectors for the komodor agent daemon |
-| components.gpuAccess.tolerations | list | `[{"effect":"NoSchedule","key":"nvidia.com/gpu","operator":"Exists"}]` | Add tolerations to the komodor agent daemon |
-| components.gpuAccess.podSecurityContext | object | `{}` | Set custom pod-level securityContext for the GPU accessor DaemonSet. (use with caution) |
-| components.gpuAccess.containerSecurityContext | object | `{}` | Set container-level securityContext for the GPU accessor container. When empty, defaults to privileged: true (matching gpuAccess.enabled). (use with caution) |
-| allowedResources.event | bool | `true` | Enables watching `event` |
-| allowedResources.deployment | bool | `true` | Enables watching `deployments` |
-| allowedResources.replicationController | bool | `true` | Enables watching `replicationControllers` |
-| allowedResources.replicaSet | bool | `true` | Enables watching `replicaSets` |
-| allowedResources.daemonSet | bool | `true` | Enables watching `daemonSets` |
-| allowedResources.statefulSet | bool | `true` | Enables watching `statefulSets` |
-| allowedResources.service | bool | `true` | Enables watching `services` |
-| allowedResources.pod | bool | `true` | Enables watching `pods` |
-| allowedResources.job | bool | `true` | Enables watching `jobs` |
-| allowedResources.cronjob | bool | `true` | Enables watching `cronjobs` |
-| allowedResources.node | bool | `true` | Enables watching `nodes` |
-| allowedResources.clusterRole | bool | `true` | Enables watching `clusterRoles` |
-| allowedResources.serviceAccount | bool | `true` | Enables watching `serviceAccounts` |
-| allowedResources.persistentVolume | bool | `true` | Enables watching `persistentVolumes` |
-| allowedResources.persistentVolumeClaim | bool | `true` | Enables watching `persistentVolumeClaims` |
-| allowedResources.namespace | bool | `true` | Enables watching `namespaces` |
-| allowedResources.secret | bool | `true` | Enables watching `secrets` |
-| allowedResources.configMap | bool | `true` | Enables watching `configmaps` |
-| allowedResources.ingress | bool | `true` | Enables watching `ingresses` |
-| allowedResources.endpoints | bool | `true` | Enables watching `endpoints` |
-| allowedResources.storageClass | bool | `true` | Enables watching `storageClasses` |
-| allowedResources.rollout | bool | `true` | Enables watching `rollouts` |
-| allowedResources.metrics | bool | `true` | Enables watching `metrics` |
-| allowedResources.limitRange | bool | `true` | Enables watching `limitRange` |
-| allowedResources.podTemplate | bool | `true` | Enables watching `podTemplate` |
-| allowedResources.resourceQuota | bool | `true` | Enables watching `resourceQuota` |
-| allowedResources.admissionRegistrationResources | bool | `true` | Enables watching `admissionRegistrationResources` |
-| allowedResources.controllerRevision | bool | `true` | Enables watching `controllerRevision` |
-| allowedResources.authorizationResources | bool | `true` | Enables watching `authorizationResources` |
-| allowedResources.horizontalPodAutoscaler | bool | `true` | Enables watching `horizontalPodAutoscaler` |
-| allowedResources.certificateSigningRequest | bool | `true` | Enables watching `certificateSigningRequest` |
-| allowedResources.lease | bool | `true` | Enables watching `lease` |
-| allowedResources.endpointSlice | bool | `true` | Enables watching `endpointslice` |
-| allowedResources.flowControlResources | bool | `true` | Enables watching `flowControlResources` |
-| allowedResources.ingressClass | bool | `true` | Enables watching `ingressClass` |
-| allowedResources.networkPolicy | bool | `true` | Enables watching `networkPolicy` |
-| allowedResources.runtimeClass | bool | `true` | Enables watching `runtimeClass` |
-| allowedResources.podDisruptionBudget | bool | `true` | Enables watching `podDisruptionBudgets` |
-| allowedResources.policyResources | bool | `true` | Enables watching `policyResources` |
-| allowedResources.clusterRoleBinding | bool | `true` | Enables watching `clusterRoleBinding` |
-| allowedResources.roleBinding | bool | `true` | Enables watching `roleBinding` |
-| allowedResources.role | bool | `true` | Enables watching `role` |
-| allowedResources.priorityClass | bool | `true` | Enables watching `priorityClass` |
-| allowedResources.csiDriver | bool | `true` | Enables watching `csiDriver` |
-| allowedResources.csiNode | bool | `true` | Enables watching `csiNode` |
-| allowedResources.csiStorageCapacity | bool | `true` | Enables watching `csiStorageCapacity` |
-| allowedResources.volumeAttachment | bool | `true` | Enables watching `volumeAttachment` |
-| allowedResources.argoWorkflows | object | See sub-values | Enables watching argo resources |
-| allowedResources.argoWorkflows.workflows | bool | `true` | Enables watching Argo `workflows` |
-| allowedResources.argoWorkflows.workflowTemplates | bool | `true` | Enables watching Argo `workflowTemplates` |
-| allowedResources.argoWorkflows.clusterWorkflowTemplates | bool | `true` | Enables watching Argo `clusterWorkflowTemplates` |
-| allowedResources.argoWorkflows.cronWorkflows | bool | `true` | Enables watching Argo `cronWorkflows` |
-| allowedResources.customReadAPIGroups | list | `[]` | A list of custom API groups to allow read access to - each array element should be a string which represents the group name |
-| allowedResources.allowReadAll | bool | `true` | Allow reading all the resources in the cluster |
+| components.komodorDaemonWindows.metricsInit | object | See sub-values | Configure the komodor daemon metrics init container |
+| components.komodorDaemonWindows.metricsInit.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
+| components.komodorDaemonWindows.metricsInit.image | object | `{ "name": "init-daemon-agent", "tag": .Chart.AppVersion }` | Override the komodor agent metrics init image name or tag. |
+| components.komodorDaemonWindows.metricsInit.resources | object | `{"limits":{"cpu":1,"memory":"100Mi"},"requests":{"cpu":0.1,"memory":"50Mi"}}` | Set custom resources to the komodor agent metrics init container |
+| components.komodorDaemonWindows.metricsInit.securityContext | object | `{}` | Set container-level securityContext for the Windows daemon metrics init and sidecar containers. Configure only fields supported by Windows containers. (use with caution) |
+| components.komodorDaemonWindows.nodeSelector | object | `{}` | Set node selectors for the komodor agent daemon |
+| components.komodorDaemonWindows.podAnnotations | object | `{}` | # Add annotations to the komodor agent watcher pod |
+| components.komodorDaemonWindows.podSecurityContext | object | `{}` | Set custom pod-level securityContext for the komodor Windows daemon. Configure only fields supported by Windows pods. (use with caution) |
+| components.komodorDaemonWindows.tolerations | list | `[{"operator":"Exists"}]` | Add tolerations to the komodor agent daemon |
+| components.komodorDaemonWindows.updateStrategy | object | `{}` | Set the rolling update strategy for the komodor agent daemon deployment |
+| components.komodorKubectlProxy | object | See sub-values | Configure the komodor kubectl proxy components |
+| components.komodorKubectlProxy.PriorityClassValue | int | `10000000` | Set the priority class value for the komodor kubectl proxy deployment |
+| components.komodorKubectlProxy.affinity | object | `{}` | Set node affinity for the komodor kubectl proxy deployment |
+| components.komodorKubectlProxy.annotations | object | `{}` | Set annotations for the komodor kubectl proxy deployment |
+| components.komodorKubectlProxy.containerSecurityContext | object | `{}` | Set container-level securityContext for the komodor kubectl proxy container. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
+| components.komodorKubectlProxy.image | object | see sub-values | Override the komodor kubectl proxy image name or tag. |
+| components.komodorKubectlProxy.labels | object | `{}` | Set custom labels |
+| components.komodorKubectlProxy.nodeSelector | object | `{}` | Set node selectors for the komodor kubectl proxy deployment |
+| components.komodorKubectlProxy.podAnnotations | object | `{}` | Set pod annotations for the komodor kubectl proxy deployment |
+| components.komodorKubectlProxy.podSecurityContext | object | `{}` | Set custom pod-level securityContext for the komodor kubectl proxy deployment. Supports pod-only fields: fsGroup, runAsUser, runAsGroup, runAsNonRoot, supplementalGroups, sysctls, seccompProfile. (use with caution) |
+| components.komodorKubectlProxy.priorityClassName | string | `""` | Use an existing priority class for the komodor kubectl proxy deployment. If not set, will create and use a priority class with PriorityClassValue. WARNING: priorityClassName is immutable and cannot be changed after initial deployment |
+| components.komodorKubectlProxy.resources | object | `{}` | Set custom resources to the komodor kubectl proxy container |
+| components.komodorKubectlProxy.securityContext | object | `{}` | DEPRECATED: use podSecurityContext instead. Kept as a fallback for backward compatibility with pod-level securityContext. |
+| components.komodorKubectlProxy.strategy | object | `{}` | Set the rolling update strategy for the komodor kubectl proxy deployment |
+| components.komodorKubectlProxy.tolerations | list | `[]` | Set tolerations for the komodor kubectl proxy deployment |
+| components.komodorMetrics.PriorityClassValue | int | `10000000` | Set the priority class value for the komodor metrics agent deployment |
+| components.komodorMetrics.affinity | object | `{}` | Set node affinity for the komodor metrics agent deployment |
+| components.komodorMetrics.annotations | object | `{}` | Set annotations for the komodor metrics agent deployment |
+| components.komodorMetrics.disableHttp2 | bool | `false` | Disable HTTP/2 client by setting GODEBUG=http2client=0 for komodor-agent-metrics |
+| components.komodorMetrics.labels | object | `{}` | Set custom labels |
+| components.komodorMetrics.metrics.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
+| components.komodorMetrics.metrics.image | object | `{"name":"telegraf","tag":"v2.0.56-alpine"}` | Override the komodor agent metrics image name or tag. |
+| components.komodorMetrics.metrics.resources | object | `{"limits":{"cpu":1,"memory":"4Gi"},"requests":{"cpu":0.1,"memory":"384Mi"}}` | Set custom resources to the komodor agent metrics container |
+| components.komodorMetrics.metrics.securityContext | object | `{}` | Set container-level securityContext for the komodor metrics (telegraf) container. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
+| components.komodorMetrics.metrics.sidecar | object | `{"enabled":true}` | Configure the telegraf-init sidecar container |
+| components.komodorMetrics.metrics.sidecar.enabled | bool | `true` | Enable the telegraf-init sidecar container |
+| components.komodorMetrics.metricsInit | object | See sub-values | Configure the komodor metrics init container |
+| components.komodorMetrics.metricsInit.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
+| components.komodorMetrics.metricsInit.image | object | `{ "name": "komodor-agent", "tag": .Chart.AppVersion }` | Override the komodor agent metrics init image name or tag. |
+| components.komodorMetrics.metricsInit.resources | object | `{}` | Set custom resources to the komodor agent metrics init container |
+| components.komodorMetrics.metricsInit.securityContext | object | `{}` | Set container-level securityContext for the komodor metrics init and sidecar containers. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
+| components.komodorMetrics.nodeSelector | object | `{}` | Set node selectors for the komodor metrics agent deployment |
+| components.komodorMetrics.podAnnotations | object | `{}` | Set pod annotations for the komodor metrics agent deployment |
+| components.komodorMetrics.podSecurityContext | object | `{}` | Set custom pod-level securityContext for the komodor metrics deployment. Supports pod-only fields: fsGroup, runAsUser, runAsGroup, runAsNonRoot, supplementalGroups, sysctls, seccompProfile. (use with caution) |
+| components.komodorMetrics.priorityClassName | string | `""` | Use an existing priority class for the komodor metrics agent deployment. If not set, will create and use a priority class with PriorityClassValue. WARNING: priorityClassName is immutable and cannot be changed after initial deployment |
+| components.komodorMetrics.securityContext | object | `{}` | DEPRECATED: use podSecurityContext instead. Kept as a fallback for backward compatibility with pod-level securityContext. |
+| components.komodorMetrics.strategy | object | `{}` | Set the rolling update strategy for the komodor metrics agent deployment |
+| components.komodorMetrics.tolerations | list | `[]` | Set tolerations for the komodor metrics agent deployment |
+| createNamespace | bool | `true` | Creates the namespace |
+| createRbac | bool | `true` | Creates the necessary RBAC resources for the agent - use with caution! |
+| customCa | object | See sub-values | Configure custom CA for the agent (Not supported for windows) |
+| customCa.enabled | bool | `false` | Enable custom CA certificate for the agent |
+| customCa.resources | dict | `{"limits":{"cpu":"10m","memory":"100Mi"},"requests":{"cpu":"1m","memory":"10Mi"}}` | Set custom resources to the custom CA container |
+| customCa.secretName | string | `nil` | Name of the secret containing the CA |
+| customCa.securityContext | dict | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000}` | Set container-level securityContext for the custom CA init container. Supports container-only fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
+| global | object | See sub-values | Global defaults applied across the chart. |
+| global.podSecurityContext | object | `{}` | Set a pod-level securityContext applied to all agent pods unless a component-specific podSecurityContext is defined. Supports pod-only fields: fsGroup, runAsUser, runAsGroup, runAsNonRoot, supplementalGroups, sysctls, seccompProfile. (use with caution) |
+| global.securityContext | object | `{}` | Set a container-level securityContext applied to all containers unless a container-specific securityContext is defined. Supports container fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |
+| imagePullSecret | string | `nil` | Set the image pull secret for the komodor agent |
+| imageRepo | string | `"public.ecr.aws/komodor-public"` | Override the komodor agent image repository. |
+| proxy.enabled | bool | `false` | Enable proxy for the agent |
+| proxy.http | string | `nil` | Configure Proxy setting (HTTP_PROXY) `eg. http://proxy.com:8080` |
+| proxy.https | string | `nil` | Configure Proxy setting (HTTPS_PROXY) `eg. https://proxy.com:8080` |
+| proxy.komodorOnly | bool | `true` | Configure proxy to be applied only on communication to Komodor servers (comms. to K8S API remains without proxy) |
+| proxy.no_proxy | string | `nil` | Specify specific domains to ignore proxy for. eg. `komodor.com,google.com` |
+| proxy.no_proxy_local_addresses | bool | `false` | When true, prepends standard Kubernetes-internal addresses (localhost, 127.0.0.1, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, .cluster.local, .svc) to NO_PROXY so that in-cluster traffic (e.g. Kubernetes API server) bypasses the proxy. |
+| publicApiKey | guid | `nil` | Komodor public API key. Required when features that depend on it are enabled (currently capabilities.klaudiaIntegrationSync). |
+| publicApiKeySecret | string | `nil` | Existing Kubernetes secret containing the public API key |
+| publicApiKeySecretKey | string | `nil` | Key inside publicApiKeySecret (defaults to publicApiKey) |
+| pullPolicy | string | `"IfNotPresent"` | Default Image pull policy for the komodor agent image acceptable values <ifNotPresent\Always\Never>. |
+| serviceAccount | object | See sub-values | Configure service account for the agent |
+| serviceAccount.annotations | object | `{}` | Add annotations to the service account |
+| serviceAccount.create | bool | `true` | Creates a service account for the agent |
+| serviceAccount.name | string | `nil` | Name of the service account, Required if `serviceAccount.create` is false |
+| site | string | "us" | Komodor site, allowed values: "us", "eu" |
+| tags | dict | `{}` | Tags the agent in order to identify it based on `key:value` properties separated by semicolon (`;`) example: `--set tags.env=staging,tags.team=payments` --- Can also be set in the values under `tags` as a dictionary of key:value strings |
+| telegrafImageVersion | string | `"v2.0.56-alpine"` | Telegraf version to be used |
+| telegrafWindowsImageVersion | string | `"v2.0.56"` | Telegraf version to be used for windows |
 
 [README.md](README.md)
 > **Tip**: You can use the default [values.yaml](values.yaml)

--- a/charts/komodor-agent/templates/configmap.yaml
+++ b/charts/komodor-agent/templates/configmap.yaml
@@ -53,6 +53,8 @@ data:
     tunnel:
       enabled: {{ .Values.capabilities.tunnel.enabled }}
       whitelist: {{ toYaml .Values.capabilities.tunnel.whitelist | trim | nindent 8 }}
+      kubeapiserver:
+        enabled: {{ .Values.capabilities.tunnel.kubeapiserver.enabled }}
 
     resources:
       {{- toYaml .Values.allowedResources | trim | nindent 6 }}

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -222,6 +222,11 @@ capabilities:
     #   - "host:port" pairs (e.g. "myservice:8080") — exact match
     #   - plain hosts (e.g. "myservice") — any port on that host
     whitelist: []
+    # capabilities.tunnel.kubeapiserver -- Configure Kubernetes API server tunneling
+    # @default -- See sub-values
+    kubeapiserver:
+      # capabilities.tunnel.kubeapiserver.enabled -- (bool) Enable tunneling to the Kubernetes API server
+      enabled: true
 
   # capabilities.klaudiaIntegrationSync -- Sync KomodorMCPIntegration and KomodorSkill CRs to the Klaudia API.
   # CRs (and any Secrets they reference) must be created in the agent's release namespace;


### PR DESCRIPTION
## Motivation
Add support for `capabilities.tunnel.kubeapiserver.enabled` configuration to allow enabling/disabling Kubernetes API server tunneling independently. Defaults to `true`.

## Changelog
**Helm Chart Changes:**
- Added `capabilities.tunnel.kubeapiserver.enabled` (bool, default `true`) under the tunnel section in `values.yaml`
- Regenerated `README.md` to include the new config entry

## Testing coverage
- [x] Manual testing