### PR TITLE
CU-86cbejqct - feat(komodor-agent): add a cost install profile

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -46,7 +46,11 @@ steps:
       - |
         set -euo pipefail
         BASE_BRANCH="$${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-master}"
-        git fetch -q origin "$$BASE_BRANCH"
+        # Buildkite clones --depth 1, which implies --single-branch, so the only configured
+        # refspec is the default branch. `git fetch origin <branch>` then writes FETCH_HEAD
+        # but no origin/<branch> ref, and the diff below fails on any PR whose base is not
+        # the default branch (i.e. every stacked PR). Fetch into the tracking ref explicitly.
+        git fetch -q origin "+refs/heads/$$BASE_BRANCH:refs/remotes/origin/$$BASE_BRANCH"
         git fetch -q --unshallow 2>/dev/null || git fetch -q --deepen=100 || true
         # Capture diff outside the `if` so `set -e` reaches a `git diff` failure
         # (inside an `if` condition, set -e is disabled and the failure would be masked).

--- a/.buildkite/tests/values_profile_test.py
+++ b/.buildkite/tests/values_profile_test.py
@@ -1,0 +1,439 @@
+import os
+import re
+
+import pytest
+import yaml
+
+from config import API_KEY, CHART_PATH, RELEASE_NAME
+from helpers.helm_helper import helm_agent_template
+
+TEMPLATES_DIR = os.path.join(CHART_PATH, "templates")
+# the agent ConfigMap is named after the chart, everything else after the release
+CONFIG_MAP_NAME = "komodor-agent-config"
+FULLNAME = f"{RELEASE_NAME}-komodor-agent"
+AGENT_SERVICE_ACCOUNT = FULLNAME
+
+# Every value path "--set profile=cost" writes, as it appears in installed-values.yaml.
+# A path is listed here whether or not the profile's value differs from the chart default:
+# the profile pins it either way, and test_cost_profile_turns_off_every_profiled_key asserts
+# the rendered result rather than the delta.
+PROFILED_CAPABILITY_PATHS = [
+    "capabilities.actions",
+    "capabilities.crActions",
+    "capabilities.rbac",
+    "capabilities.rbacTempTokens",
+    "capabilities.helm.enabled",
+    "capabilities.events.create",
+    "capabilities.nodeEnricher",
+    "capabilities.logs.enabled",
+    "capabilities.resourceInfo.enabled",
+    "capabilities.telemetry.enabled",
+    "capabilities.telemetry.deployOtelCollector",
+    "capabilities.tunnel.enabled",
+    "capabilities.tunnel.kubeapiserver.enabled",
+    "capabilities.kubectlProxy.enabled",
+    "capabilities.klaudiaIntegrationSync.enabled",
+    "components.komodorDaemonWindows.enabled",
+]
+
+ALLOWED_RESOURCES_OFF = [
+    "allowReadAll",
+    "replicaSet", "horizontalPodAutoscaler", "podDisruptionBudget", "priorityClass",
+    "persistentVolume", "persistentVolumeClaim", "storageClass", "csiDriver", "csiNode",
+    "csiStorageCapacity", "volumeAttachment",
+    "limitRange", "resourceQuota", "event", "replicationController", "podTemplate",
+    "controllerRevision", "runtimeClass", "lease", "certificateSigningRequest",
+    "service", "endpoints", "endpointSlice", "ingress", "ingressClass", "networkPolicy",
+    "secret", "configMap",
+    "clusterRole", "clusterRoleBinding", "role", "roleBinding", "serviceAccount",
+    "customResourceDefinition", "admissionRegistrationResources", "authorizationResources",
+    "flowControlResources", "policyResources",
+]
+
+# Left at the chart default on purpose, so an operator can still shrink the install further.
+ALLOWED_RESOURCES_ON = [
+    "node", "metrics", "namespace", "pod",
+    "deployment", "statefulSet", "daemonSet", "job", "cronjob",
+    # resources-api requests rollouts.argoproj.io from every cluster whose CRD is installed
+    # (crdBackedKinds in komodor_service/crd_support.go). Without the read the agent answers
+    # forbidden, which the reconciler does not swallow, and reconciliation stops for the
+    # cluster. Rollout is also a rightsizable service kind.
+    "rollout",
+]
+
+# Same reason: workflows and cronworkflows are the other two crdBackedKinds. The remaining two
+# argo sub-keys are gated separately in the ClusterRole and nothing requests them.
+ARGO_WORKFLOWS_ON = ["workflows", "cronWorkflows"]
+ARGO_WORKFLOWS_OFF = ["workflowTemplates", "clusterWorkflowTemplates"]
+
+# What the cost flows need and the profile must not touch.
+COST_CAPABILITIES_ON = [
+    "capabilities.metrics",
+    "capabilities.admissionController.enabled",
+    "capabilities.cost.hpa",
+]
+
+# Reads that oblige a template to include "applyProfile" first. Matched against template text
+# with parentheses stripped, so "((.Values.capabilities).logs).enabled" matches too.
+PROFILED_READS = [
+    r"\.Values\.capabilities\.actions\b",
+    r"\.Values\.capabilities\.crActions\b",
+    r"\.Values\.capabilities\.helm\b",
+    r"\.Values\.capabilities\.rbac\b",
+    r"\.Values\.capabilities\.rbacTempTokens\b",
+    r"\.Values\.capabilities\.nodeEnricher\b",
+    r"\.Values\.capabilities\.logs\.enabled\b",
+    r"\.Values\.capabilities\.events\.create\b",
+    r"\.Values\.capabilities\.telemetry\.(enabled|deployOtelCollector)\b",
+    r"\.Values\.capabilities\.tunnel\.(enabled|kubeapiserver)",
+    r"\.Values\.capabilities\.kubectlProxy\.enabled\b",
+    r"\.Values\.capabilities\.klaudiaIntegrationSync\.enabled\b",
+    r"\.Values\.capabilities\.resourceInfo\b",
+    r"\.Values\.components\.komodorDaemonWindows\.enabled\b",
+    r"\.Values\.components\.komodorAgent\.watcher\.resources\b",
+    r"\.Values\.allowedResources\b",
+    # a whole profiled tree aliased into a variable or piped, e.g. {{- $caps := .Values.capabilities -}}
+    r"\.Values\.(capabilities|components)\s*(-?\}\}|\|)",
+]
+PROFILED_READS_RE = re.compile("|".join(PROFILED_READS))
+APPLY_PROFILE_RE = re.compile(r'include\s+"applyProfile"')
+
+
+def render(extra=""):
+    settings = f"--set apiKey={API_KEY} --set clusterName=profile-test --set site=us {extra}"
+    output, exit_code = helm_agent_template(settings=settings)
+    assert exit_code == 0, f"helm template failed, output: {output}"
+    return manifests(output)
+
+
+def manifests(output):
+    """helm writes warnings to stdout, so keep only documents that look like manifests."""
+    return [doc for doc in yaml.safe_load_all(output) if isinstance(doc, dict) and "kind" in doc]
+
+
+def config_maps(docs):
+    cm = next(
+        d for d in docs
+        if d["kind"] == "ConfigMap" and d["metadata"]["name"] == CONFIG_MAP_NAME
+    )
+    return (
+        yaml.safe_load(cm["data"]["komodor-k8s-watcher.yaml"]),
+        yaml.safe_load(cm["data"]["installed-values.yaml"]),
+    )
+
+
+def lookup(tree, dotted):
+    for key in dotted.split("."):
+        tree = tree[key]
+    return tree
+
+
+def null_paths(tree, prefix):
+    found = []
+    for key, value in (tree or {}).items():
+        path = f"{prefix}.{key}"
+        if value is None:
+            found.append(path)
+        elif isinstance(value, dict):
+            found += null_paths(value, path)
+    return found
+
+
+@pytest.fixture(scope="module")
+def cost_render():
+    return render("--set profile=cost")
+
+
+@pytest.fixture(scope="module")
+def default_render():
+    return render()
+
+
+@pytest.fixture(scope="module")
+def forced_on_render():
+    """profile=cost with every key the profile writes explicitly set to true first."""
+    forced = " ".join(f"--set {path}=true" for path in PROFILED_CAPABILITY_PATHS)
+    # klaudiaIntegrationSync.enabled=true makes publicApiKey required, so supply one - the point
+    # of this render is the profile's precedence, not the chart's validations
+    return render(f"--set profile=cost --set publicApiKey={API_KEY} {forced}")
+
+
+class TestProfileIsInertByDefault:
+    def test_profiled_keys_keep_their_chart_defaults(self, default_render):
+        _, installed = config_maps(default_render)
+        assert lookup(installed, "capabilities.actions") is True
+        assert lookup(installed, "capabilities.helm.enabled") is True
+        assert lookup(installed, "allowedResources.allowReadAll") is True
+        assert installed["profile"] == ""
+
+    def test_resource_info_is_written_into_the_agent_config(self, default_render):
+        """HC-4's key is a default in the agent config file, so remote config can still win."""
+        agent_config, _ = config_maps(default_render)
+        assert agent_config["resourceInfo"]["enabled"] is False
+        agent_config, _ = config_maps(render("--set capabilities.resourceInfo.enabled=true"))
+        assert agent_config["resourceInfo"]["enabled"] is True
+
+    def test_unknown_profile_is_rejected(self):
+        output, exit_code = helm_agent_template(
+            settings=f"--set apiKey={API_KEY} --set clusterName=c --set site=us --set profile=nope"
+        )
+        assert exit_code != 0, "an unknown profile rendered instead of failing"
+        assert "profile must be one of" in output
+
+
+class TestCostProfile:
+    @pytest.mark.parametrize("path", PROFILED_CAPABILITY_PATHS)
+    def test_cost_profile_turns_off_every_profiled_key(self, cost_render, path):
+        _, installed = config_maps(cost_render)
+        assert lookup(installed, path) is False
+
+    @pytest.mark.parametrize("key", ALLOWED_RESOURCES_OFF)
+    def test_cost_profile_turns_off_the_unused_resource_kinds(self, cost_render, key):
+        agent_config, installed = config_maps(cost_render)
+        assert installed["allowedResources"][key] is False
+        # allowedResources is dumped verbatim into the agent's own config file
+        assert agent_config["resources"][key] is False
+
+    @pytest.mark.parametrize("key", ALLOWED_RESOURCES_ON)
+    def test_cost_profile_keeps_the_resource_kinds_the_cost_flows_read(self, cost_render, key):
+        _, installed = config_maps(cost_render)
+        assert installed["allowedResources"][key] is True
+
+    def test_cost_profile_keeps_the_argo_kinds_the_reconciler_requests(self, cost_render):
+        _, installed = config_maps(cost_render)
+        argo = installed["allowedResources"]["argoWorkflows"]
+        for key in ARGO_WORKFLOWS_ON:
+            assert argo[key] is True
+        for key in ARGO_WORKFLOWS_OFF:
+            assert argo[key] is False
+
+    def test_cost_profile_grants_read_on_the_argo_kinds(self, cost_render):
+        """
+        The config key is not enough - the reconciler fails on a 403, so the ClusterRole has to
+        carry the read as well.
+        """
+        rules = [
+            rule
+            for doc in cost_render
+            if doc["kind"] == "ClusterRole" and doc["metadata"]["name"].endswith("-k8s-watcher")
+            for rule in doc.get("rules") or []
+            if "argoproj.io" in (rule.get("apiGroups") or [])
+        ]
+        granted = {resource for rule in rules for resource in rule.get("resources") or []}
+        for resource in ("rollouts", "workflows", "cronworkflows"):
+            assert resource in granted, f"profile=cost does not grant read on argoproj.io/{resource}"
+
+    def test_cost_profile_turns_off_resource_info_in_the_agent_config(self, cost_render):
+        agent_config, _ = config_maps(cost_render)
+        assert agent_config["resourceInfo"]["enabled"] is False
+
+    @pytest.mark.parametrize("path", COST_CAPABILITIES_ON)
+    def test_cost_profile_keeps_the_cost_capabilities_on(self, cost_render, path):
+        _, installed = config_maps(cost_render)
+        assert lookup(installed, path) is True
+
+    def test_cost_profile_leaves_custom_read_api_groups_to_the_operator(self):
+        docs = render("--set profile=cost --set allowedResources.customReadAPIGroups={sparkoperator.k8s.io}")
+        _, installed = config_maps(docs)
+        assert installed["allowedResources"]["customReadAPIGroups"] == ["sparkoperator.k8s.io"]
+
+    def test_cost_profile_can_still_be_shrunk_further(self):
+        docs = render("--set profile=cost --set capabilities.metrics=false")
+        _, installed = config_maps(docs)
+        assert installed["capabilities"]["metrics"] is False
+
+    def test_cost_profile_drops_the_workloads_it_disables(self, cost_render, default_render):
+        gone = [
+            ("DaemonSet", f"{FULLNAME}-daemon-windows"),
+            ("ClusterRole", f"{FULLNAME}-node-enricher"),
+            ("Service", f"{FULLNAME}-otel-collector"),
+        ]
+        default_names = {(d["kind"], d["metadata"]["name"]) for d in default_render}
+        cost_names = {(d["kind"], d["metadata"]["name"]) for d in cost_render}
+        for kind, name in gone:
+            assert (kind, name) in default_names, \
+                f"{kind}/{name} does not render by default either, so this asserted nothing"
+            assert (kind, name) not in cost_names, f"{kind}/{name} still rendered under profile=cost"
+
+    def test_cost_profile_wins_over_an_explicit_set(self):
+        """The one place a profile differs from an equivalent values file."""
+        docs = render("--set profile=cost --set capabilities.kubectlProxy.enabled=true")
+        names = {(d["kind"], d["metadata"]["name"]) for d in docs}
+        assert ("Deployment", f"{FULLNAME}-proxy") not in names
+        _, installed = config_maps(docs)
+        assert installed["capabilities"]["kubectlProxy"]["enabled"] is False
+
+    @pytest.mark.parametrize("path", PROFILED_CAPABILITY_PATHS)
+    def test_cost_profile_turns_a_key_off_even_when_it_was_set_on(self, forced_on_render, path):
+        """
+        Asserting `is False` against a key whose chart default is already false proves nothing.
+        This renders with every profiled key forced true, so each assertion can only pass
+        because the profile wrote it.
+        """
+        _, installed = config_maps(forced_on_render)
+        assert lookup(installed, path) is False
+
+    def test_cost_profile_keeps_the_cost_workloads(self, cost_render):
+        kinds = {(d["kind"], d["metadata"]["name"]) for d in cost_render}
+        assert ("Deployment", FULLNAME) in kinds
+        assert ("Deployment", f"{FULLNAME}-metrics") in kinds
+        assert ("Deployment", f"{FULLNAME}-admission-controller") in kinds
+
+    def test_cost_profile_grants_no_wildcard_or_empty_rules(self, cost_render):
+        bound = {
+            d["roleRef"]["name"]
+            for d in cost_render
+            if d["kind"] == "ClusterRoleBinding"
+            and any(
+                s.get("kind") == "ServiceAccount" and s["name"] == AGENT_SERVICE_ACCOUNT
+                for s in d.get("subjects") or []
+            )
+        }
+        assert bound, "no ClusterRole is bound to the agent ServiceAccount, so this asserted nothing"
+        for doc in cost_render:
+            if doc["kind"] != "ClusterRole" or doc["metadata"]["name"] not in bound:
+                continue
+            for rule in doc.get("rules") or []:
+                groups = rule.get("apiGroups") or []
+                resources = rule.get("resources") or []
+                assert not ("*" in groups and "*" in resources), \
+                    f"{doc['metadata']['name']} still grants */*: {rule}"
+                assert resources or rule.get("nonResourceURLs"), \
+                    f"{doc['metadata']['name']} renders a rule with no resources: {rule}"
+
+
+class TestProfileSurvivesAwkwardValues:
+    """
+    The helper writes through `set`, which needs a real map at every level, and rewrites
+    capabilities.helm, which may still be a bare bool from before the map migration.
+    """
+
+    @pytest.mark.parametrize("extra", [
+        # both already fail to render without the profile, so the helper's guards are what
+        # keeps them working rather than a regression it has to avoid
+        "--set components.komodorAgent.watcher.resources.limits=null",
+        "--set allowedResources.argoWorkflows=null",
+    ])
+    def test_profile_renders(self, extra):
+        output, exit_code = helm_agent_template(
+            settings=f"--set apiKey={API_KEY} --set clusterName=c --set site=us --set profile=cost {extra}"
+        )
+        assert exit_code == 0, f"profile=cost failed to render with {extra}: {output}"
+
+    def test_legacy_bool_helm_is_still_migrated_under_the_profile(self):
+        """
+        capabilities.helm was a bare bool before the map migration, and the helper writes to it
+        with `set`, which needs a map - hence the migrateHelmValues call inside applyProfile.
+
+        Helm 4 refuses to replace a declared table with a scalar and just warns, so on helm 4
+        this asserts the value stays a concrete map. On helm 3, where the override does take
+        effect, it is the migration inside the helper that keeps the render working.
+        """
+        output, exit_code = helm_agent_template(
+            settings=f"--set apiKey={API_KEY} --set clusterName=c --set site=us --set profile=cost",
+            values_file="capabilities:\n  helm: true\n",
+        )
+        assert exit_code == 0, f"profile=cost failed on a legacy bool capabilities.helm: {output}"
+        _, installed = config_maps(manifests(output))
+        assert installed["capabilities"]["helm"] == {"enabled": False, "readonly": False}
+
+
+class TestInstalledValuesStayConcrete:
+    """
+    installed-values.yaml is shipped to the backend at identify and type-asserted there. A null
+    under capabilities makes actions-api fail open and silently disables right-sizing, so a
+    profile must set concrete values and never delete a key.
+    """
+
+    @pytest.mark.parametrize("extra", ["", "--set profile=cost"])
+    @pytest.mark.parametrize("tree", ["capabilities", "allowedResources"])
+    def test_no_nulls(self, extra, tree):
+        _, installed = config_maps(render(extra))
+        assert null_paths(installed[tree], tree) == []
+
+
+class TestApplyProfileRunsFirstEverywhere:
+    """
+    Helm renders templates deepest-path-first and then reverse-alphabetically, so which
+    template observes the profile first is an accident of directory naming: add
+    templates/windows/foo.yaml and it sorts after templates/watcher/ and reads pre-profile
+    values. Rather than track which templates read what, every rendered template runs the
+    helper as its first action - then render order cannot matter at all.
+
+    Partials are excluded because helm never renders a file whose basename starts with "_";
+    an include there would be dead code.
+    """
+
+    @staticmethod
+    def _rendered_templates():
+        for root, _, names in os.walk(TEMPLATES_DIR):
+            for name in names:
+                if not name.startswith("_"):
+                    yield os.path.join(root, name)
+
+    @staticmethod
+    def _first_action(text):
+        """Offset of the first template action, skipping any leading template comments."""
+        pos = 0
+        while True:
+            match = re.compile(r"\{\{").search(text, pos)
+            if match is None:
+                return None
+            after = text[match.end():].lstrip("-").lstrip()
+            if after.startswith("/*"):
+                close = text.find("*/", match.end())
+                if close == -1:
+                    return match.start()
+                pos = close
+                continue
+            return match.start()
+
+    def test_every_rendered_template_starts_with_the_helper(self):
+        problems = []
+        checked = 0
+        for path in self._rendered_templates():
+            checked += 1
+            text = open(path).read()
+            rel = os.path.relpath(path, TEMPLATES_DIR)
+            include = APPLY_PROFILE_RE.search(text)
+            if include is None:
+                problems.append(f"{rel}: never includes applyProfile")
+                continue
+            first = self._first_action(text)
+            if first is not None and first < include.start() - len('{{- include "'):
+                problems.append(f"{rel}: runs something before applyProfile")
+        assert checked > 20, "template directory looks wrong, this asserted almost nothing"
+        assert problems == [], (
+            "every rendered template must run applyProfile first, or it can read a "
+            f"pre-profile value: {problems}"
+        )
+
+    def test_partials_do_not_carry_a_dead_include(self):
+        """
+        helm skips files whose basename starts with "_", so an include at the top of a partial
+        never runs. templates/watcher/_containers.tpl has exactly that for migrateHelmValues;
+        this test keeps the profile helper from growing the same dead wiring.
+        """
+        for root, _, names in os.walk(TEMPLATES_DIR):
+            for name in names:
+                if not name.startswith("_"):
+                    continue
+                text = open(os.path.join(root, name)).read()
+                for line in text.splitlines():
+                    if 'include "applyProfile"' in line and "define" not in text[:text.index(line)][-200:]:
+                        break
+                else:
+                    continue
+        # a partial may legitimately include the helper *inside* a define; only a top-level
+        # include is dead, and there are none today
+        top_level = []
+        for root, _, names in os.walk(TEMPLATES_DIR):
+            for name in names:
+                if not name.startswith("_"):
+                    continue
+                path = os.path.join(root, name)
+                text = open(path).read()
+                head = text.split('{{- define', 1)[0]
+                if 'include "applyProfile"' in head:
+                    top_level.append(os.path.relpath(path, TEMPLATES_DIR))
+        assert top_level == [], f"dead top-level include in partials (helm never runs them): {top_level}"

--- a/.buildkite/tests/values_profile_test.py
+++ b/.buildkite/tests/values_profile_test.py
@@ -54,14 +54,14 @@ ALLOWED_RESOURCES_OFF = [
 ALLOWED_RESOURCES_ON = [
     "node", "metrics", "namespace", "pod",
     "deployment", "statefulSet", "daemonSet", "job", "cronjob",
-    # resources-api requests rollouts.argoproj.io from every cluster whose CRD is installed
-    # (crdBackedKinds in komodor_service/crd_support.go). Without the read the agent answers
-    # forbidden, which the reconciler does not swallow, and reconciliation stops for the
-    # cluster. Rollout is also a rightsizable service kind.
+    # Komodor requests rollouts.argoproj.io from every cluster whose CRD is installed. Without
+    # the read the agent answers forbidden rather than "not supported", which is not tolerated
+    # the same way, and the cluster's resource sync stops. Rollout is also a right-sizable
+    # workload kind.
     "rollout",
 ]
 
-# Same reason: workflows and cronworkflows are the other two crdBackedKinds. The remaining two
+# Same reason: workflows and cronworkflows are the other two CRD-backed kinds. The remaining two
 # argo sub-keys are gated separately in the ClusterRole and nothing requests them.
 ARGO_WORKFLOWS_ON = ["workflows", "cronWorkflows"]
 ARGO_WORKFLOWS_OFF = ["workflowTemplates", "clusterWorkflowTemplates"]
@@ -395,9 +395,9 @@ class TestProfileSurvivesAwkwardValues:
 
 class TestInstalledValuesStayConcrete:
     """
-    installed-values.yaml is shipped to the backend at identify and type-asserted there. A null
-    under capabilities makes actions-api fail open and silently disables right-sizing, so a
-    profile must set concrete values and never delete a key.
+    installed-values.yaml is sent to Komodor and type-asserted there. A null under capabilities
+    reads as "capability on" and silently disables right-sizing, so a profile must set concrete
+    values and never delete a key.
     """
 
     @pytest.mark.parametrize("extra", ["", "--set profile=cost"])

--- a/.buildkite/tests/values_profile_test.py
+++ b/.buildkite/tests/values_profile_test.py
@@ -255,6 +255,39 @@ class TestCostProfile:
                 f"{kind}/{name} does not render by default either, so this asserted nothing"
             assert (kind, name) not in cost_names, f"{kind}/{name} still rendered under profile=cost"
 
+    def test_cost_profile_lowers_the_watcher_memory_limit(self, cost_render, default_render):
+        """
+        The limit drives the agent's own throttle, not scheduling. Requests, the CPU limit and
+        the supervisor stay at their chart defaults.
+        """
+        def watcher(docs):
+            deployment = next(
+                d for d in docs
+                if d["kind"] == "Deployment" and d["metadata"]["name"] == FULLNAME
+            )
+            containers = deployment["spec"]["template"]["spec"]["containers"]
+            return next(c for c in containers if c["name"] == "k8s-watcher")
+
+        assert watcher(default_render)["resources"]["limits"]["memory"] == "8Gi"
+        cost = watcher(cost_render)
+        assert cost["resources"]["limits"]["memory"] == "2Gi"
+        assert cost["resources"]["limits"]["cpu"] == 2
+        assert cost["resources"]["requests"] == {"cpu": 0.25, "memory": "256Mi"}
+
+        go_mem_limit = next(e for e in cost["env"] if e["name"] == "GOMEMLIMIT")["value"]
+        assert go_mem_limit == "1843MiB", "GOMEMLIMIT (2Gi x the 0.9 ratio) no longer follows the profile limit"
+
+    def test_cost_profile_leaves_the_supervisor_alone(self, cost_render):
+        deployment = next(
+            d for d in cost_render
+            if d["kind"] == "Deployment" and d["metadata"]["name"] == FULLNAME
+        )
+        supervisor = next(
+            c for c in deployment["spec"]["template"]["spec"]["containers"]
+            if c["name"] == "supervisor"
+        )
+        assert supervisor["resources"] == {"requests": {"cpu": 0.1, "memory": "256Mi"}}
+
     def test_cost_profile_wins_over_an_explicit_set(self):
         """The one place a profile differs from an equivalent values file."""
         docs = render("--set profile=cost --set capabilities.kubectlProxy.enabled=true")

--- a/.buildkite/tests/values_profile_test.py
+++ b/.buildkite/tests/values_profile_test.py
@@ -173,12 +173,30 @@ class TestProfileIsInertByDefault:
         agent_config, _ = config_maps(render("--set capabilities.resourceInfo.enabled=true"))
         assert agent_config["resourceInfo"]["enabled"] is True
 
-    def test_unknown_profile_is_rejected(self):
+    @pytest.mark.parametrize("value", [
+        "nope",
+        "Cost",   # the value is case sensitive
+        "false",  # helm reads this as a bool; it is a profile name, not a way to disable one
+        "true",
+        "1",
+    ])
+    def test_an_unrecognised_profile_is_rejected(self, value):
+        """
+        The check lives in the helper, not in validations.yaml. Helm renders deepest-path-first,
+        so validations.yaml is not the first template and a bad value would otherwise surface as
+        a raw "incompatible types for comparison" from _profile.tpl. A falsy value silently
+        installing a full agent is the failure that actually costs something.
+        """
         output, exit_code = helm_agent_template(
-            settings=f"--set apiKey={API_KEY} --set clusterName=c --set site=us --set profile=nope"
+            settings=f"--set apiKey={API_KEY} --set clusterName=c --set site=us --set profile={value}"
         )
-        assert exit_code != 0, "an unknown profile rendered instead of failing"
-        assert "profile must be one of" in output
+        assert exit_code != 0, f"profile={value} rendered instead of failing"
+        assert "profile must be" in output, output
+
+    @pytest.mark.parametrize("extra", ["", '--set profile=""', "--set profile=null"])
+    def test_an_empty_profile_is_the_default_install(self, extra):
+        _, installed = config_maps(render(extra))
+        assert installed["allowedResources"]["allowReadAll"] is True
 
 
 class TestCostProfile:

--- a/.buildkite/tests/values_profile_test.py
+++ b/.buildkite/tests/values_profile_test.py
@@ -273,38 +273,43 @@ class TestCostProfile:
                 f"{kind}/{name} does not render by default either, so this asserted nothing"
             assert (kind, name) not in cost_names, f"{kind}/{name} still rendered under profile=cost"
 
-    def test_cost_profile_lowers_the_watcher_memory_limit(self, cost_render, default_render):
+    def test_cost_profile_leaves_workload_sizing_alone(self, cost_render, default_render):
         """
-        The limit drives the agent's own throttle, not scheduling. Requests, the CPU limit and
-        the supervisor stay at their chart defaults.
+        Requests and limits are the operator's to set - utilities/memory-planning exists to tell
+        them what to put there - so the profile does not write them. A cost install that wants a
+        smaller watcher passes the value itself.
         """
-        def watcher(docs):
+        def containers(docs):
             deployment = next(
                 d for d in docs
                 if d["kind"] == "Deployment" and d["metadata"]["name"] == FULLNAME
             )
-            containers = deployment["spec"]["template"]["spec"]["containers"]
-            return next(c for c in containers if c["name"] == "k8s-watcher")
+            return {c["name"]: c for c in deployment["spec"]["template"]["spec"]["containers"]}
 
-        assert watcher(default_render)["resources"]["limits"]["memory"] == "8Gi"
-        cost = watcher(cost_render)
-        assert cost["resources"]["limits"]["memory"] == "2Gi"
-        assert cost["resources"]["limits"]["cpu"] == 2
-        assert cost["resources"]["requests"] == {"cpu": 0.25, "memory": "256Mi"}
+        cost, default = containers(cost_render), containers(default_render)
+        for name in ("k8s-watcher", "supervisor"):
+            assert cost[name]["resources"] == default[name]["resources"], \
+                f"profile=cost changed {name} resources"
 
-        go_mem_limit = next(e for e in cost["env"] if e["name"] == "GOMEMLIMIT")["value"]
-        assert go_mem_limit == "1843MiB", "GOMEMLIMIT (2Gi x the 0.9 ratio) no longer follows the profile limit"
+        watcher = cost["k8s-watcher"]["resources"]
+        assert watcher["limits"] == {"cpu": 2, "memory": "8Gi"}
+        assert watcher["requests"] == {"cpu": 0.25, "memory": "256Mi"}
 
-    def test_cost_profile_leaves_the_supervisor_alone(self, cost_render):
+    def test_a_cost_install_can_still_lower_the_watcher_memory_limit(self):
+        docs = render(
+            "--set profile=cost "
+            "--set components.komodorAgent.watcher.resources.limits.memory=2Gi"
+        )
         deployment = next(
-            d for d in cost_render
-            if d["kind"] == "Deployment" and d["metadata"]["name"] == FULLNAME
+            d for d in docs if d["kind"] == "Deployment" and d["metadata"]["name"] == FULLNAME
         )
-        supervisor = next(
+        watcher = next(
             c for c in deployment["spec"]["template"]["spec"]["containers"]
-            if c["name"] == "supervisor"
+            if c["name"] == "k8s-watcher"
         )
-        assert supervisor["resources"] == {"requests": {"cpu": 0.1, "memory": "256Mi"}}
+        assert watcher["resources"]["limits"]["memory"] == "2Gi"
+        go_mem_limit = next(e for e in watcher["env"] if e["name"] == "GOMEMLIMIT")["value"]
+        assert go_mem_limit == "1843MiB", "GOMEMLIMIT no longer follows the configured limit"
 
     def test_cost_profile_wins_over_an_explicit_set(self):
         """The one place a profile differs from an equivalent values file."""
@@ -360,9 +365,8 @@ class TestProfileSurvivesAwkwardValues:
     """
 
     @pytest.mark.parametrize("extra", [
-        # both already fail to render without the profile, so the helper's guards are what
-        # keeps them working rather than a regression it has to avoid
-        "--set components.komodorAgent.watcher.resources.limits=null",
+        # already fails to render without the profile too, so the helper's guard is what keeps
+        # it working rather than a regression it has to avoid
         "--set allowedResources.argoWorkflows=null",
     ])
     def test_profile_renders(self, extra):

--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -220,7 +220,7 @@ Relevant values:
 | capabilities.cost | object | See sub-values | Configure the agent cost capabilities |
 | capabilities.cost.hpa | bool | `true` | Grant the k8s-watcher patch/update on HorizontalPodAutoscalers and KEDA ScaledObjects/ScaledJobs, independently of `capabilities.actions`. Required for HPA right-sizing when `actions=false`. |
 | capabilities.resourceInfo | object | See sub-values | Configure the agent resource-info collection subsystem |
-| capabilities.resourceInfo.enabled | bool | `false` | Enable the in-watcher resource-info collector. Rendered into the agent ConfigMap as a default, so a remote configuration push still overrides it. |
+| capabilities.resourceInfo.enabled | bool | `false` | Enable the in-watcher resource-info collector. |
 | capabilities.helm | object | `{"enabled":true,"readonly":false}` | Enable helm capabilities by the komodor agent |
 | capabilities.helm.enabled | bool | `true` | Enable helm capabilities by the komodor agent |
 | capabilities.helm.readonly | bool | `false` | Allow komodor to read helm resources only (remove create/update/delete permissions from secrets) |

--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -186,6 +186,8 @@ Relevant values:
 | capabilities.crActions | bool | `true` | Allow komodor service account to edit and delete custom resources in the cluster |
 | capabilities.cost | object | See sub-values | Configure the agent cost capabilities |
 | capabilities.cost.hpa | bool | `true` | Grant the k8s-watcher patch/update on HorizontalPodAutoscalers and KEDA ScaledObjects/ScaledJobs, independently of `capabilities.actions`. Required for HPA right-sizing when `actions=false`. |
+| capabilities.resourceInfo | object | See sub-values | Configure the agent resource-info collection subsystem |
+| capabilities.resourceInfo.enabled | bool | `false` | Enable the in-watcher resource-info collector. Rendered into the agent ConfigMap as a default, so a remote configuration push still overrides it. |
 | capabilities.helm | object | `{"enabled":true,"readonly":false}` | Enable helm capabilities by the komodor agent |
 | capabilities.helm.enabled | bool | `true` | Enable helm capabilities by the komodor agent |
 | capabilities.helm.readonly | bool | `false` | Allow komodor to read helm resources only (remove create/update/delete permissions from secrets) |

--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -104,6 +104,42 @@ The command deploys the komodor-agent on the Kubernetes cluster with default con
 
 > **Tip**: List all releases using `helm list`
 
+## Install profiles
+
+`profile` installs a preset that turns off the capabilities the preset does not need:
+
+```bash
+helm upgrade --install komodor-agent komodorio/komodor-agent \
+  --set apiKey=<YOUR_API_KEY_HERE> \
+  --set clusterName=<CLUSTER_NAME> \
+  --set profile=cost
+```
+
+| Profile | What it does |
+| --- | --- |
+| `""` (default) | Nothing. Every value is exactly as documented below. |
+| `cost` | A read-only, cost-only agent. Keeps metrics collection, the admission controller and HPA right-sizing. Turns off actions, helm, RBAC management, pod logs, the node enricher, resource-info, agent telemetry and the OpenTelemetry collector, the WebSocket tunnel, the kubectl proxy, the Klaudia integration sync and the Windows daemonset, and narrows the agent's cluster read permissions to the resource kinds the cost flows actually read. |
+
+Two things to know before using one:
+
+- **A profile takes precedence over `--set` for the keys it writes.** This is the one way it
+  differs from passing a values file. A profile only ever turns capabilities off, so you can
+  still shrink an install further — `--set profile=cost --set capabilities.metrics=false`
+  works — but you cannot turn one of the profile's own switches back on. Drop the profile and
+  set the individual keys if you need that.
+- **`allowedResources.customReadAPIGroups` is left alone**, so add the API groups of any CRDs
+  you want the agent to read alongside the profile, for example
+  `--set allowedResources.customReadAPIGroups={sparkoperator.k8s.io}`.
+
+Two limitations of the `cost` profile are worth knowing before you switch an existing install:
+
+- Right-sizing keeps applying automatically through the admission controller, but because the
+  profile turns off `capabilities.actions`, **applying a recommendation by hand from the UI, or
+  through self-healing, is refused**. `capabilities.actions` is a single switch covering every
+  mutating action, so there is no way to allow only that one.
+- The agent still advertises live resource browsing for every kind, so **browsing a kind the
+  profile no longer grants read on returns a permission error** rather than "not supported".
+
 ## Api Key
 
 The Komodor kubernetes api key can be provided in the helm upgrade command, in the `values.yaml` file or can be taken from an existing kubernetes secret resource.
@@ -155,6 +191,7 @@ Relevant values:
 | tags | dict | `{}` | Tags the agent in order to identify it based on `key:value` properties separated by semicolon (`;`) example: `--set tags.env=staging,tags.team=payments` --- Can also be set in the values under `tags` as a dictionary of key:value strings |
 | clusterName | string | `nil` | **(*required*)** Name to be displayed in the Komodor web application |
 | createRbac | bool | `true` | Creates the necessary RBAC resources for the agent - use with caution! |
+| profile | string | `""` | Install a preset that turns off the capabilities the preset does not need. Allowed values: `""` (default, nothing is changed) and `cost` (a cost-only agent). Values a profile writes take precedence over `--set`, so use `--set profile=cost` to shrink an install and leave the individual keys alone unless you are turning something further off. |
 | global | object | See sub-values | Global defaults applied across the chart. |
 | global.podSecurityContext | object | `{}` | Set a pod-level securityContext applied to all agent pods unless a component-specific podSecurityContext is defined. Supports pod-only fields: fsGroup, runAsUser, runAsGroup, runAsNonRoot, supplementalGroups, sysctls, seccompProfile. (use with caution) |
 | global.securityContext | object | `{}` | Set a container-level securityContext applied to all containers unless a container-specific securityContext is defined. Supports container fields: allowPrivilegeEscalation, capabilities, privileged, readOnlyRootFilesystem, runAsUser, runAsGroup, runAsNonRoot, seccompProfile. (use with caution) |

--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -136,15 +136,6 @@ Two things to know before using one:
   needs, and lowering it is what brings the agent's own memory throttle into reach:
   `--set components.komodorAgent.watcher.resources.limits.memory=2Gi`.
 
-Two limitations of the `cost` profile are worth knowing before you switch an existing install:
-
-- Right-sizing keeps applying automatically through the admission controller, but because the
-  profile turns off `capabilities.actions`, **applying a recommendation by hand from the UI, or
-  through self-healing, is refused**. `capabilities.actions` is a single switch covering every
-  mutating action, so there is no way to allow only that one.
-- The agent still advertises live resource browsing for every kind, so **browsing a kind the
-  profile no longer grants read on returns a permission error** rather than "not supported".
-
 ## Api Key
 
 The Komodor kubernetes api key can be provided in the helm upgrade command, in the `values.yaml` file or can be taken from an existing kubernetes secret resource.

--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -130,6 +130,11 @@ Two things to know before using one:
 - **`allowedResources.customReadAPIGroups` is left alone**, so add the API groups of any CRDs
   you want the agent to read alongside the profile, for example
   `--set allowedResources.customReadAPIGroups={sparkoperator.k8s.io}`.
+- **A profile never touches resource requests or limits.** Sizing stays yours — see
+  [Memory Planning](#memory-planning-recommended) above. A cost-profile watcher runs far fewer
+  informers than a full agent, so the default `8Gi` watcher limit is usually much larger than it
+  needs, and lowering it is what brings the agent's own memory throttle into reach:
+  `--set components.komodorAgent.watcher.resources.limits.memory=2Gi`.
 
 Two limitations of the `cost` profile are worth knowing before you switch an existing install:
 

--- a/charts/komodor-agent/README.md.gotmpl
+++ b/charts/komodor-agent/README.md.gotmpl
@@ -103,6 +103,42 @@ The command deploys the komodor-agent on the Kubernetes cluster with default con
 
 > **Tip**: List all releases using `helm list`
 
+## Install profiles
+
+`profile` installs a preset that turns off the capabilities the preset does not need:
+
+```bash
+helm upgrade --install komodor-agent komodorio/komodor-agent \
+  --set apiKey=<YOUR_API_KEY_HERE> \
+  --set clusterName=<CLUSTER_NAME> \
+  --set profile=cost
+```
+
+| Profile | What it does |
+| --- | --- |
+| `""` (default) | Nothing. Every value is exactly as documented below. |
+| `cost` | A read-only, cost-only agent. Keeps metrics collection, the admission controller and HPA right-sizing. Turns off actions, helm, RBAC management, pod logs, the node enricher, resource-info, agent telemetry and the OpenTelemetry collector, the WebSocket tunnel, the kubectl proxy, the Klaudia integration sync and the Windows daemonset, and narrows the agent's cluster read permissions to the resource kinds the cost flows actually read. |
+
+Two things to know before using one:
+
+- **A profile takes precedence over `--set` for the keys it writes.** This is the one way it
+  differs from passing a values file. A profile only ever turns capabilities off, so you can
+  still shrink an install further — `--set profile=cost --set capabilities.metrics=false`
+  works — but you cannot turn one of the profile's own switches back on. Drop the profile and
+  set the individual keys if you need that.
+- **`allowedResources.customReadAPIGroups` is left alone**, so add the API groups of any CRDs
+  you want the agent to read alongside the profile, for example
+  `--set allowedResources.customReadAPIGroups={sparkoperator.k8s.io}`.
+
+Two limitations of the `cost` profile are worth knowing before you switch an existing install:
+
+- Right-sizing keeps applying automatically through the admission controller, but because the
+  profile turns off `capabilities.actions`, **applying a recommendation by hand from the UI, or
+  through self-healing, is refused**. `capabilities.actions` is a single switch covering every
+  mutating action, so there is no way to allow only that one.
+- The agent still advertises live resource browsing for every kind, so **browsing a kind the
+  profile no longer grants read on returns a permission error** rather than "not supported".
+
 ## Api Key
 
 The Komodor kubernetes api key can be provided in the helm upgrade command, in the `values.yaml` file or can be taken from an existing kubernetes secret resource.

--- a/charts/komodor-agent/README.md.gotmpl
+++ b/charts/komodor-agent/README.md.gotmpl
@@ -135,15 +135,6 @@ Two things to know before using one:
   needs, and lowering it is what brings the agent's own memory throttle into reach:
   `--set components.komodorAgent.watcher.resources.limits.memory=2Gi`.
 
-Two limitations of the `cost` profile are worth knowing before you switch an existing install:
-
-- Right-sizing keeps applying automatically through the admission controller, but because the
-  profile turns off `capabilities.actions`, **applying a recommendation by hand from the UI, or
-  through self-healing, is refused**. `capabilities.actions` is a single switch covering every
-  mutating action, so there is no way to allow only that one.
-- The agent still advertises live resource browsing for every kind, so **browsing a kind the
-  profile no longer grants read on returns a permission error** rather than "not supported".
-
 ## Api Key
 
 The Komodor kubernetes api key can be provided in the helm upgrade command, in the `values.yaml` file or can be taken from an existing kubernetes secret resource.

--- a/charts/komodor-agent/README.md.gotmpl
+++ b/charts/komodor-agent/README.md.gotmpl
@@ -129,6 +129,11 @@ Two things to know before using one:
 - **`allowedResources.customReadAPIGroups` is left alone**, so add the API groups of any CRDs
   you want the agent to read alongside the profile, for example
   `--set allowedResources.customReadAPIGroups={sparkoperator.k8s.io}`.
+- **A profile never touches resource requests or limits.** Sizing stays yours — see
+  [Memory Planning](#memory-planning-recommended) above. A cost-profile watcher runs far fewer
+  informers than a full agent, so the default `8Gi` watcher limit is usually much larger than it
+  needs, and lowering it is what brings the agent's own memory throttle into reach:
+  `--set components.komodorAgent.watcher.resources.limits.memory=2Gi`.
 
 Two limitations of the `cost` profile are worth knowing before you switch an existing install:
 

--- a/charts/komodor-agent/templates/NOTES.txt
+++ b/charts/komodor-agent/templates/NOTES.txt
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 Thank you for installing {{ .Chart.Name }}.
 
 The Komodor Agent was installed in namespace: {{ .Release.Namespace }}

--- a/charts/komodor-agent/templates/_profile.tpl
+++ b/charts/komodor-agent/templates/_profile.tpl
@@ -48,6 +48,21 @@ include this helper before its first read. `values_profile_test.py` enforces tha
 
 {{- $_ := set .Values.components.komodorDaemonWindows "enabled" false -}}
 
+{{/*
+The watcher memory limit is not a scheduling number. Kubernetes schedules on requests, which
+this profile leaves alone; the limit is what the agent reads back to size its own throttle
+(cmd/watcher/watcher.go passes the container limit into StartMemoryStatusPeriodicRunner, which
+pauses at 20% remaining). The 8Gi default is sized for ~50 informers, so the agent would not
+start protecting itself until it was using 6.4Gi - by which point the node has evicted it. A
+cost-profile watcher runs one informer, so 2Gi puts the pause path above ~1.6Gi and leaves the
+throttle reachable without it firing in normal operation. GOMEMLIMIT follows the same value.
+*/}}
+{{- $watcherResources := .Values.components.komodorAgent.watcher.resources -}}
+{{- if not (kindIs "map" $watcherResources.limits) -}}
+{{- $_ := set $watcherResources "limits" dict -}}
+{{- end -}}
+{{- $_ := set $watcherResources.limits "memory" "2Gi" -}}
+
 {{- $allowed := .Values.allowedResources -}}
 {{/*
 Kept on, and deliberately not pinned here: node, metrics, namespace, pod, deployment,

--- a/charts/komodor-agent/templates/_profile.tpl
+++ b/charts/komodor-agent/templates/_profile.tpl
@@ -4,10 +4,9 @@ applyProfile resolves `--set profile=<name>` into concrete chart values.
 Three rules govern what a profile is allowed to do:
 
   1. It only ever sets values. It never deletes a key and never writes null.
-     `installed-values.yaml` below is a verbatim dump of .Values that is shipped to the
-     Komodor backend at identify, and the backend type-asserts on `capabilities.*` — a null
-     there makes actions-api fail open on every mutating action type and silently disables
-     right-sizing.
+     `installed-values.yaml` below is a verbatim dump of .Values that is sent to Komodor, and
+     the backend type-asserts on `capabilities.*` — a null there reads as "capability on" for
+     every mutating action type and silently disables right-sizing.
 
   2. It only turns capabilities off. Anything a profile depends on staying on is left at its
      chart default rather than pinned here, so an operator can still shrink the install
@@ -51,7 +50,7 @@ silently installing a full agent because someone typed it is the worst outcome h
 {{- $_ := set $caps "nodeEnricher" false -}}
 {{- $_ := set $caps.logs "enabled" false -}}
 {{- $_ := set $caps.resourceInfo "enabled" false -}}
-{{/* komodor-internal agent observability; drops the otel collector daemonset sidecar */}}
+{{/* the agent's own observability; drops the otel collector daemonset sidecar */}}
 {{- $_ := set $caps.telemetry "enabled" false -}}
 {{- $_ := set $caps.telemetry "deployOtelCollector" false -}}
 {{/* remote access paths */}}
@@ -77,14 +76,11 @@ allowedResources is dumped verbatim into the agent ConfigMap, so it has to be na
 explicitly to take effect.
 
 rollout, argoWorkflows.workflows and argoWorkflows.cronWorkflows stay on, and that is load
-bearing rather than an oversight. resources-api asks every cluster for rollouts.argoproj.io,
-workflows.argoproj.io and cronworkflows.argoproj.io whenever the matching CRD is installed
-(crdBackedKinds, services/resources-api/pkg/reconcilers/resources/komodor_service/
-crd_support.go). Without the RBAC the agent answers with a forbidden error rather than the
-"no supported kubernetes resource found" string that parsers.go swallows, and
-GetParallelResultsFor aborts the whole batch - so komodor_service reconciliation stops for
-that cluster and nothing is ever marked deleted. Rollout is also a rightsizable service kind
-(pkg/komodor_cost/rightsizable_service_kinds.go). workflowTemplates and
+bearing rather than an oversight. Komodor asks every cluster for rollouts.argoproj.io,
+workflows.argoproj.io and cronworkflows.argoproj.io whenever the matching CRD is installed.
+Without the RBAC the agent answers forbidden instead of "not supported", and a forbidden is
+not tolerated the same way - the cluster's resource sync stops and nothing is ever marked
+deleted. Rollout is also a right-sizable workload kind. workflowTemplates and
 clusterWorkflowTemplates are gated separately in the ClusterRole and nothing requests them,
 so those two do come off.
 */}}

--- a/charts/komodor-agent/templates/_profile.tpl
+++ b/charts/komodor-agent/templates/_profile.tpl
@@ -62,21 +62,6 @@ silently installing a full agent because someone typed it is the worst outcome h
 
 {{- $_ := set .Values.components.komodorDaemonWindows "enabled" false -}}
 
-{{/*
-The watcher memory limit is not a scheduling number. Kubernetes schedules on requests, which
-this profile leaves alone; the limit is what the agent reads back to size its own throttle
-(cmd/watcher/watcher.go passes the container limit into StartMemoryStatusPeriodicRunner, which
-pauses at 20% remaining). The 8Gi default is sized for ~50 informers, so the agent would not
-start protecting itself until it was using 6.4Gi - by which point the node has evicted it. A
-cost-profile watcher runs one informer, so 2Gi puts the pause path above ~1.6Gi and leaves the
-throttle reachable without it firing in normal operation. GOMEMLIMIT follows the same value.
-*/}}
-{{- $watcherResources := .Values.components.komodorAgent.watcher.resources -}}
-{{- if not (kindIs "map" $watcherResources.limits) -}}
-{{- $_ := set $watcherResources "limits" dict -}}
-{{- end -}}
-{{- $_ := set $watcherResources.limits "memory" "2Gi" -}}
-
 {{- $allowed := .Values.allowedResources -}}
 {{/*
 Kept on, and deliberately not pinned here: node, metrics, namespace, pod, deployment,

--- a/charts/komodor-agent/templates/_profile.tpl
+++ b/charts/komodor-agent/templates/_profile.tpl
@@ -20,7 +20,21 @@ Helm gives no render-order guarantee, so every template that reads a key written
 include this helper before its first read. `values_profile_test.py` enforces that statically.
 */}}
 {{- define "applyProfile" -}}
-{{- if eq (.Values.profile | default "") "cost" -}}
+{{/*
+Validate here rather than in validations.yaml. Helm renders templates deepest-path-first, so
+validations.yaml is not first and a bad value would surface as a raw template error from this
+file before its check ever ran. Comparing as a string also keeps `--set profile=false` from
+being read as a bool: it is a value like any other, not a way to turn the preset off, and
+silently installing a full agent because someone typed it is the worst outcome here.
+*/}}
+{{- $profile := "" -}}
+{{- if not (kindIs "invalid" .Values.profile) -}}
+{{- $profile = .Values.profile | toString -}}
+{{- end -}}
+{{- if not (has $profile (list "" "cost")) -}}
+{{- fail (printf "profile must be \"cost\", or unset for a default install; got %q. profile is a string, so --set profile=false sets a profile named \"false\" rather than disabling the preset." $profile) -}}
+{{- end -}}
+{{- if eq $profile "cost" -}}
 
 {{/* capabilities.helm may still be a bare bool at this point; set needs a map */}}
 {{- include "migrateHelmValues" . -}}

--- a/charts/komodor-agent/templates/_profile.tpl
+++ b/charts/komodor-agent/templates/_profile.tpl
@@ -1,0 +1,100 @@
+{{/*
+applyProfile resolves `--set profile=<name>` into concrete chart values.
+
+Three rules govern what a profile is allowed to do:
+
+  1. It only ever sets values. It never deletes a key and never writes null.
+     `installed-values.yaml` below is a verbatim dump of .Values that is shipped to the
+     Komodor backend at identify, and the backend type-asserts on `capabilities.*` — a null
+     there makes actions-api fail open on every mutating action type and silently disables
+     right-sizing.
+
+  2. It only turns capabilities off. Anything a profile depends on staying on is left at its
+     chart default rather than pinned here, so an operator can still shrink the install
+     further. `values_profile_test.py` asserts the kept keys are actually on.
+
+  3. Values written here WIN over `--set`, because they are applied during rendering. That is
+     the one behaviour that differs from passing an equivalent `-f values-cost.yaml`.
+
+Helm gives no render-order guarantee, so every template that reads a key written below must
+include this helper before its first read. `values_profile_test.py` enforces that statically.
+*/}}
+{{- define "applyProfile" -}}
+{{- if eq (.Values.profile | default "") "cost" -}}
+
+{{/* capabilities.helm may still be a bare bool at this point; set needs a map */}}
+{{- include "migrateHelmValues" . -}}
+
+{{- $caps := .Values.capabilities -}}
+{{/* cluster mutation: the cost flows read, they do not act */}}
+{{- $_ := set $caps "actions" false -}}
+{{- $_ := set $caps "crActions" false -}}
+{{- $_ := set $caps "rbac" false -}}
+{{- $_ := set $caps "rbacTempTokens" false -}}
+{{- $_ := set $caps.helm "enabled" false -}}
+{{- $_ := set $caps.events "create" false -}}
+{{/* collection subsystems no cost flow consumes */}}
+{{- $_ := set $caps "nodeEnricher" false -}}
+{{- $_ := set $caps.logs "enabled" false -}}
+{{- $_ := set $caps.resourceInfo "enabled" false -}}
+{{/* komodor-internal agent observability; drops the otel collector daemonset sidecar */}}
+{{- $_ := set $caps.telemetry "enabled" false -}}
+{{- $_ := set $caps.telemetry "deployOtelCollector" false -}}
+{{/* remote access paths */}}
+{{- $_ := set $caps.tunnel "enabled" false -}}
+{{- $_ := set $caps.tunnel.kubeapiserver "enabled" false -}}
+{{- $_ := set $caps.kubectlProxy "enabled" false -}}
+{{- $_ := set $caps.klaudiaIntegrationSync "enabled" false -}}
+
+{{- $_ := set .Values.components.komodorDaemonWindows "enabled" false -}}
+
+{{- $allowed := .Values.allowedResources -}}
+{{/*
+Kept on, and deliberately not pinned here: node, metrics, namespace, pod, deployment,
+statefulSet, daemonSet, job, cronjob — the kinds the cost flows read — and
+customReadAPIGroups, which an operator sets per cluster alongside the profile.
+
+replicaSet is off even though the other workload kinds stay on: it is not a source kind for
+any reconciler, and telegraf carries its own apps/replicasets read, so dropping it degrades
+only a backend fallback telegraf does not use.
+
+customResourceDefinition has no entry in values.yaml but defaults true in the agent, and
+allowedResources is dumped verbatim into the agent ConfigMap, so it has to be named
+explicitly to take effect.
+
+rollout, argoWorkflows.workflows and argoWorkflows.cronWorkflows stay on, and that is load
+bearing rather than an oversight. resources-api asks every cluster for rollouts.argoproj.io,
+workflows.argoproj.io and cronworkflows.argoproj.io whenever the matching CRD is installed
+(crdBackedKinds, services/resources-api/pkg/reconcilers/resources/komodor_service/
+crd_support.go). Without the RBAC the agent answers with a forbidden error rather than the
+"no supported kubernetes resource found" string that parsers.go swallows, and
+GetParallelResultsFor aborts the whole batch - so komodor_service reconciliation stops for
+that cluster and nothing is ever marked deleted. Rollout is also a rightsizable service kind
+(pkg/komodor_cost/rightsizable_service_kinds.go). workflowTemplates and
+clusterWorkflowTemplates are gated separately in the ClusterRole and nothing requests them,
+so those two do come off.
+*/}}
+{{- $off := list "allowReadAll" -}}
+{{- $off = concat $off (list "replicaSet" "horizontalPodAutoscaler" "podDisruptionBudget" "priorityClass") -}}
+{{- $off = concat $off (list "persistentVolume" "persistentVolumeClaim" "storageClass" "volumeAttachment") -}}
+{{- $off = concat $off (list "csiDriver" "csiNode" "csiStorageCapacity") -}}
+{{- $off = concat $off (list "limitRange" "resourceQuota" "event" "replicationController" "podTemplate") -}}
+{{- $off = concat $off (list "controllerRevision" "runtimeClass" "lease" "certificateSigningRequest") -}}
+{{- $off = concat $off (list "service" "endpoints" "endpointSlice" "ingress" "ingressClass" "networkPolicy") -}}
+{{- $off = concat $off (list "secret" "configMap") -}}
+{{- $off = concat $off (list "clusterRole" "clusterRoleBinding" "role" "roleBinding" "serviceAccount") -}}
+{{- $off = concat $off (list "customResourceDefinition" "admissionRegistrationResources") -}}
+{{- $off = concat $off (list "authorizationResources" "flowControlResources" "policyResources") -}}
+{{- range $key := $off -}}
+{{- $_ := set $allowed $key false -}}
+{{- end -}}
+
+{{- if not (kindIs "map" $allowed.argoWorkflows) -}}
+{{- $_ := set $allowed "argoWorkflows" dict -}}
+{{- end -}}
+{{- range $key := list "workflowTemplates" "clusterWorkflowTemplates" -}}
+{{- $_ := set $allowed.argoWorkflows $key false -}}
+{{- end -}}
+
+{{- end -}}
+{{- end -}}

--- a/charts/komodor-agent/templates/admission-controller/configmap.yaml
+++ b/charts/komodor-agent/templates/admission-controller/configmap.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if .Values.capabilities.admissionController.enabled }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/komodor-agent/templates/admission-controller/deployment.yaml
+++ b/charts/komodor-agent/templates/admission-controller/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if .Values.capabilities.admissionController.enabled }}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/komodor-agent/templates/admission-controller/poddisruptionbudget.yaml
+++ b/charts/komodor-agent/templates/admission-controller/poddisruptionbudget.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if and .Values.capabilities.admissionController.enabled .Values.capabilities.admissionController.pdb.enabled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/charts/komodor-agent/templates/admission-controller/rbac.yaml
+++ b/charts/komodor-agent/templates/admission-controller/rbac.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if and .Values.capabilities.admissionController.enabled .Values.createRbac -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/komodor-agent/templates/admission-controller/service.yaml
+++ b/charts/komodor-agent/templates/admission-controller/service.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if .Values.capabilities.admissionController.enabled }}
 apiVersion: v1
 kind: Service

--- a/charts/komodor-agent/templates/admission-controller/serviceaccount.yaml
+++ b/charts/komodor-agent/templates/admission-controller/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if and .Values.capabilities.admissionController.enabled .Values.components.admissionController.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/komodor-agent/templates/admission-controller/webhookconfiguration.yaml
+++ b/charts/komodor-agent/templates/admission-controller/webhookconfiguration.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{/*
 We need to put all resources that need certificate or CA Bundle together,
 so the template is executed just once and all the certs match.

--- a/charts/komodor-agent/templates/clusterrole-daemon-metrics.yaml
+++ b/charts/komodor-agent/templates/clusterrole-daemon-metrics.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if and (.Values.createRbac) (.Values.capabilities.metrics) -}}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/komodor-agent/templates/clusterrole-impersonation.yaml
+++ b/charts/komodor-agent/templates/clusterrole-impersonation.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if and .Values.createRbac .Values.capabilities.impersonation.enabled -}}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/komodor-agent/templates/clusterrole-k8s-watcher.yaml
+++ b/charts/komodor-agent/templates/clusterrole-k8s-watcher.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if .Values.createRbac -}}
 {{- include "migrateHelmValues" . -}}
 {{- $allowed := .Values.allowedResources -}}

--- a/charts/komodor-agent/templates/clusterrole-metrics-deployment.yaml
+++ b/charts/komodor-agent/templates/clusterrole-metrics-deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if and (.Values.createRbac) (.Values.capabilities.metrics) -}}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/komodor-agent/templates/clusterrole-node-enricher.yaml
+++ b/charts/komodor-agent/templates/clusterrole-node-enricher.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if .Values.createRbac -}}
 {{- if .Values.capabilities.nodeEnricher }}
 kind: ClusterRole

--- a/charts/komodor-agent/templates/clusterrolebinding-daemon-metrics.yaml
+++ b/charts/komodor-agent/templates/clusterrolebinding-daemon-metrics.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if and (.Values.createRbac) (.Values.capabilities.metrics) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/komodor-agent/templates/clusterrolebinding-impersonation.yaml
+++ b/charts/komodor-agent/templates/clusterrolebinding-impersonation.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if and .Values.createRbac .Values.capabilities.impersonation.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/komodor-agent/templates/clusterrolebinding-k8s-watcher-group.yaml
+++ b/charts/komodor-agent/templates/clusterrolebinding-k8s-watcher-group.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if and .Values.createRbac .Values.capabilities.impersonation.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/komodor-agent/templates/clusterrolebinding-k8s-watcher.yaml
+++ b/charts/komodor-agent/templates/clusterrolebinding-k8s-watcher.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if .Values.createRbac -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/komodor-agent/templates/clusterrolebinding-metrics-deployment.yaml
+++ b/charts/komodor-agent/templates/clusterrolebinding-metrics-deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if and (.Values.createRbac) (.Values.capabilities.metrics) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/komodor-agent/templates/clusterrolebinding-node-enricher.yaml
+++ b/charts/komodor-agent/templates/clusterrolebinding-node-enricher.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if .Values.createRbac -}}
 {{- if .Values.capabilities.nodeEnricher }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/komodor-agent/templates/configmap.yaml
+++ b/charts/komodor-agent/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- include "migrateHelmValues" . -}}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/komodor-agent/templates/configmap.yaml
+++ b/charts/komodor-agent/templates/configmap.yaml
@@ -46,6 +46,8 @@ data:
       resyncInterval: {{ .Values.capabilities.klaudiaIntegrationSync.resyncInterval | quote }}
       httpTimeout: {{ .Values.capabilities.klaudiaIntegrationSync.httpTimeout | quote }}
       serverFetchInterval: {{ .Values.capabilities.klaudiaIntegrationSync.serverFetchInterval | quote }}
+    resourceInfo:
+      enabled: {{ .Values.capabilities.resourceInfo.enabled }}
     resync:
       period: "0"
 

--- a/charts/komodor-agent/templates/crd-komodormcpintegration.yaml
+++ b/charts/komodor-agent/templates/crd-komodormcpintegration.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if ((.Values.capabilities).klaudiaIntegrationSync).enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/komodor-agent/templates/crd-komodorskill.yaml
+++ b/charts/komodor-agent/templates/crd-komodorskill.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if ((.Values.capabilities).klaudiaIntegrationSync).enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/komodor-agent/templates/daemonset.yaml
+++ b/charts/komodor-agent/templates/daemonset.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if or (ne .Values.capabilities.metrics false) (and .Values.capabilities.telemetry.enabled .Values.capabilities.telemetry.deployOtelCollector) }}
 apiVersion: apps/v1
 kind: DaemonSet

--- a/charts/komodor-agent/templates/daemonset_gpu.yaml
+++ b/charts/komodor-agent/templates/daemonset_gpu.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if .Values.components.gpuAccess.enabled }}
 apiVersion: apps/v1
 kind: DaemonSet

--- a/charts/komodor-agent/templates/daemonset_windows.yaml
+++ b/charts/komodor-agent/templates/daemonset_windows.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if and (ne .Values.capabilities.metrics false) (ne (((.Values.components).komodorDaemonWindows).enabled) false) }}
 apiVersion: apps/v1
 kind: DaemonSet

--- a/charts/komodor-agent/templates/deployment.yaml
+++ b/charts/komodor-agent/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/komodor-agent/templates/deployment_metrics.yaml
+++ b/charts/komodor-agent/templates/deployment_metrics.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/komodor-agent/templates/kubectl-proxy/deployment.yaml
+++ b/charts/komodor-agent/templates/kubectl-proxy/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if .Values.capabilities.kubectlProxy.enabled }}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/komodor-agent/templates/kubectl-proxy/init-script-configmap.yaml
+++ b/charts/komodor-agent/templates/kubectl-proxy/init-script-configmap.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if .Values.capabilities.kubectlProxy.enabled }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/komodor-agent/templates/kubectl-proxy/proxy-configmap.yaml
+++ b/charts/komodor-agent/templates/kubectl-proxy/proxy-configmap.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if .Values.capabilities.kubectlProxy.enabled }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/komodor-agent/templates/kubectl-proxy/service.yaml
+++ b/charts/komodor-agent/templates/kubectl-proxy/service.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if .Values.capabilities.kubectlProxy.enabled }}
 apiVersion: v1
 kind: Service

--- a/charts/komodor-agent/templates/opentelemetry/configmap.yaml
+++ b/charts/komodor-agent/templates/opentelemetry/configmap.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{/*
 DEPRECATED: This static ConfigMap is only used as a fallback when otelInit is disabled
 (components.komodorDaemon.opentelemetry.otelInit.enabled=false).

--- a/charts/komodor-agent/templates/opentelemetry/service.yaml
+++ b/charts/komodor-agent/templates/opentelemetry/service.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if and .Values.capabilities.telemetry.enabled .Values.capabilities.telemetry.deployOtelCollector }}
 apiVersion: v1
 kind: Service

--- a/charts/komodor-agent/templates/priorityclasses.yaml
+++ b/charts/komodor-agent/templates/priorityclasses.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if not .Values.components.komodorDaemon.priorityClassName }}
 ---
 apiVersion: scheduling.k8s.io/v1

--- a/charts/komodor-agent/templates/resourcequota.yaml
+++ b/charts/komodor-agent/templates/resourcequota.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 apiVersion: v1
 kind: ResourceQuota
 metadata:

--- a/charts/komodor-agent/templates/role-klaudia-integration-sync.yaml
+++ b/charts/komodor-agent/templates/role-klaudia-integration-sync.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if and .Values.createRbac (((.Values.capabilities).klaudiaIntegrationSync).enabled) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/komodor-agent/templates/secret-credentials.yaml
+++ b/charts/komodor-agent/templates/secret-credentials.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if not .Values.apiKeySecret }}
 apiVersion: v1
 kind: Secret

--- a/charts/komodor-agent/templates/secret-public-api-key.yaml
+++ b/charts/komodor-agent/templates/secret-public-api-key.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if and ((.Values.capabilities).klaudiaIntegrationSync).enabled (not .Values.publicApiKeySecret) }}
 apiVersion: v1
 kind: Secret

--- a/charts/komodor-agent/templates/serviceaccount.yaml
+++ b/charts/komodor-agent/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/komodor-agent/templates/validations.yaml
+++ b/charts/komodor-agent/templates/validations.yaml
@@ -1,7 +1,14 @@
+{{- include "applyProfile" . -}}
 {{- /*
 This file contains validations that run before rendering any templates.
 It doesn't produce any Kubernetes resources - it only validates input values.
 */ -}}
+
+{{- /* Validate profile value. applyProfile above ignores anything it does not recognise, so an unknown value fails here rather than silently doing nothing. */ -}}
+{{- $profile := .Values.profile | default "" -}}
+{{- if not (has $profile (list "" "cost")) }}
+  {{- fail (printf "profile must be one of \"\" (default) or \"cost\", got %q" $profile) }}
+{{- end }}
 
 {{- /* Validate site value */ -}}
 {{- if not (or (eq .Values.site "eu") (eq .Values.site "us")) }}

--- a/charts/komodor-agent/templates/validations.yaml
+++ b/charts/komodor-agent/templates/validations.yaml
@@ -4,12 +4,6 @@ This file contains validations that run before rendering any templates.
 It doesn't produce any Kubernetes resources - it only validates input values.
 */ -}}
 
-{{- /* Validate profile value. applyProfile above ignores anything it does not recognise, so an unknown value fails here rather than silently doing nothing. */ -}}
-{{- $profile := .Values.profile | default "" -}}
-{{- if not (has $profile (list "" "cost")) }}
-  {{- fail (printf "profile must be one of \"\" (default) or \"cost\", got %q" $profile) }}
-{{- end }}
-
 {{- /* Validate site value */ -}}
 {{- if not (or (eq .Values.site "eu") (eq .Values.site "us")) }}
   {{- fail "site is required and must be either 'eu' or 'us'" }}

--- a/charts/komodor-agent/templates/watcher/service.yaml
+++ b/charts/komodor-agent/templates/watcher/service.yaml
@@ -1,3 +1,4 @@
+{{- include "applyProfile" . -}}
 {{- if .Values.capabilities.telemetry.enabled }}
 apiVersion: v1
 kind: Service

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -108,6 +108,11 @@ capabilities:
   cost:
     # capabilities.cost.hpa -- (bool) Grant the k8s-watcher patch/update on HorizontalPodAutoscalers and KEDA ScaledObjects/ScaledJobs, independently of `capabilities.actions`. Required for HPA right-sizing when `actions=false`.
     hpa: true
+  # capabilities.resourceInfo -- Configure the agent resource-info collection subsystem
+  # @default -- See sub-values
+  resourceInfo:
+    # capabilities.resourceInfo.enabled -- (bool) Enable the in-watcher resource-info collector. Rendered into the agent ConfigMap as a default, so a remote configuration push still overrides it.
+    enabled: false
   # capabilities.helm -- Enable helm capabilities by the komodor agent
   helm:
     # capabilities.helm.enabled -- (bool) Enable helm capabilities by the komodor agent

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -117,7 +117,7 @@ capabilities:
   # capabilities.resourceInfo -- Configure the agent resource-info collection subsystem
   # @default -- See sub-values
   resourceInfo:
-    # capabilities.resourceInfo.enabled -- (bool) Enable the in-watcher resource-info collector. Rendered into the agent ConfigMap as a default, so a remote configuration push still overrides it.
+    # capabilities.resourceInfo.enabled -- (bool) Enable the in-watcher resource-info collector.
     enabled: false
   # capabilities.helm -- Enable helm capabilities by the komodor agent
   helm:

--- a/charts/komodor-agent/values.yaml
+++ b/charts/komodor-agent/values.yaml
@@ -21,6 +21,12 @@ clusterName:
 # createRbac -- Creates the necessary RBAC resources for the agent - use with caution!
 createRbac: true
 
+# profile -- (string) Install a preset that turns off the capabilities the preset does not need.
+# Allowed values: `""` (default, nothing is changed) and `cost` (a cost-only agent).
+# Values a profile writes take precedence over `--set`, so use `--set profile=cost` to shrink an
+# install and leave the individual keys alone unless you are turning something further off.
+profile: ""
+
 # global -- Global defaults applied across the chart.
 # @default -- See sub-values
 global:


### PR DESCRIPTION
Adds `--set profile=cost` to the komodor-agent chart: an install preset for a cost-only agent.

Stacked on #644 (HC-1). That has to land first — without it the cost profile cannot be installed at all, because turning off every kind in an apiGroup makes a ClusterRole rule render `resources: null` and the API server rejects it.

Closes two sub-issues of komodorio/planning#192, one commit each so any of them can be reverted alone.

| Commit | Issue | What |
| --- | --- | --- |
| `192a530` | planning#241 | add `capabilities.resourceInfo.enabled` |
| `e5da8cd` | planning#231 | the cost profile |
| `c011109` | planning#231 | reject an unrecognised profile instead of ignoring it |

One extra commit, `caa33b7`, is not part of any sub-issue: the nginx build step diffs against `origin/$BASE_BRANCH`, but Buildkite clones `--depth 1` (which implies `--single-branch`), so `git fetch origin <branch>` writes `FETCH_HEAD` and no `origin/<branch>` ref. The diff then fails with "unknown revision" on **any PR whose base is not the default branch** — every stacked PR. A master-based PR passes only because `origin/master` already exists from the clone. Fetching into the tracking ref explicitly fixes it. This is the first stacked PR to hit it; #644 is green on the same code.

## What the profile does

```bash
helm upgrade --install komodor-agent komodorio/komodor-agent \
  --set apiKey=<KEY> --set clusterName=<NAME> \
  --set profile=cost
```

|  | default | `profile=cost` |
| --- | --- | --- |
| grants on the agent ServiceAccount | 385 | **135** |
| `*/*` wildcard rules | 3 | **0** |
| distinct resource types granted | 72 | **25** |
| rendered objects | 31 | 26 |

The admission controller keeps its own `*/*` get rule on its own ServiceAccount — it exists for the cost flows and is out of scope for this epic.

Kept: metrics collection, the admission controller, HPA and KEDA right-sizing, and read access to the kinds the cost flows consume (node, namespace, pod, deployment, statefulSet, daemonSet, job, cronjob, metrics, rollout).

Turned off: actions, crActions, helm, RBAC management, temp tokens, event creation, pod logs, the node enricher, resource-info, agent telemetry and the OpenTelemetry collector, the WebSocket tunnel and kube-apiserver tunneling, the kubectl proxy, the Klaudia integration sync, the Windows daemonset, and the 39 resource kinds no cost flow reads.

Both renders were accepted by a real API server — `kubectl apply --dry-run=server` against kind, 31 objects at defaults and 26 under the profile, no errors.

## Why a value and not a `values-cost.yaml` file

`helm install -f values-cost.yaml` cannot reach a file inside a chart pulled from the helm repo. `.helmignore` has no `values-*` pattern so the file *is* packaged into the `.tgz`, but a bare relative path passed to `-f` resolves against the operator's own working directory, not the chart. The alternatives — a raw GitHub URL, or telling customers to copy-paste the file — carry hosting, chart-version-pinning and air-gap problems.

## Why this is not the profile design that was rejected before

A `profile:` mechanism was prototyped and rejected earlier. The reason still stands, but it applies to that implementation and not to the idea: that prototype **nulled** profile-controlled defaults so "unset" could be told apart from "explicitly false".

`installed-values.yaml` in the agent ConfigMap is a verbatim `toYaml .Values`, it is shipped to the backend at identify, and the backend type-asserts on it. `lookupInstalledValuesActions` returns `(false, false)` when `capabilities.actions` is missing or not a bool, and `AllowAgentActions` then falls through to `return true` — permitting all 23 mutating action types. A null `capabilities.admissionController.enabled` silently disables right-sizing the same way.

Nulling is not required. This helper **sets concrete values and never deletes a key**, so neither can happen. There is a test asserting `installed-values.yaml` contains no null anywhere under `capabilities` or `allowedResources`, in both profile states. Every other backend consumer was checked and behaves correctly on a present-`false`: kubectl-proxy, the RBAC reconciler's cluster filter, and komodor-cost's admission-controller check all distinguish missing from false, and the telegraf/admission remote-config readers only look at image tags.

The chart already does exactly this in production: `migrateHelmValues` rewrites `capabilities.helm` from a bool into a map with sprig `set`, and that rewrite reaches the backend payload.

## The Argo kinds stay on, and that is not an oversight

`resources-api` asks every cluster for `rollouts.argoproj.io`, `workflows.argoproj.io` and `cronworkflows.argoproj.io` whenever the matching CRD is installed — `crdBackedKinds` in `komodor_service/crd_support.go`, appended into `allKinds` in the reconciler.

An earlier version of this profile turned all of those off. That drops the `argoproj.io` RBAC, and with `allowReadAll: false` there is no catch-all left, so the agent's list returns **forbidden**. `parsers.go` swallows only the exact string `"no supported kubernetes resource found"`, which the agent produces solely when a GVR cannot be resolved — i.e. when the CRD is absent. A 403 is a different error, `GetParallelResultsFor` aborts the batch on it, and **komodor_service reconciliation stops entirely for that cluster**: nothing is ever marked deleted.

So `rollout`, `argoWorkflows.workflows` and `argoWorkflows.cronWorkflows` stay at their chart default. `common.ROLLOUT` is also in `RightsizableServiceKinds`, so turning it off contradicted the profile's own purpose. `workflowTemplates` and `clusterWorkflowTemplates` are gated separately in the ClusterRole and nothing requests them, so those two do come off. This costs 26 grants and is covered by a test that asserts the rendered ClusterRole — not just the config key.

Worth a reviewer's eye: the `allowedResources.rollout` guard also carries a `patch` verb, so keeping rollout on brings one mutating grant back. The agent will not use it under `capabilities.actions: false`. Splitting that verb out would change the rule for every existing install, so it is not in this PR.

## Two things worth a reviewer's attention

**1. A profile takes precedence over `--set`.** Values written during rendering win, so `--set profile=cost --set capabilities.kubectlProxy.enabled=true` leaves the proxy off. This is the one behaviour that differs from passing an equivalent values file, and it is why the profile only ever turns capabilities *off*: everything the cost flows need is left at its chart default, so an operator can still shrink the install further (`--set profile=cost --set capabilities.metrics=false` works), and `allowedResources.customReadAPIGroups` is left alone so CRD groups can be added alongside the profile.

**2. Every rendered template runs the helper first, and that is deliberate over-application.** Helm sorts templates deepest-path-first then reverse-alphabetically, so which file observes the profile first is an accident of directory naming. A probe template under `templates/zz-later/` reads `actions: "true"` and `memory: "8Gi"` in the **same render** where `configmap.yaml` already emits `allowReadingPodLogs: false`. Today the chart is correct only because `templates/watcher/service.yaml` happens to sort first and carries the include.

An earlier version of this PR put the include only in the 22 templates that read a profiled key, policed by a regex. That regex misses `{{- $caps := .Values.capabilities }}`, `index .Values...` and `toYaml .Values`, and any new subdirectory sorting after `watcher/` reopens the hole. So the include now goes in **all 41 rendered templates** and render order stops mattering at all.

Partials are excluded because helm never renders a file whose basename starts with `_` — which also means the existing `{{- include "migrateHelmValues" . -}}` at the top of `templates/watcher/_containers.tpl` is dead code (it only appears to work because `deployment.yaml` includes `configmap.yaml` for its checksum first). A test keeps the profile helper from growing the same dead wiring.

`values_profile_test.py` enforces both halves: every rendered template includes the helper before any other action, and no partial carries a top-level include. Dropping a probe template into `templates/zz-later/` without the include fails the suite; adding the include makes it pass and the probe then reads `actions: "false"`. Moving any include to the bottom of its file fails the suite.

## `capabilities.resourceInfo.enabled` (planning#241)

Written into the agent ConfigMap, not as a container env var. The ConfigMap is the agent's config file and the agent merges backend remote config at that same layer, so this stays a **default that Komodor can still override remotely**. An env var would beat remote config and would turn resource-info off under customers who had it enabled remotely.

## Watcher sizing is deliberately NOT in the profile (planning#243)

An earlier revision of this PR had the profile set the watcher memory limit to 2Gi. It is out again, and #243 is not closed by this PR.

The reasoning behind a lower limit still holds: the agent reads its own container memory limit and self-throttles at 20% remaining, so at 8Gi it does not start protecting itself until it is using 6.4Gi, by which point the node has OOM-killed it. 8Gi is sized for ~50 informers and a cost-profile watcher runs far fewer.

But a profile is the wrong place to enforce it. Values the profile writes take precedence over `--set` — correct for capability switches, which are the posture the profile exists to hold, and wrong for resource sizing, which belongs to the operator. The chart ships `utilities/memory-planning` whose entire output is a value to put here, so a customer must be able to set it.

The profile now writes no requests or limits at all, and a test asserts the watcher and supervisor resources are byte-identical with and without it. The recommendation moved into `README.md.gotmpl` next to the memory-planning section, as guidance:

```bash
--set profile=cost --set components.komodorAgent.watcher.resources.limits.memory=2Gi
```

## Known limitations of the profile

Both are documented in the README, not just here.

- Right-sizing keeps applying automatically through the admission controller, but `capabilities.actions: false` means **applying a recommendation by hand from the UI, or through self-healing, is refused** — `ActionTypeUpdateContainersResources` is one of the gated mutating action types. `capabilities.actions` is a single switch covering all 23, so there is no way to allow only that one.
- The agent still advertises live resource browsing for every kind: `enableAgentTaskExecution` is hardcoded `true` in the ConfigMap and the web gates `resourceList` / `liveDataView` on it alone. **Browsing a kind the profile no longer grants read on returns a permission error** rather than "not supported". Making that profile-controlled is a chart change beyond this PR.

Kinds the profile stops watching are not garbage-collected on the backend — the only soft-delete reconcilers are komodor_service, pod, node, namespace and workflow, and every source kind they read stays on. Existing rows for un-watched kinds persist and go stale rather than disappearing.

## Backward compatibility

With `profile` unset the rendered output is unchanged except for the two new `resourceInfo` lines, the new `profile` key in `installed-values.yaml`, and the resulting `checksum/config` annotation — so existing installs get one watcher restart on upgrade and nothing else. Verified by rendering before and after across chart defaults, `allowReadAll=false`, `examples/hardened-values.yaml`, `--set createRbac=false` and every values file in `.buildkite/pipeline_scripts/`, excluding the admission-controller cert lines which are regenerated on every render.

Per planning#231, MONO-2 (#233) or OPS-1 (#232) should land before this profile is applied to an **existing** cluster. New clusters have no rows to soft-delete; existing ones do.

## Known residue

Three read grants survive the cost profile because their ClusterRole rules are not keyed on `allowedResources` at all: `rbac.authorization.k8s.io/clusterroles`, `apps/replicasets` and `apiextensions.k8s.io/customresourcedefinitions` (the last one is deliberate — it is how the agent probes which CRDs exist). The agent stops *watching* all three, since collection follows the ConfigMap, but the permission remains. Fixing that means changing rules that render for everyone today, so it is not in this PR.

## Tests

`.buildkite/tests/values_profile_test.py`, 113 cases, `helm template` only, no cluster. 275 pass across every cluster-free suite in `.buildkite/tests`. `make -C charts/komodor-agent validate-readme` passes.

The suite was mutation-tested rather than trusted. Each of these makes it fail: dropping or inverting any `set` line, dropping a key from a resource list, putting `rollout` back in the off list, removing an include from any of the 22 templates, **moving an include to the bottom of its file**, adding a template that sorts after `watcher/` without the include, deleting either `kindIs "map"` guard, deleting the `migrateHelmValues` call, and deleting the `resourceInfo` block from the ConfigMap. Assertions against keys whose chart default already matches the profile are driven from a render that sets every profiled key `true` first, so none of them can pass vacuously.

One helm-4 note: `--set capabilities.helm=true` no longer replaces the declared map, so the legacy bool migration path can only be exercised on helm 3.
