### PR TITLE
CU-86car0853 - ci: notify Slack with failing image on vuln scan failure

### DIFF
--- a/.buildkite/vulnerability-scan/pipeline.yaml
+++ b/.buildkite/vulnerability-scan/pipeline.yaml
@@ -13,6 +13,11 @@ steps:
           parameters:
             WIZ_CLIENT_ID: /app/ci/wiz/cli/CLIENT_ID
             WIZ_CLIENT_SECRET: /app/ci/wiz/cli/CLIENT_SECRET
+    notify:
+      - slack:
+          channels: ["#critical-security-vulns"]
+          message: ":rotating_light: Vulnerability scan failed for the `komodor-agent` image"
+        if: step.outcome == "hard_failed" || step.outcome == "errored"
 
   - label: ":microbe: Scan telegraf image"
     commands:
@@ -24,6 +29,11 @@ steps:
           parameters:
             WIZ_CLIENT_ID: /app/ci/wiz/cli/CLIENT_ID
             WIZ_CLIENT_SECRET: /app/ci/wiz/cli/CLIENT_SECRET
+    notify:
+      - slack:
+          channels: ["#critical-security-vulns"]
+          message: ":rotating_light: Vulnerability scan failed for the `telegraf` image"
+        if: step.outcome == "hard_failed" || step.outcome == "errored"
 
   - label: ":microbe: Scan admission-controller image"
     commands:
@@ -35,6 +45,11 @@ steps:
           parameters:
             WIZ_CLIENT_ID: /app/ci/wiz/cli/CLIENT_ID
             WIZ_CLIENT_SECRET: /app/ci/wiz/cli/CLIENT_SECRET
+    notify:
+      - slack:
+          channels: ["#critical-security-vulns"]
+          message: ":rotating_light: Vulnerability scan failed for the `admission-controller` image"
+        if: step.outcome == "hard_failed" || step.outcome == "errored"
 
   - label: ":microbe: Scan komodor-otel-collector image"
     commands:
@@ -46,6 +61,11 @@ steps:
           parameters:
             WIZ_CLIENT_ID: /app/ci/wiz/cli/CLIENT_ID
             WIZ_CLIENT_SECRET: /app/ci/wiz/cli/CLIENT_SECRET
+    notify:
+      - slack:
+          channels: ["#critical-security-vulns"]
+          message: ":rotating_light: Vulnerability scan failed for the `komodor-otel-collector` image"
+        if: step.outcome == "hard_failed" || step.outcome == "errored"
 
   - label: ":microbe: Scan nginx image"
     commands:
@@ -57,3 +77,8 @@ steps:
           parameters:
             WIZ_CLIENT_ID: /app/ci/wiz/cli/CLIENT_ID
             WIZ_CLIENT_SECRET: /app/ci/wiz/cli/CLIENT_SECRET
+    notify:
+      - slack:
+          channels: ["#critical-security-vulns"]
+          message: ":rotating_light: Vulnerability scan failed for the `nginx` image"
+        if: step.outcome == "hard_failed" || step.outcome == "errored"


### PR DESCRIPTION
Adds per-step Slack `notify` blocks to each image scan step in the komodor-agent vulnerability scan pipeline. On a scan failure, Slack now reports the specific failing image (e.g. `telegraf`) to `#critical-security-vulns` instead of the generic build-level "View Build" message. Each block fires only on `hard_failed` or `errored` step outcomes.

Note: the pre-existing generic Buildkite Slack notification is managed outside this repo (Slack app subscription / org settings) and will still fire until disabled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)