### PR TITLE
feat(komodor-agent): grant watch on pods to metrics daemon for informer-based pod fetching

### DIFF
--- a/charts/komodor-agent/templates/clusterrole-daemon-metrics.yaml
+++ b/charts/komodor-agent/templates/clusterrole-daemon-metrics.yaml
@@ -17,6 +17,14 @@ rules:
   verbs:
   - get
   - list
+# watch on pods lets the metrics daemon serve pod enrichment from an informer
+# cache (kube_consolidated use_pod_informer) instead of per-pod API GETs
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - watch
 - apiGroups:
   - apps
   resources:


### PR DESCRIPTION
## Why

Part of eliminating the storm of individual `GET /api/v1/namespaces/{ns}/pods/{name}` requests the metrics DaemonSet issues from `kube_consolidated`. The follow-up telegraf-plugins change serves pod enrichment from an informer (LIST+WATCH) instead of per-pod GETs, which requires the `watch` verb on pods.

The `komodor-agent-daemon-metrics` ClusterRole currently grants only `get, list` on pods.

## Change

Adds an additive rule granting `watch` on `pods` to the daemon-metrics ClusterRole. Only the daemon runs `kube_consolidated`, so no other role needs it.

## Rollout ordering

This must be **deployed before** `use_pod_informer` is enabled in the agent's telegraf config, otherwise the informer fails to sync. Enabling the informer is a separate, gated change (default off).

## Testing

`helm template` renders the ClusterRole correctly with the new rule.
