### PR TITLE
feat(komodor-agent): bump otel collector image to 0.1.12

### DIFF
--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -391,7 +391,7 @@ Relevant values:
 | components.komodorDaemon.nodeEnricher.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemon.nodeEnricher.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"add":[],"drop":["ALL"]},"runAsNonRoot":true}` | Set custom securityContext to the komodor agent node enricher container |
 | components.komodorDaemon.opentelemetry | object | See sub-values | Configure the komodor daemon OpenTelemetry collector components |
-| components.komodorDaemon.opentelemetry.image | object | `{"name":"komodor-otel-collector","tag":"0.1.13"}` | Override the OpenTelemetry collector image name or tag. |
+| components.komodorDaemon.opentelemetry.image | object | `{"name":"komodor-otel-collector","tag":"0.1.12"}` | Override the OpenTelemetry collector image name or tag. |
 | components.komodorDaemon.opentelemetry.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Set custom resources to the OpenTelemetry collector container |
 | components.komodorDaemon.opentelemetry.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemon.opentelemetry.otelInit | object | See sub-values | Configure the OTel init/sidecar containers for remote configuration |

--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -391,7 +391,7 @@ Relevant values:
 | components.komodorDaemon.nodeEnricher.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemon.nodeEnricher.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"add":[],"drop":["ALL"]},"runAsNonRoot":true}` | Set custom securityContext to the komodor agent node enricher container |
 | components.komodorDaemon.opentelemetry | object | See sub-values | Configure the komodor daemon OpenTelemetry collector components |
-| components.komodorDaemon.opentelemetry.image | object | `{"name":"komodor-otel-collector","tag":"0.1.11"}` | Override the OpenTelemetry collector image name or tag. |
+| components.komodorDaemon.opentelemetry.image | object | `{"name":"komodor-otel-collector","tag":"0.1.13"}` | Override the OpenTelemetry collector image name or tag. |
 | components.komodorDaemon.opentelemetry.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Set custom resources to the OpenTelemetry collector container |
 | components.komodorDaemon.opentelemetry.extraEnvVars | list | `[]` | List of additional environment variables, Each entry is a key-value pair |
 | components.komodorDaemon.opentelemetry.otelInit | object | See sub-values | Configure the OTel init/sidecar containers for remote configuration |

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -733,7 +733,7 @@ components:
       # components.komodorDaemon.opentelemetry.image -- Override the OpenTelemetry collector image name or tag.
       image:
         name: komodor-otel-collector
-        tag: 0.1.11
+        tag: 0.1.13
       # components.komodorDaemon.opentelemetry.resources -- Set custom resources to the OpenTelemetry collector container
       resources:
         limits:

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -733,7 +733,7 @@ components:
       # components.komodorDaemon.opentelemetry.image -- Override the OpenTelemetry collector image name or tag.
       image:
         name: komodor-otel-collector
-        tag: 0.1.13
+        tag: 0.1.12
       # components.komodorDaemon.opentelemetry.resources -- Set custom resources to the OpenTelemetry collector container
       resources:
         limits:


### PR DESCRIPTION
## What

Bumps the komodor-agent OpenTelemetry collector image tag `0.1.11` → `0.1.12` in `charts/komodor-agent/values.yaml`, and regenerates the chart README via `make generate-readme`.

```
components.komodorDaemon.opentelemetry.image.tag: 0.1.11 -> 0.1.12
```

## Why

`0.1.12` is the collector release that includes the `deltatocumulativeprocessor` (komodorio/komodor-otel-collector#30, merged). That processor is required by the new agent-side remote OTel config version `0.1.12` in komodorio/mono#29600, which converts the agent's delta histograms to cumulative on the local Prometheus branch — fixing the `prometheusexporter "Misaligned starting timestamps"` warnings without affecting the Datadog pipeline.

The remote-config system keys the agent collector config off this image tag (`ExtractOtelVersion` → `komodorDaemon.opentelemetry.image.tag`), so moving the chart to `0.1.12` is what activates the new config for agents.

## Validation

- `make generate-readme` → only the `opentelemetry.image` row changed (`tag":"0.1.12"`).
- `make validate-readme` passes (committed README matches generated).

## Ordering

Release the `0.1.12` collector image (from komodor-otel-collector#30) **before** this chart bump rolls out — a `0.1.12` collector without `deltatocumulative` would fail to start on the new mono config. Validated locally: the `0.1.12` mono config runs cleanly on a build that includes the processor and hard-fails on one that doesn't.


---
**Update:** the collector `0.1.12` image is already published to public ECR + Dockerhub with `deltatocumulative` (komodorio/komodor-otel-collector#30), so the cross-repo ordering dependency is already satisfied — no further release gating needed. (Earlier drafts referenced `0.1.13`; CI auto-released the change as `0.1.12`, so all references were corrected.)