### PR TITLE
CU-86cbeh85x - CU-86cbeh848 - Update nginx Docker tag to v1.31.5

### DIFF
--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -431,7 +431,7 @@ components:
     # @default -- see sub-values
     image:
       name: nginx
-      tag: 1.31.4-alpine3.24-slim
+      tag: 1.31.5-alpine3.24-slim
     # components.komodorKubectlProxy.resources -- Set custom resources to the komodor kubectl proxy container
     resources: {}
     # components.komodorKubectlProxy.PriorityClassValue -- Set the priority class value for the komodor kubectl proxy deployment

--- a/scripts/nginx/Dockerfile
+++ b/scripts/nginx/Dockerfile
@@ -1,3 +1,3 @@
-FROM nginx:1.31.4-alpine3.24-slim
+FROM nginx:1.31.5-alpine3.24-slim
 
 RUN apk add --no-cache openssl


### PR DESCRIPTION
Security bump: nginx 1.31.4 → 1.31.5 (alpine3.24-slim).

- charts/komodor-agent/values.yaml (komodorKubectlProxy)
- scripts/nginx/Dockerfile
