### PR TITLE
CU-86cac3u44 - fix(komodor-agent): add enabled flag to disable Windows daemonset

### DIFF
--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -417,7 +417,7 @@ Relevant values:
 | components.komodorDaemon.opentelemetry.volumes.varlibdockercontainers.hostPath.type | string | `""` | Type of hostPath ("" (Empty string, default = no checks), Directory, DirectoryOrCreate, File, FileOrCreate, Socket, CharDevice, BlockDevice) |
 | components.komodorDaemon.opentelemetry.volumes.varlibdockercontainers.mountPath | string | `"/var/lib/docker/containers"` | Mount path inside the container for docker containers |
 | components.komodorDaemonWindows | object | See sub-values | Configure the komodor agent components |
-| components.komodorDaemonWindows.enabled | bool | `true` | Enable the Windows daemonset. Set to false on Linux-only clusters (e.g. OpenShift) to omit the Windows daemonset entirely. |
+| components.komodorDaemonWindows.enabled | bool | `true` | Enable the Windows daemonset. Set to false on Linux-only clusters to omit the Windows daemonset entirely. |
 | components.komodorDaemonWindows.dnsPolicy | string | `"ClusterFirst"` | Set dns policy for the komodor agent daemon |
 | components.komodorDaemonWindows.affinity | object | `{}` | Set node affinity for the komodor agent daemon |
 | components.komodorDaemonWindows.annotations | object | `{}` | Adds custom annotations - Example: `--set annotations."app\.komodor\.com/app"="komodor-agent"` |

--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -417,6 +417,7 @@ Relevant values:
 | components.komodorDaemon.opentelemetry.volumes.varlibdockercontainers.hostPath.type | string | `""` | Type of hostPath ("" (Empty string, default = no checks), Directory, DirectoryOrCreate, File, FileOrCreate, Socket, CharDevice, BlockDevice) |
 | components.komodorDaemon.opentelemetry.volumes.varlibdockercontainers.mountPath | string | `"/var/lib/docker/containers"` | Mount path inside the container for docker containers |
 | components.komodorDaemonWindows | object | See sub-values | Configure the komodor agent components |
+| components.komodorDaemonWindows.enabled | bool | `true` | Enable the Windows daemonset. Set to false on Linux-only clusters (e.g. OpenShift) to omit the Windows daemonset entirely. |
 | components.komodorDaemonWindows.dnsPolicy | string | `"ClusterFirst"` | Set dns policy for the komodor agent daemon |
 | components.komodorDaemonWindows.affinity | object | `{}` | Set node affinity for the komodor agent daemon |
 | components.komodorDaemonWindows.annotations | object | `{}` | Adds custom annotations - Example: `--set annotations."app\.komodor\.com/app"="komodor-agent"` |

--- a/charts/komodor-agent/templates/daemonset_windows.yaml
+++ b/charts/komodor-agent/templates/daemonset_windows.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.capabilities.metrics false }}
+{{- if and (ne .Values.capabilities.metrics false) (ne (((.Values.components).komodorDaemonWindows).enabled) false) }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -821,6 +821,8 @@ components:
   # components.komodorDaemonWindows -- Configure the komodor agent components
   # @default -- See sub-values
   komodorDaemonWindows:
+    # components.komodorDaemonWindows.enabled -- (bool) Enable the Windows daemonset. Set to false on Linux-only clusters (e.g. OpenShift) to omit the Windows daemonset entirely.
+    enabled: true
     # components.komodorDaemonWindows.dnsPolicy -- Set dns policy for the komodor agent daemon
     dnsPolicy: ClusterFirst
     # components.komodorDaemonWindows.affinity -- Set node affinity for the komodor agent daemon

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -821,7 +821,7 @@ components:
   # components.komodorDaemonWindows -- Configure the komodor agent components
   # @default -- See sub-values
   komodorDaemonWindows:
-    # components.komodorDaemonWindows.enabled -- (bool) Enable the Windows daemonset. Set to false on Linux-only clusters (e.g. OpenShift) to omit the Windows daemonset entirely.
+    # components.komodorDaemonWindows.enabled -- (bool) Enable the Windows daemonset. Set to false on Linux-only clusters to omit the Windows daemonset entirely.
     enabled: true
     # components.komodorDaemonWindows.dnsPolicy -- Set dns policy for the komodor agent daemon
     dnsPolicy: ClusterFirst


### PR DESCRIPTION
## What

Adds a `components.komodorDaemonWindows.enabled` flag (defaults to `true`) to the `komodor-agent` chart so the Windows daemonset can be disabled via values overrides.

Linked task: CU-86cac3u44

## Why

There was no enable/disable flag for `components.komodorDaemonWindows`. On Linux-only / OpenShift clusters, attempting to disable the Windows daemonset still rendered `daemonset_windows.yaml`, which panicked with a nil-pointer error and blocked the Helm release:

```
template: komodor-agent/templates/daemonset_windows.yaml:45:12 ... executing "metrics.daemonsetWindows.container"
at <.Values.components.komodorDaemonWindows.metrics.image.name>: nil pointer evaluating interface {}.image
```

Until now a Linux customer had only two workarounds, neither good:

- **Fork the chart** and delete `daemonset_windows.yaml` themselves to get past the panic.
- **Let the template render anyway** (without touching the Windows values). The daemonset has a `kubernetes.io/os: windows` nodeSelector, so on a Linux-only cluster no pods schedule and it's effectively inert — but on **mixed clusters with Windows nodes**, it would still deploy onto those Windows nodes, which is exactly what these customers want to avoid.

This flag gives them a clean third option: omit the Windows daemonset entirely via values overrides, no fork required.

## Change

- `templates/daemonset_windows.yaml` — gate the whole template on the new flag using safe nil-traversal:
  ```
  {{- if and (ne .Values.capabilities.metrics false) (ne (((.Values.components).komodorDaemonWindows).enabled) false) }}
  ```
  Using `ne (...) false` keeps current behavior when the flag is unset/true, and only an explicit `enabled: false` omits the daemonset — short-circuiting before the panicking image lookups.
- `values.yaml` — add `enabled: true` with helm-docs comment.
- `README.md` — add matching values-table row.

## Verification

`helm lint` passes. `helm template` results:

| Scenario | `daemon-windows` rendered |
|---|---|
| Default (flag unset) | yes — backward compatible |
| `enabled=true` | yes |
| `enabled=false` | none |
| `enabled=false` + nulled `metrics.image` (repro case) | none, no panic |
