### PR TITLE
ci: add devops-agent PR-review caller workflow

### DIFF
--- a/.github/workflows/pr-review-request.yml
+++ b/.github/workflows/pr-review-request.yml
@@ -1,0 +1,16 @@
+name: devops-agent PR review
+on:
+  pull_request:
+    types: [review_requested]
+concurrency:
+  group: devops-agent-pr-review-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+  cancel-in-progress: true
+jobs:
+  request:
+    # Only when komodor-bot is the requested reviewer, and only for same-repo branches (never forks).
+    if: >-
+      github.event.requested_reviewer.login == 'komodor-bot' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    uses: komodorio/agent-skills/.github/workflows/devops-agent-pr-review.yml@master
+    secrets:
+      webhook_token: ${{ secrets.DEVOPS_AGENT_WEBHOOK_TOKEN }}


### PR DESCRIPTION
## What
Adds the thin caller `.github/workflows/pr-review-request.yml` that asks the Komodor **DevOps Agent** to post an **advisory** review of this repo's DevOps changes when **komodor-bot** is requested as a reviewer. It calls the reusable workflow in `komodorio/agent-skills` (merged in agent-skills#40); it only relays PR metadata, never runs PR code, and never approves/merges.

## How to use
On a PR, add **komodor-bot** as a reviewer → the agent posts one advisory review (DevOps-slice files only). Push a new commit + re-request to refresh.

## Prereqs (org-level, already set up)
- Org secret `DEVOPS_AGENT_WEBHOOK_TOKEN` ✅
- agent-skills reusable-workflow access allowed for org repos; komodor-bot requestable as reviewer here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)