### PR TITLE
cu-86cb8ttp0 feat(pipeline): install komodor-agent on agentops-hosted-agents

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -299,6 +299,7 @@ steps:
       - ./.buildkite/pipeline_scripts/update_agent.sh agentops-production agentops-production komodor-agent
       - ./.buildkite/pipeline_scripts/update_agent.sh agentops-staging agentops-staging komodor-agent
       - ./.buildkite/pipeline_scripts/update_agent.sh agentops-demo agentops-demo komodor-agent
+      - ./.buildkite/pipeline_scripts/update_agent.sh agentops-hosted-agents agentops-hosted-agents komodor-agent
      # Install komodor agent on EU-production cluster report to US-production cluster
       - ./.buildkite/pipeline_scripts/update_agent.sh eu-production eu-production "komodor-agent-us" "" "komodor-agent-report-to-us"
       - ./.buildkite/pipeline_scripts/update_agent.sh production production-rc-chart komodor-agent-rc "" "komodor-agent-rc" "rc"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -299,10 +299,25 @@ steps:
       - ./.buildkite/pipeline_scripts/update_agent.sh agentops-production agentops-production komodor-agent
       - ./.buildkite/pipeline_scripts/update_agent.sh agentops-staging agentops-staging komodor-agent
       - ./.buildkite/pipeline_scripts/update_agent.sh agentops-demo agentops-demo komodor-agent
-      - ./.buildkite/pipeline_scripts/update_agent.sh agentops-hosted-agents agentops-hosted-agents komodor-agent
      # Install komodor agent on EU-production cluster report to US-production cluster
       - ./.buildkite/pipeline_scripts/update_agent.sh eu-production eu-production "komodor-agent-us" "" "komodor-agent-report-to-us"
       - ./.buildkite/pipeline_scripts/update_agent.sh production production-rc-chart komodor-agent-rc "" "komodor-agent-rc" "rc"
+    agents:
+      builder: "builder-dind-agent"
+    plugins:
+      - zacharymctague/aws-ssm#v1.0.0:
+          parameters:
+            API_KEY: /komodor/production/kubernetes/api-key
+    if: build.message !~ /feat\(OSS.+\):/i && build.branch == "master"
+
+
+  # Its own step on purpose. The step above installs six targets in one `set -e` shell, so any
+  # single failure there — a komo context the agent does not know yet, an unreachable cluster —
+  # aborts the rest, and this is the newest and least-proven target of the set. Isolated, a failure
+  # here costs this cluster only.
+  - label: ":magic_wand: Install new komodor-agent version on agentops-hosted-agents :kubernetes: cluster"
+    commands:
+      - ./.buildkite/pipeline_scripts/update_agent.sh agentops-hosted-agents agentops-hosted-agents komodor-agent
     agents:
       builder: "builder-dind-agent"
     plugins:

--- a/.buildkite/pipeline_scripts/agentops-hosted-agents-override-values.yaml
+++ b/.buildkite/pipeline_scripts/agentops-hosted-agents-override-values.yaml
@@ -1,0 +1,41 @@
+# agentops-hosted-agents (us-east-2, account 913615820321) — the cluster that runs production
+# hosted customer agents.
+#
+# This file exists because production-values.yaml is wrong for this cluster in both directions:
+#
+#   * It gives komodorDaemon and komodorMetrics tolerations for `komodor.io/sensitive` and
+#     `dedicated=ws-redis`. NEITHER taint exists here.
+#   * It gives komodorAgent, admissionController and komodorKubectlProxy no tolerations at all.
+#
+# Every Karpenter NodePool on this cluster is tainted on purpose: `platform` carries
+# `komodor.io/agentops-hosted-agents-core` and `agents-production` carries
+# `agentops.komodor.com/env=production`, so a workload that tolerates nothing goes Pending rather
+# than landing on whatever pool happens to be untainted. Without this file every komodor-agent
+# workload stays Pending on this cluster.
+#
+# Helm replaces lists rather than merging them, so each `tolerations` below fully supersedes the
+# production-values.yaml one.
+components:
+  # The daemon must observe EVERY node, the agent pool included. A blanket `Exists` is the chart's
+  # own default and stays correct when a pool is added later; naming the two taints explicitly
+  # would silently stop monitoring the next pool someone introduces, and a monitoring DaemonSet
+  # that misses a pool reports healthy while seeing nothing.
+  komodorDaemon:
+    tolerations:
+      - operator: Exists
+
+  # The Deployments tolerate the core taint only. That is what confines them to `platform` — no
+  # nodeSelector needed, because not tolerating the agents-pool taint is what keeps them off
+  # capacity sized for customer workers.
+  komodorAgent:
+    tolerations: &coreToleration
+      - key: komodor.io/agentops-hosted-agents-core
+        operator: Equal
+        value: "true"
+        effect: NoSchedule
+  admissionController:
+    tolerations: *coreToleration
+  komodorMetrics:
+    tolerations: *coreToleration
+  komodorKubectlProxy:
+    tolerations: *coreToleration


### PR DESCRIPTION
Adds `agentops-hosted-agents` to the komodor-agent install step, alongside the existing `agentops-production` / `agentops-staging` / `agentops-demo` lines, plus the per-cluster override values that cluster requires.

## ⛔ Merge order: komodorio/build-tools#418 first

`update_agent.sh` starts with `komo ctx "${environment}"`, and komo has **no `agentops-hosted-agents` context** — #418 adds it. Because that script runs under `set -e` with every cluster in a single Buildkite step, merging this first does not fail one cluster: it takes down the komodor-agent install for komodor production, `agentops-production`, `agentops-staging`, `agentops-demo`, `eu-production` **and** the rc chart.

I could not determine whether merging #418 propagates `komo` to the Buildkite agent automatically or the agent image must be rebuilt — worth confirming before merging this.

## The override file is not optional

`production-values.yaml` is wrong for this cluster **in both directions**:

- `komodorDaemon` and `komodorMetrics` get tolerations for `komodor.io/sensitive` and `dedicated=ws-redis` — **neither taint exists here**
- `komodorAgent`, `admissionController` and `komodorKubectlProxy` get **no tolerations at all**

Every Karpenter NodePool on this cluster is tainted on purpose: `platform` carries `komodor.io/agentops-hosted-agents-core`, `agents-production` carries `agentops.komodor.com/env=production`. A workload tolerating nothing goes Pending rather than landing on whatever pool happens to be untainted — so with the base values alone, **every komodor-agent workload stays Pending**.

Rendered both ways rather than reasoned about:

| | daemon | metrics | agent / admission-controller / proxy |
|---|---|---|---|
| base only | `sensitive` + `ws-redis` (neither exists) | `sensitive` (doesn't exist) | **no tolerations** |
| base + override | tolerates all taints | core toleration | core toleration |

Two deliberate choices worth reviewing:

- **The daemon gets a blanket `operator: Exists`**, not the two taints spelled out. That's the chart's own default, and it stays correct when a pool is added later. An explicit pair would silently stop monitoring the next pool someone introduces — and a monitoring DaemonSet that misses a pool reports healthy while seeing nothing. This is the trap `production-values.yaml` already fell into.
- **The Deployments tolerate only the core taint.** Not tolerating the agents-pool taint is precisely what keeps them off capacity sized for customer agents, so no `nodeSelector` is needed.

## State of the cluster right now

I installed the chart by hand first (before knowing this pipeline was the mechanism), so komodor-agent **is already running** there — release `komodor-agent` rev 1, chart 2.17.8, 7 pods healthy, 2 daemon pods matching the 2 `platform` nodes.

That install is a stopgap, and this PR supersedes it: `update_agent.sh` reuses the live values only for its dry-run preview, while the real `helm upgrade` passes `production-values.yaml` + this override + `--set` flags. So the next master build overwrites my hand-rolled values with these — which is the point, and also **exactly why the override file has to land with the pipeline line**: without it that overwrite would push a healthy cluster into all-Pending.

Also dropped from what I installed: `imagePullSecret: docker-cfg-komodorio` comes in via `production-values.yaml` and names a secret that exists on **neither** cluster. It's harmless — all images come from `public.ecr.aws/komodor-public`, which is public, and `agentops-production` has run this way for 42 days — so I left it rather than special-casing it here.