### PR TITLE
CU-86cavtgra - chore: bump nginx to 1.31.3-alpine3.24-slim

### DIFF
--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -431,7 +431,7 @@ components:
     # @default -- see sub-values
     image:
       name: nginx
-      tag: 1.31.2-alpine3.23-slim
+      tag: 1.31.3-alpine3.24-slim
     # components.komodorKubectlProxy.resources -- Set custom resources to the komodor kubectl proxy container
     resources: {}
     # components.komodorKubectlProxy.PriorityClassValue -- Set the priority class value for the komodor kubectl proxy deployment

--- a/scripts/nginx/Dockerfile
+++ b/scripts/nginx/Dockerfile
@@ -1,3 +1,3 @@
-FROM nginx:1.31.2-alpine3.23-slim
+FROM nginx:1.31.3-alpine3.24-slim
 
 RUN apk add --no-cache openssl


### PR DESCRIPTION
Bump nginx image to 1.31.3-alpine3.24-slim in both places we pin it:
- charts/komodor-agent/values.yaml (komodorKubectlProxy.image.tag)
- scripts/nginx/Dockerfile