### PR TITLE
CU-86cadxfw1 - ci: bump helm chart publish-validation timeout to ~5min

### DIFF
--- a/.buildkite/validate_helm_chart_updated.py
+++ b/.buildkite/validate_helm_chart_updated.py
@@ -22,7 +22,7 @@ def main(chart, new_version):
     is_rc = "-RC" in new_version.upper()
     version_updated = False
 
-    for _ in range(10):
+    for _ in range(30):
         run_cmd("helm repo update")
         current_version = get_current_version(chart, new_version, is_rc)
         if current_version == new_version:


### PR DESCRIPTION
The `validate helm chart version updated` CI step polls GitHub Pages for the freshly published chart. The old ~100s window (10 retries × 10s) was too short and failed frequently when Pages propagation was slow, requiring manual retries. This bumps the retry count from 10 to 30 (~5min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)