### PR TITLE
CU-86cbejekx - fix(komodor-agent): drop RBAC rules whose resource list is empty

### DIFF
--- a/.buildkite/tests/validations_test.py
+++ b/.buildkite/tests/validations_test.py
@@ -1,3 +1,4 @@
+import yaml
 import pytest
 from config import API_KEY
 from helpers.utils import get_filename_as_cluster_name
@@ -199,3 +200,124 @@ class TestCombinedValidations:
         # Should fail on first validation (site)
         assert "site is required" in output or "clusterName is a required" in output or "apiKey is a required" in output, \
             f"Expected validation error message, got: {output}"
+
+
+class TestAllowedResourcesEmptyRuleValidation:
+    """Tests that an apiGroup rule is dropped, not emptied, when its kinds are disabled"""
+
+    K8S_WATCHER_SUFFIX = "-k8s-watcher"
+    READ_VERBS = {"get", "watch", "list"}
+
+    # group -> (apiGroups as rendered, {allowedResources key: rendered resource})
+    RESOURCE_GROUPS = {
+        "core": (
+            [""],
+            {
+                "configMap": "configmaps",
+                "endpoints": "endpoints",
+                "event": "events",
+                "limitRange": "limitranges",
+                "namespace": "namespaces",
+                "node": "nodes",
+                "persistentVolume": "persistentvolumes",
+                "persistentVolumeClaim": "persistentvolumeclaims",
+                "pod": "pods",
+                "podTemplate": "podtemplates",
+                "replicationController": "replicationcontrollers",
+                "resourceQuota": "resourcequotas",
+                "secret": "secrets",
+                "service": "services",
+                "serviceAccount": "serviceaccounts",
+            },
+        ),
+        "batch": (
+            ["batch"],
+            {"cronjob": "cronjobs", "job": "jobs"},
+        ),
+        "storage.k8s.io": (
+            ["storage.k8s.io"],
+            {
+                "csiDriver": "csidrivers",
+                "csiNode": "csinodes",
+                "csiStorageCapacity": "csistoragecapacities",
+                "storageClass": "storageclasses",
+                "volumeAttachment": "volumeattachments",
+            },
+        ),
+        # one key set drives two rules: extensions and networking.k8s.io
+        "networking": (
+            ["extensions", "networking.k8s.io"],
+            {
+                "ingress": "ingresses",
+                "ingressClass": "ingressclasses",
+                "networkPolicy": "networkpolicies",
+            },
+        ),
+    }
+
+    ALL_KEYS = [key for _, keys in RESOURCE_GROUPS.values() for key in keys]
+    KEPT_KEY_CASES = [(group, key) for group, (_, keys) in RESOURCE_GROUPS.items() for key in keys]
+
+    @staticmethod
+    def _render(disabled_keys, extra_settings=""):
+        settings = f"--set apiKey={API_KEY} --set clusterName={CLUSTER_NAME} --set site=us {extra_settings} " + \
+                   " ".join(f"--set allowedResources.{key}=false" for key in disabled_keys)
+        output, exit_code = helm_agent_template(settings=settings)
+        assert exit_code == 0, f"helm template failed, output: {output}"
+        return output
+
+    @staticmethod
+    def _rbac_rules(output):
+        for doc in yaml.safe_load_all(output):
+            if doc and doc.get("kind") in ("ClusterRole", "Role"):
+                for rule in doc.get("rules") or []:
+                    yield doc["metadata"]["name"], rule
+
+    def _assert_no_empty_rules(self, output):
+        """A rule rendering `resources: null` is rejected by the API server with
+        "resource rules must supply at least one resource". helm template still
+        exits 0, so this asserts on the parsed rules rather than the exit code."""
+        watcher_rules = 0
+        for name, rule in self._rbac_rules(output):
+            assert rule.get("resources") or rule.get("nonResourceURLs"), \
+                f"{name} renders a rule with no resources, the API server will reject it: {rule}"
+            if name.endswith(self.K8S_WATCHER_SUFFIX):
+                watcher_rules += 1
+        assert watcher_rules, "no k8s-watcher ClusterRole was rendered, so this test asserted nothing"
+
+    @pytest.mark.parametrize("group", RESOURCE_GROUPS.keys())
+    def test_that_disabling_a_whole_group_leaves_no_empty_rule(self, group):
+        """Test that disabling every kind in one apiGroup drops the rule instead of emptying it"""
+        _, keys = self.RESOURCE_GROUPS[group]
+        self._assert_no_empty_rules(self._render(keys))
+
+    def test_that_disabling_every_group_leaves_no_empty_rule(self):
+        """Test that all conditional kinds across all groups can be disabled at once"""
+        self._assert_no_empty_rules(self._render(self.ALL_KEYS))
+
+    @pytest.mark.parametrize("group,kept_key", KEPT_KEY_CASES)
+    def test_that_one_kind_left_enabled_still_renders_the_rule(self, group, kept_key):
+        """Test that a guard missing a key does not drop a rule that still has kinds"""
+        api_groups, keys = self.RESOURCE_GROUPS[group]
+        kept_resource = keys[kept_key]
+        # capabilities.helm adds its own `"" -> secrets` read rule to the same ClusterRole,
+        # which would satisfy the assertion below even if the core guard had lost `secret`
+        output = self._render(
+            [key for key in keys if key != kept_key],
+            extra_settings="--set capabilities.helm.enabled=false",
+        )
+        self._assert_no_empty_rules(output)
+
+        # scope to the k8s-watcher role: the metrics ClusterRoles carry an identical
+        # extensions/networking.k8s.io -> ingresses read rule and would mask a regression
+        for api_group in api_groups:
+            matching = [
+                rule for name, rule in self._rbac_rules(output)
+                if name.endswith(self.K8S_WATCHER_SUFFIX)
+                and api_group in (rule.get("apiGroups") or [])
+                and set(rule.get("verbs") or []) == self.READ_VERBS
+                and kept_resource in (rule.get("resources") or [])
+            ]
+            assert matching, \
+                f"apiGroup '{api_group}' lost its read rule for '{kept_resource}' " \
+                f"even though allowedResources.{kept_key} is still true"

--- a/charts/komodor-agent/templates/clusterrole-k8s-watcher.yaml
+++ b/charts/komodor-agent/templates/clusterrole-k8s-watcher.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.createRbac -}}
 {{- include "migrateHelmValues" . -}}
+{{- $allowed := .Values.allowedResources -}}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -83,6 +84,7 @@ rules:
     - get
     - watch
     - list
+{{- if or $allowed.configMap $allowed.endpoints $allowed.event $allowed.limitRange $allowed.namespace $allowed.node $allowed.persistentVolume $allowed.persistentVolumeClaim $allowed.pod $allowed.podTemplate $allowed.replicationController $allowed.resourceQuota $allowed.secret $allowed.service $allowed.serviceAccount }}
   - apiGroups:
     - ""
     resources:
@@ -135,6 +137,7 @@ rules:
     - get
     - watch
     - list
+{{- end }}
   - apiGroups:
     - apps
     resources:
@@ -149,6 +152,7 @@ rules:
     - get
     - watch
     - list
+{{- if or $allowed.cronjob $allowed.job }}
   - apiGroups:
     - batch
     resources:
@@ -162,6 +166,8 @@ rules:
     - get
     - watch
     - list
+{{- end }}
+{{- if or $allowed.csiDriver $allowed.csiNode $allowed.csiStorageCapacity $allowed.storageClass $allowed.volumeAttachment }}
   - apiGroups:
     - storage.k8s.io
     resources:
@@ -184,6 +190,7 @@ rules:
     - get
     - watch
     - list
+{{- end }}
 {{- if and .Values.allowedResources.customReadAPIGroups (gt (len .Values.allowedResources.customReadAPIGroups) 0) }}
   - apiGroups:
     {{- toYaml .Values.allowedResources.customReadAPIGroups | nindent 6 }}
@@ -221,6 +228,7 @@ rules:
     - watch
     - list
 {{- end }}
+{{- if or $allowed.ingress $allowed.ingressClass $allowed.networkPolicy }}
   - apiGroups:
     - extensions
     resources:
@@ -237,6 +245,8 @@ rules:
     - get
     - watch
     - list
+{{- end }}
+{{- if or $allowed.ingress $allowed.ingressClass $allowed.networkPolicy }}
   - apiGroups:
     - networking.k8s.io
     resources:
@@ -253,6 +263,7 @@ rules:
     - get
     - watch
     - list
+{{- end }}
 {{- if .Values.allowedResources.lease }}
   - apiGroups:
     - coordination.k8s.io


### PR DESCRIPTION
Five rules in `clusterrole-k8s-watcher.yaml` have a fixed `apiGroups`/`verbs` but a fully conditional `resources` list. Turn off every kind in one of those groups and the rule renders `resources: null`, which the API server rejects:

```
The ClusterRole "komodor-agent-k8s-watcher" is invalid:
* rules[13].resources: Required value: resource rules must supply at least one resource
* rules[14].resources: Required value: resource rules must supply at least one resource
```

This blocks any hardened install. Turning off `ingress`, `ingressClass` and `networkPolicy` is enough to hit it, since that empties both the `extensions` and the `networking.k8s.io` rule.

The fix wraps each of the five in `{{- if or <its keys> }}`, so the rule is dropped instead of emptied. Same shape as the `argoWorkflows` guard already in the file. Groups covered: core (15 keys), `batch`, `storage.k8s.io`, `extensions`, `networking.k8s.io`.

The core condition needs all 15 keys, so the file now aliases `{{- $allowed := .Values.allowedResources -}}` at the top and the five guards use it. Rule bodies are untouched, which keeps the diff at 11 lines.

## Backward compatibility

Rendered output is byte identical at chart defaults, with `allowReadAll=false`, with `examples/hardened-values.yaml`, and with every values file in the repo. No `values.yaml`, `Chart.yaml` or README change.

The admission controller self-signed cert and its `checksum/certs-webhook` annotation are regenerated on every `helm template` run and differ between two renders of the same tree, so those lines are excluded from the diff.

## Verification

`kubectl apply --dry-run=server` against a kind cluster, rendering with the three networking kinds off: master is rejected with 4 invalid rules, this branch is accepted. Same result with all 25 keys off.

New test class in `.buildkite/tests/validations_test.py`, 30 cases: each group disabled on its own, all groups at once, and one case per key that keeps that kind alone and asserts its rule still renders.

Mutation checked against the template:

- deleting any one of the five guards turns a case red
- flipping any `or` to `and` turns a case red
- dropping any single key from a guard's `or` list turns a case red, 25 of 25
- deleting the whole ClusterRole turns 30 cases red, so nothing passes vacuously
- reordering the verbs in a rule, which is semantically identical, stays green

The per-key cases render with `capabilities.helm.enabled=false`. That capability adds its own `"" -> secrets` read rule to the same ClusterRole, which otherwise satisfies the assertion even when the core guard has lost `secret`. That was the one mutation the first version of the test missed.

Suite goes from 23 to 53 cases, 7s to 13s. No cluster needed, `make validations_test` is the only target that runs without kind.

## Noticed, not fixed

- The `argoWorkflows` guard checks only `workflows` and `cronWorkflows`, but the body also emits `workflowtemplates` and `clusterworkflowtemplates`. Enabling only those two drops the whole rule.
- `allowedResources.clusterRole` is declared in `values.yaml` but never referenced in this template.

Part of komodorio/planning#230.
