### PR TITLE
CU-86cbem137 - fix(komodor-agent): gate the metrics Deployment and fix the admission-controller SA validation

### DIFF
--- a/.buildkite/tests/validations_test.py
+++ b/.buildkite/tests/validations_test.py
@@ -114,7 +114,7 @@ class TestAdmissionControllerServiceAccountValidation:
     def test_missing_admission_controller_sa_name_when_not_creating(self):
         """Test that admission controller serviceAccount.name is required when create is false"""
         settings = f"--set apiKey={API_KEY} --set clusterName={CLUSTER_NAME} --set site=us " \
-                   f"--set components.admissionController.enabled=true " \
+                   f"--set capabilities.admissionController.enabled=true " \
                    f"--set components.admissionController.serviceAccount.create=false"
         output, exit_code = helm_agent_template(settings=settings)
 
@@ -126,7 +126,7 @@ class TestAdmissionControllerServiceAccountValidation:
     def test_admission_controller_sa_name_provided_when_not_creating(self):
         """Test that providing admission controller serviceAccount.name when create is false works"""
         settings = f"--set apiKey={API_KEY} --set clusterName={CLUSTER_NAME} --set site=us " \
-                   f"--set components.admissionController.enabled=true " \
+                   f"--set capabilities.admissionController.enabled=true " \
                    f"--set components.admissionController.serviceAccount.create=false " \
                    f"--set components.admissionController.serviceAccount.name=my-ac-sa"
         output, exit_code = helm_agent_template(settings=settings)
@@ -137,7 +137,7 @@ class TestAdmissionControllerServiceAccountValidation:
     def test_admission_controller_disabled_skips_validation(self):
         """Test that admission controller SA validation is skipped when disabled"""
         settings = f"--set apiKey={API_KEY} --set clusterName={CLUSTER_NAME} --set site=us " \
-                   f"--set components.admissionController.enabled=false " \
+                   f"--set capabilities.admissionController.enabled=false " \
                    f"--set components.admissionController.serviceAccount.create=false"
         output, exit_code = helm_agent_template(settings=settings)
 

--- a/.buildkite/tests/values_components_test.py
+++ b/.buildkite/tests/values_components_test.py
@@ -1,8 +1,9 @@
 import pytest
+import yaml
 from pathlib import Path
 
 from config import RELEASE_NAME
-from helpers.helm_helper import get_yaml_from_helm_template
+from helpers.helm_helper import get_yaml_from_helm_template, helm_agent_template
 from helpers.utils import get_filename_as_cluster_name
 
 CLUSTER_NAME = get_filename_as_cluster_name(__file__)
@@ -747,3 +748,32 @@ def test_override_update_strategy(component_name, deployment_name_suffix, strate
                                                       f"spec.{strategy_key}", values_file=values_file)
 
     assert deployment_strategy["type"] == "RollingUpdate", f"Expected rollingUpdate in deployment tolerations {deployment_strategy}"
+
+
+METRICS_OBJECTS = [
+    ("Deployment", f"{RELEASE_NAME}-komodor-agent-metrics"),
+    ("PriorityClass", f"{RELEASE_NAME}-metrics-high-priority"),
+]
+
+
+def rendered_objects(additional_settings=""):
+    templates, exit_code = helm_agent_template(additional_settings=additional_settings)
+    assert exit_code == 0, f"helm template failed, output: {templates}"
+    return {(doc.get("kind"), doc.get("metadata", {}).get("name")) for doc in yaml.safe_load_all(templates) if doc}
+
+
+@pytest.mark.parametrize("kind, name", METRICS_OBJECTS)
+def test_metrics_objects_render_by_default(kind, name):
+    assert (kind, name) in rendered_objects(), f"{kind} {name} missing from a default install"
+
+
+@pytest.mark.parametrize("kind, name", METRICS_OBJECTS)
+def test_metrics_objects_are_dropped_when_metrics_is_off(kind, name):
+    rendered = rendered_objects("--set capabilities.metrics=false")
+    assert (kind, name) not in rendered, f"{kind} {name} still rendered with capabilities.metrics=false"
+
+
+@pytest.mark.parametrize("kind, name", METRICS_OBJECTS)
+def test_metrics_objects_survive_create_rbac_false(kind, name):
+    # createRbac only gates the ClusterRole. Guards against re-gating the workload on the wrong key.
+    assert (kind, name) in rendered_objects("--set createRbac=false"), f"{kind} {name} dropped by createRbac=false"

--- a/charts/komodor-agent/templates/deployment_metrics.yaml
+++ b/charts/komodor-agent/templates/deployment_metrics.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.capabilities.metrics }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -48,3 +49,4 @@ spec:
       initContainers:
         {{- include "ca-init.container" .                 | nindent 8 }}
         {{- include "metrics.deployment.init.container" . | nindent 8 }}
+{{- end }}

--- a/charts/komodor-agent/templates/priorityclasses.yaml
+++ b/charts/komodor-agent/templates/priorityclasses.yaml
@@ -19,7 +19,7 @@ value: {{ .Values.components.komodorAgent.PriorityClassValue }}
 globalDefault: false
 description: "This priority class should be used for Komodor agent pods only."
 {{- end }}
-{{- if not .Values.components.komodorMetrics.priorityClassName }}
+{{- if and .Values.capabilities.metrics (not .Values.components.komodorMetrics.priorityClassName) }}
 ---
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass

--- a/charts/komodor-agent/templates/validations.yaml
+++ b/charts/komodor-agent/templates/validations.yaml
@@ -37,7 +37,7 @@ It doesn't produce any Kubernetes resources - it only validates input values.
 {{- end }}
 
 {{- /* Validate admission controller serviceAccount configuration */ -}}
-{{- if .Values.components.admissionController.enabled }}
+{{- if .Values.capabilities.admissionController.enabled }}
   {{- if not .Values.components.admissionController.serviceAccount.create }}
     {{- if not .Values.components.admissionController.serviceAccount.name }}
       {{- fail "you must provide a components.admissionController.serviceAccount.name when components.admissionController.serviceAccount.create is not set to true" }}


### PR DESCRIPTION
Two small "the chart is wrong" fixes, one commit each so either can be reverted alone.

Closes komodorio/planning#240 and komodorio/planning#231's sibling komodorio/planning#242.

| Commit | Issue | What |
| --- | --- | --- |
| `8058b577` | planning#240 | gate the metrics Deployment on `capabilities.metrics` |
| `be20f931` | planning#242 | validate the admission-controller ServiceAccount on the key that exists |

## Gate the metrics Deployment

The metrics ClusterRoles and the metrics DaemonSet are gated on `capabilities.metrics`. The Deployment was gated on nothing, so turning metrics off left a telegraf pod running against a ServiceAccount with no metrics ClusterRole. It 403s on every scrape, forever, while holding a high-priority class and its resource reservation. A dead pod that looks alive.

The metrics PriorityClass follows it. `deployment_metrics.yaml` is its only consumer, so with the Deployment gone it has nothing left to schedule.

Rendered:

| | Deployment | PriorityClass |
| --- | --- | --- |
| default | yes | yes |
| `capabilities.metrics=false` | gone | gone |
| `createRbac=false` | yes | yes |
| `metrics=false` + otel collector on | gone | gone |

The last row is the one worth checking. The DaemonSet still renders for the collector, and it uses `daemon-high-priority`, not the metrics class, so that install is unaffected.

`createRbac` keeps gating only the ClusterRole, never the workload.

## Fix the admission-controller ServiceAccount validation

The guard read `.Values.components.admissionController.enabled`. That key has no leaf in `values.yaml`, so the condition evaluated nil and the validation inside never ran in a real install: `serviceAccount.create=false` with no name rendered cleanly instead of failing. Born broken, the key never existed.

It now reads `.Values.capabilities.admissionController.enabled`, which does exist and defaults to true. Same shape as `priorityclasses.yaml`.

**Behaviour change, worth a release note.** The validation now runs on default installs. Anyone setting `components.admissionController.serviceAccount.create=false` without a `name` will start failing `helm upgrade`. That is the correct behaviour, but it is a break. Worth checking whether any install is actually in that state before this merges.

### The tests were masking it

`validations_test.py` passed `--set components.admissionController.enabled=true/false`. Helm happily invents a key that does not exist, so the guard fired and the tests passed against the broken condition. They now set the real key.

## Tests

Six new cases in `values_components_test.py` for the metrics gating, three existing cases in `validations_test.py` moved to the real key. Both suites are template-only, no cluster needed.

```
cd .buildkite/tests && pytest validations_test.py values_components_test.py
161 passed
```

Each fix was confirmed to fail without it: stash the template, the new tests go red.

## Relationship to #645

Independent, not stacked. Either can merge first.

One thing to know: #645 prepends `{{- include "applyProfile" . -}}` to every template, and both branches insert a line above `apiVersion:` in `deployment_metrics.yaml`. Whoever merges second gets a one-line conflict there. Keep both lines, include first. `priorityclasses.yaml` and `validations.yaml` merge clean.

