### PR TITLE
CU-86caavcuf - ci: notify Slack on new komodor-agent release

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -257,6 +257,22 @@ steps:
     if: build.message !~ /feat\(OSS.+\):/i && build.branch == "master"
   - wait
 
+  - label: ":mega: Notify Slack about new komodor-agent release"
+    commands:
+      - |
+        CHART_VERSION="$$(buildkite-agent meta-data get komodor-agent-version)"
+        AGENT_VERSION="$$(buildkite-agent meta-data get agent-version)"
+        curl -fsS -X POST -H 'Content-type: application/json' \
+          --data "{\"text\":\":rocket: New *komodor-agent* chart released: \`$$CHART_VERSION\` (agent \`$$AGENT_VERSION\`)\nhttps://github.com/komodorio/helm-charts/releases/tag/komodor-agent/$$CHART_VERSION\"}" \
+          "$$SLACK_WEBHOOK_URL"
+    agents:
+      builder: "builder-dind-agent"
+    plugins:
+      - zacharymctague/aws-ssm#v1.0.0:
+          parameters:
+            SLACK_WEBHOOK_URL: /app/ci/slack/release-webhook
+    if: build.message !~ /feat\(OSS.+\):/i && build.branch == "master"
+
   - label: ":magic_wand: Install new komodor-agent version on komodor staging :kubernetes: cluster"
     commands:
       - komo ctx staging


### PR DESCRIPTION
## Motivation
We want visibility into komodor-agent chart releases in a dedicated Slack channel.

## Changelog
- Add a Buildkite step after "validate helm chart version updated" that posts the new chart/agent version to Slack via an incoming webhook.
- The webhook URL is injected from SSM at `/app/ci/slack/release-webhook` (via the `aws-ssm` plugin); version info comes from buildkite meta-data.
- Runs in parallel with the install steps and is gated to real master releases (same `if:` as the rest of the release flow).
- Scope: komodor-agent only — the release/validate/install flow is hardcoded to that chart.

## Testing coverage
- [ ] Manual testing — requires the SSM param + Slack webhook to be provisioned first

> **Note:** This step will fail until the `/app/ci/slack/release-webhook` SSM SecureString is created. Can add a graceful-skip if preferred.