### PR TITLE
chore(codeowners): split cost team into cost-be

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,8 +2,8 @@
 * @komodorio/platform
 
 # Platform and cost teams co-own files directly under komodor-agent (e.g. values, readme)
-charts/komodor-agent/* @komodorio/platform @komodorio/cost
+charts/komodor-agent/* @komodorio/platform @komodorio/cost-be
 
 # Cost team owns admission-controller and metrics templates
-charts/komodor-agent/templates/admission-controller/ @komodorio/cost
-charts/komodor-agent/templates/metrics/ @komodorio/cost
+charts/komodor-agent/templates/admission-controller/ @komodorio/cost-be
+charts/komodor-agent/templates/metrics/ @komodorio/cost-be


### PR DESCRIPTION
Replaces `@komodorio/cost` with `@komodorio/cost-be` in CODEOWNERS for the helm charts (`charts/komodor-agent/*`), admission-controller templates, and metrics templates — all backend-owned areas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)