### PR TITLE
Add permissions for HPA in clusterrole-k8s-watcher

### DIFF
--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -185,7 +185,7 @@ Relevant values:
 | capabilities.actions | bool | `true` | Allow users to perform actions on the cluster, granular access control is defined in the application<boolean> |
 | capabilities.crActions | bool | `true` | Allow komodor service account to edit and delete custom resources in the cluster |
 | capabilities.cost | object | See sub-values | Configure the agent cost capabilities |
-| capabilities.cost.hpa | bool | `true` | Enable patch and update permissions for KEDA ScaledObjects and ScaledJobs |
+| capabilities.cost.hpa | bool | `true` | Grant the k8s-watcher patch/update on HorizontalPodAutoscalers and KEDA ScaledObjects/ScaledJobs, independently of `capabilities.actions`. Required for HPA right-sizing when `actions=false`. |
 | capabilities.helm | object | `{"enabled":true,"readonly":false}` | Enable helm capabilities by the komodor agent |
 | capabilities.helm.enabled | bool | `true` | Enable helm capabilities by the komodor agent |
 | capabilities.helm.readonly | bool | `false` | Allow komodor to read helm resources only (remove create/update/delete permissions from secrets) |

--- a/charts/komodor-agent/templates/clusterrole-k8s-watcher.yaml
+++ b/charts/komodor-agent/templates/clusterrole-k8s-watcher.yaml
@@ -433,6 +433,15 @@ rules:
 {{- end}}
 {{- if .Values.capabilities.cost.hpa }}
   - apiGroups:
+    - autoscaling
+    resources:
+    - horizontalpodautoscalers
+    verbs:
+    - get
+    - list
+    - patch
+    - update
+  - apiGroups:
     - keda.sh
     resources:
     - scaledjobs

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -106,7 +106,7 @@ capabilities:
   # capabilities.cost -- Configure the agent cost capabilities
   # @default -- See sub-values
   cost:
-    # capabilities.cost.hpa -- (bool) Enable patch and update permissions for KEDA ScaledObjects and ScaledJobs
+    # capabilities.cost.hpa -- (bool) Grant the k8s-watcher patch/update on HorizontalPodAutoscalers and KEDA ScaledObjects/ScaledJobs, independently of `capabilities.actions`. Required for HPA right-sizing when `actions=false`.
     hpa: true
   # capabilities.helm -- Enable helm capabilities by the komodor agent
   helm:


### PR DESCRIPTION
This pull request adds new permissions for managing Horizontal Pod Autoscalers (HPAs) to the Kubernetes watcher cluster role. This change enables the agent to interact more fully with HPAs when the cost capabilities are enabled.

**Kubernetes RBAC changes:**

* Added permissions to `clusterrole-k8s-watcher.yaml` to allow `get`, `list`, `patch`, and `update` actions on `horizontalpodautoscalers` resources in the `autoscaling` API group.