### PR TITLE
cu-86cb5td6a fix(ci): skip the values-preservation dry-run on a first install

### DIFF
--- a/.buildkite/pipeline_scripts/update_agent.sh
+++ b/.buildkite/pipeline_scripts/update_agent.sh
@@ -40,13 +40,25 @@ if [ -f ./.buildkite/pipeline_scripts/${environment}-override-values.yaml ]; the
   EXTRA_VALUES_ARG="-f ./.buildkite/pipeline_scripts/${environment}-override-values.yaml"
 fi
 
-# Carry the live release's values forward. On a cluster where this release does not exist yet,
-# `helm get values` exits 1 with "release: not found" — and with `set -e` that kills the whole step,
-# taking every other cluster in it down too. Start from empty values instead so the FIRST install on
-# a new cluster is just a normal `--install`.
-helm get values "$RELEASE_NAME" -n "${NAMESPACE}" > current-values.yaml 2>/dev/null \
-  || echo "{}" > current-values.yaml
-helm upgrade --install "${RELEASE_NAME}"  komodorio/komodor-agent -n "${NAMESPACE}" --create-namespace -f current-values.yaml  --dry-run
+# Carry the live release's values forward, and preview that they still render.
+#
+# Both lines below assume the release already EXISTS, which breaks the first install on a new
+# cluster in two different ways:
+#   1. `helm get values` exits 1 with "release: not found";
+#   2. the dry-run passes ONLY current-values.yaml — no --set clusterName/apiKey, no
+#      production-values.yaml — so with empty values the chart fails its own validation
+#      ("clusterName is a required value!").
+# Under `set -e` either one kills the whole step, taking every other cluster in it down too.
+#
+# There is nothing to carry forward or preview on a cluster with no release, so skip both and let
+# the real install below (which passes every required flag) do the work. Clusters that already have
+# the release are completely unaffected — same two commands, same order, same output.
+if helm get values "$RELEASE_NAME" -n "${NAMESPACE}" > current-values.yaml 2>/dev/null; then
+  helm upgrade --install "${RELEASE_NAME}"  komodorio/komodor-agent -n "${NAMESPACE}" --create-namespace -f current-values.yaml  --dry-run
+else
+  echo "No existing '${RELEASE_NAME}' release in ${NAMESPACE} — first install on this cluster; skipping the values-preservation dry-run."
+  : > current-values.yaml
+fi
 helm upgrade --install "${RELEASE_NAME}"  komodorio/komodor-agent \
   --namespace="${NAMESPACE}" --create-namespace \
   --set clusterName="${CLUSTER_NAME}" \


### PR DESCRIPTION
Fixes the failure my own previous PR (#636) hit on build [3332](https://buildkite.com/komodor/helm-charts/builds/3332).

## What broke

The new `agentops-demo` line failed with:

```
Error: execution error at (komodor-agent/templates/validations.yaml:13:6): clusterName is a required value!
```

`production`, `agentops-production` and `agentops-staging` all installed fine (staging is on revision 21, chart 2.17.8) — the step died on the fourth command.

## Why

#636 guarded `helm get values` so a missing release no longer kills the step. That was necessary but **not sufficient** — it only moved the failure one line down. The dry-run that follows is:

```bash
helm upgrade --install "$RELEASE_NAME" komodorio/komodor-agent -n "$NAMESPACE" --create-namespace -f current-values.yaml --dry-run
```

It passes **only** `current-values.yaml` — no `--set clusterName`, no `--set apiKey`, no `production-values.yaml`. On an existing cluster that's fine, because `current-values.yaml` already carries `clusterName`. On a fresh cluster it's empty, the chart hits its own required-value check, and `set -e` takes the whole step down.

**My mistake:** before merging #636 I validated `helm template … -f {}` **with** `--set clusterName/apiKey` — which passes. The script's dry-run passes neither. I checked a command shape that wasn't the one in the script.

## The fix

There is nothing to carry forward or preview on a cluster with no release, so skip both and let the real install — which does pass every required flag — do the work.

Clusters that already have the release are **completely unaffected**: same two commands, same order, same output. The new branch only runs where the step currently crashes.

## Verified against the live clusters

```
demo (fresh)        branch: FRESH cluster -> dry-run skipped     reached real install: yes
staging (existing)  branch: EXISTING release -> dry-run runs      reached real install: yes
```

and the real install command rendered cleanly against `agentops-demo`:

```
NAME: komodor-agent    STATUS: pending-install    REVISION: 1
```

## After merge

Next `master` build installs the agent on demo. Since #636 already published chart 2.17.8 and installed the first three clusters, the re-run is idempotent for them — `helm upgrade --install` with the same values is a no-op bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
