### PR TITLE
cu-86cb5td6a ci: install komodor-agent on agentops-demo (+ guard first-install)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -298,6 +298,7 @@ steps:
       - ./.buildkite/pipeline_scripts/update_agent.sh production production komodor-agent
       - ./.buildkite/pipeline_scripts/update_agent.sh agentops-production agentops-production komodor-agent
       - ./.buildkite/pipeline_scripts/update_agent.sh agentops-staging agentops-staging komodor-agent
+      - ./.buildkite/pipeline_scripts/update_agent.sh agentops-demo agentops-demo komodor-agent
      # Install komodor agent on EU-production cluster report to US-production cluster
       - ./.buildkite/pipeline_scripts/update_agent.sh eu-production eu-production "komodor-agent-us" "" "komodor-agent-report-to-us"
       - ./.buildkite/pipeline_scripts/update_agent.sh production production-rc-chart komodor-agent-rc "" "komodor-agent-rc" "rc"

--- a/.buildkite/pipeline_scripts/update_agent.sh
+++ b/.buildkite/pipeline_scripts/update_agent.sh
@@ -40,7 +40,12 @@ if [ -f ./.buildkite/pipeline_scripts/${environment}-override-values.yaml ]; the
   EXTRA_VALUES_ARG="-f ./.buildkite/pipeline_scripts/${environment}-override-values.yaml"
 fi
 
-helm get values "$RELEASE_NAME" -n "${NAMESPACE}" > current-values.yaml
+# Carry the live release's values forward. On a cluster where this release does not exist yet,
+# `helm get values` exits 1 with "release: not found" — and with `set -e` that kills the whole step,
+# taking every other cluster in it down too. Start from empty values instead so the FIRST install on
+# a new cluster is just a normal `--install`.
+helm get values "$RELEASE_NAME" -n "${NAMESPACE}" > current-values.yaml 2>/dev/null \
+  || echo "{}" > current-values.yaml
 helm upgrade --install "${RELEASE_NAME}"  komodorio/komodor-agent -n "${NAMESPACE}" --create-namespace -f current-values.yaml  --dry-run
 helm upgrade --install "${RELEASE_NAME}"  komodorio/komodor-agent \
   --namespace="${NAMESPACE}" --create-namespace \


### PR DESCRIPTION
Installs `komodor-agent` on `agentops-demo`, the one agentops cluster that had no agent at all. Part of CU-86cb5td6a.

## Coverage before this

| Cluster | installed by |
|---|---|
| `agentops-ci` | Terraform (`infra`'s `kubernetes/komodor-agent` layer) |
| `agentops-staging`, `agentops-production` | **this pipeline** |
| `agentops-demo` | **nothing** |

A cluster with no agent is invisible to anything reading the Komodor API — including the DevOps Agent, whose only Kubernetes path *is* that API.

This installs demo exactly the way `agentops-staging` is installed: same step, same `/komodor/production/kubernetes/api-key`, so it reports to komodor production (US). No `agentops-demo-override-values.yaml`, matching both its siblings (only `ci` has an override). `komo ctx agentops-demo` already exists in build-tools (cu-86caw1eyj, 2026-07-23) with the right region and role, so nothing is needed there.

## The second change is the important one

Adding the line **alone would have broken the whole step on its first run.**

`update_agent.sh` carries the live release's values forward with:

```bash
helm get values "$RELEASE_NAME" -n "${NAMESPACE}" > current-values.yaml
```

On a cluster where that release doesn't exist yet, `helm get values` exits **1** with `Error: release: not found` — and the script runs under `set -ex`, so it dies there. Since this is a single Buildkite step running seven clusters in sequence, the first `agentops-demo` run would have taken down the komodor-agent update for `production`, `eu-production`, `agentops-staging`, `agentops-production` and the RC install alongside it.

So the guard starts from empty values when there is no release yet, making the first install on any new cluster just a normal `--install`.

## Verified, not assumed

Against a live cluster:

```
helm get values <missing>  -n komodor-agent   ->  exit 1, "Error: release: not found"
helm get values komodor-agent -n komodor-agent ->  exit 0, "USER-SUPPLIED VALUES:"
set -e + unguarded  ->  script dies, next line never runs
set -e + guarded    ->  writes {}, continues
helm template ... -f {}  ->  templates cleanly
```

Behaviour for every existing cluster is unchanged — the guard only fires in the case that currently crashes. `pipeline.yml` parses, `update_agent.sh` passes `bash -n`.

## After merge

The first `master` build installs the agent on demo. Worth confirming it appears in the Komodor API the agent actually reads:

```bash
curl -s "https://api.komodor.io/api/v2/user/clusters" -H "x-api-key: $KOMODOR_API_KEY" \
  | jq -r '.data.clusters[].name' | grep agentops
```

Expect all four agentops clusters.

## Context

Supersedes komodorio/infra#710, which I closed — it would have added Terraform layers for staging and production where this pipeline already owns the same release name and namespace, creating two owners of one Helm release. komodorio/knowledge-base#37 documents both mechanisms and the resulting coverage table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
