### PR TITLE
CU-86cb3899a - chore: remove podmotion config from komodor-agent otel collector

### DIFF
--- a/charts/komodor-agent/documentation/README_otel.md
+++ b/charts/komodor-agent/documentation/README_otel.md
@@ -15,7 +15,6 @@ The Komodor agent deploys an [OpenTelemetry Collector](https://opentelemetry.io/
   │  ┌──────────────────────────────────┐            │  :4317  OTLP/gRPC│   │
   │  │  /var/log/pods  (host mount)     │            │                  │   │
   │  │  • komodor-daemon/*/*/*.log      │ ─ tail ──► │  filelog/komodor │   │
-  │  │  • komodor-podmotion/*/*/*.log   │            │                  │   │
   │  └──────────────────────────────────┘            │                  │   │
   │                                                  │                  │   │
   │  ┌──────────────────────────────────┐  health    │                  │   │
@@ -32,10 +31,6 @@ The Komodor agent deploys an [OpenTelemetry Collector](https://opentelemetry.io/
   │  admission-controller            │ ────────────────────────────────────►│
   └──────────────────────────────────┘         (via ClusterIP service :4318)│
                                                                              │
-  ┌──────────────────────────────────┐  Prometheus scrape                   │
-  │  komodor-podmotion pods          │ ◄───────────────────────────────────►│
-  │  (annotation: scrape=true)       │  kubernetes_sd (all nodes)           │
-  └──────────────────────────────────┘                                      │
                                                        │                    │
                           ┌────────────────────────────┤                   │
                           │                            │                    │
@@ -84,18 +79,15 @@ Receives OpenTelemetry traces from `k8s-watcher` and the `admission-controller` 
 
 ---
 
-### `metrics` — Agent & pod-motion metrics
+### `metrics` — Agent metrics
 
 | | |
 |---|---|
-| **Receivers** | `otlp` (HTTP `:4318`), `prometheus/komodor-podmotion` |
+| **Receivers** | `otlp` (HTTP `:4318`) |
 | **Processors** | `memory_limiter` → `attributes/upsert-cluster` → `batch` |
 | **Destination** | **Komodor backend** |
 
-Two sources feed this pipeline:
-
-- **OTLP** — internal metrics pushed by `k8s-watcher` and the `admission-controller`.
-- **Prometheus scrape (`komodor-podmotion`)** — the collector scrapes any pod in the cluster annotated with `prometheus.io/scrape: "true"` and labelled `app.kubernetes.io/name: komodor-podmotion`. The `komodor.cluster.name` attribute is stamped on every datapoint before forwarding.
+- **OTLP** — internal metrics pushed by `k8s-watcher` and the `admission-controller`. The `komodor.cluster.name` attribute is stamped on every datapoint before forwarding.
 
 ---
 
@@ -110,7 +102,6 @@ Two sources feed this pipeline:
 Tails log files from `/var/log/pods` on the host for:
 
 - All containers of the `komodor-daemon` pod (except the `otel-collector` container itself, to avoid log loops).
-- All `komodor-podmotion` pods.
 
 Each log line is enriched with `namespace`, `pod`, `container`, and `komodor.cluster.name` attributes. The collector attempts to parse Kubernetes container-runtime headers and JSON-structured log bodies; unparseable lines are forwarded as-is.
 
@@ -205,7 +196,7 @@ Memory is managed at the pipeline level by the `memory_limiter` processor (75% l
 |---|---|---|
 | Traces | Komodor backend | Internal agent operational traces |
 | Metrics | Komodor backend | Internal agent operational metrics |
-| Logs | Komodor backend | Structured logs from all agent containers and komodor-podmotion pods |
+| Logs | Komodor backend | Structured logs from all agent containers |
 | Health metrics | **Your Prometheus** (`:9090`) | `httpcheck.*` agent health checks as well as select operational metrics we consider critical and actionable |
 | Collector internals | **Your Prometheus** (`:8888`) | OTel Collector pipeline throughput, error rates, memory usage |
 

--- a/charts/komodor-agent/templates/opentelemetry/configmap.yaml
+++ b/charts/komodor-agent/templates/opentelemetry/configmap.yaml
@@ -62,33 +62,9 @@ data:
         protocols:
           http:
             endpoint: "0.0.0.0:4318"
-      prometheus/komodor-podmotion:
-        config:
-          scrape_configs:
-          - job_name: 'komodor-podmotion'
-            scrape_interval: 15s
-            kubernetes_sd_configs:
-            - role: pod
-            relabel_configs:
-            - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
-              action: keep
-              regex: komodor-podmotion
-            - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
-              action: keep
-              regex: true
-            - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
-              action: replace
-              target_label: __metrics_path__
-              regex: (.+)
-            - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
-              action: replace
-              regex: ([^:]+)(?::\d+)?;(\d+)
-              replacement: $1:$2
-              target_label: __address__
       filelog/komodor:
         include:
           - "/var/log/pods/*{{ include "komodorAgent.fullname" . }}*/*/*.log"
-          - "/var/log/pods/*komodor-podmotion*/*/*.log"
         exclude:
           - "/var/log/pods/*{{ include "komodorAgent.fullname" . }}*/otel-collector/*.log"
         include_file_name: false
@@ -200,7 +176,7 @@ data:
           processors: [memory_limiter, batch]
           exporters: [otlphttp/komodor]
         metrics:
-          receivers: [otlp, prometheus/komodor-podmotion]
+          receivers: [otlp]
           processors: [memory_limiter, attributes/upsert-cluster, batch]
           exporters: [otlphttp/komodor]
         logs:


### PR DESCRIPTION
## Motivation
The komodor-agent OpenTelemetry collector no longer needs to collect telemetry from komodor-podmotion pods.

## Changelog
- Removed the `prometheus/komodor-podmotion` scrape receiver from the otel collector ConfigMap and dropped it from the `metrics` pipeline.
- Removed the `komodor-podmotion` log path from the `filelog/komodor` receiver.
- Updated `README_otel.md` (architecture diagram, metrics/logs pipeline docs, and data summary table) to reflect the removal.

## Testing coverage
- [x] Manual testing (`helm template` renders the ConfigMap cleanly with no podmotion references)