### PR TITLE
fix(komodor-agent): mount podinfo so the agent can read its own memory limit

### DIFF
--- a/.buildkite/tests/values_components_test.py
+++ b/.buildkite/tests/values_components_test.py
@@ -777,3 +777,44 @@ def test_metrics_objects_are_dropped_when_metrics_is_off(kind, name):
 def test_metrics_objects_survive_create_rbac_false(kind, name):
     # createRbac only gates the ClusterRole. Guards against re-gating the workload on the wrong key.
     assert (kind, name) in rendered_objects("--set createRbac=false"), f"{kind} {name} dropped by createRbac=false"
+
+
+# The agent reads its own container memory limit from /etc/podinfo/mem_limit and skips the
+# 20%-remaining safety check entirely when it cannot: podinfo.LoadMemoryLimitSafely returns
+# Limit -1, and periodic_memory_stats.Run returns early on -1 without calling
+# checkMemoryThreshold. The mount used to be gated on capabilities.events.enableMemLimitChecks,
+# a key with no entry in values.yaml, so Helm's nil-safe lookup made the guard false forever:
+# the volume rendered on every install and the mount on none. Nothing asserted it.
+def _watcher_pod_spec(output):
+    for doc in yaml.safe_load_all(output):
+        if doc and doc.get("kind") == "Deployment" and doc["metadata"]["name"].endswith("komodor-agent"):
+            return doc["spec"]["template"]["spec"]
+    raise AssertionError("no watcher Deployment was rendered, so this test asserted nothing")
+
+
+@pytest.mark.parametrize("extra", ["", "--set profile=cost"])
+def test_that_the_watcher_mounts_podinfo(extra):
+    output, exit_code = helm_agent_template(additional_settings=extra)
+    assert exit_code == 0, f"helm template failed, output: {output}"
+    spec = _watcher_pod_spec(output)
+
+    assert "podinfo" in {v["name"] for v in spec["volumes"]}, "the podinfo volume is missing"
+    watcher = next(c for c in spec["containers"] if c["name"] == "k8s-watcher")
+    mounts = {m["mountPath"] for m in watcher.get("volumeMounts", [])}
+    assert "/etc/podinfo" in mounts, (
+        "the watcher does not mount podinfo, so it cannot read its own memory limit and the "
+        "memory safety check will never run"
+    )
+
+
+def test_that_the_podinfo_volume_reports_the_watcher_container_limit():
+    """A downwardAPI resourceFieldRef naming the wrong container or resource renders perfectly
+    well and yields nothing useful, so assert what it points at rather than that it exists."""
+    output, exit_code = helm_agent_template()
+    assert exit_code == 0, f"helm template failed, output: {output}"
+    volume = next(v for v in _watcher_pod_spec(output)["volumes"] if v["name"] == "podinfo")
+
+    item = volume["downwardAPI"]["items"][0]
+    assert item["path"] == "mem_limit"
+    assert item["resourceFieldRef"]["resource"] == "limits.memory"
+    assert item["resourceFieldRef"]["containerName"] == "k8s-watcher"

--- a/charts/komodor-agent/templates/watcher/_containers.tpl
+++ b/charts/komodor-agent/templates/watcher/_containers.tpl
@@ -11,10 +11,13 @@
     mountPath: /etc/komodor
   - name: tmp
     mountPath: /tmp
-  {{- if ((.Values.capabilities).events).enableMemLimitChecks }}
+  {{- /* Unconditional, matching the volume in _volumes.tpl. This was gated on
+         capabilities.events.enableMemLimitChecks, a key with no entry in values.yaml, so the
+         guard was always nil and the mount rendered on no install at all. The agent reads
+         /etc/podinfo/mem_limit to learn its own container memory limit; without it the limit
+         stays -1 and the 20%-remaining safety check is skipped outright. */}}
   - name: podinfo
     mountPath: /etc/podinfo
-  {{- end }}
   {{- if (.Values.capabilities).helm.enabled }}
   - name: helm-data
     mountPath: /opt/watcher/helm


### PR DESCRIPTION
Closes komodorio/planning#259. Independent of the cost-profile chain — branched off master, touches neither `_profile.tpl` nor anything #648 changes.

## The bug

`charts/komodor-agent/templates/watcher/_containers.tpl` gated the podinfo mount:

```gotemplate
{{- if ((.Values.capabilities).events).enableMemLimitChecks }}
- name: podinfo
  mountPath: /etc/podinfo
{{- end }}
```

**`enableMemLimitChecks` has no entry in `charts/komodor-agent/values.yaml`.** The parenthesised lookups are nil-safe, so the expression evaluated to nil rather than erroring, and the mount rendered on **no install at all** — default, hardened or cost profile:

```
$ helm template ... | grep -c "/etc/podinfo"
0
```

The volume in `_volumes.tpl` is unconditional and correct, with a valid `resourceFieldRef` on `limits.memory`. So every agent pod has carried a podinfo volume that nothing mounted. Confirmed on a live cluster: `volumes` contains `podinfo`; the `k8s-watcher` container's `volumeMounts` are `/etc/komodor`, `/tmp`, `/.kube` and the SA token.

Same failure mode as komodorio/planning#242 (HC-5) — a condition on a key with no leaf, which reads as "disabled" forever instead of failing loudly.

## What it broke

The agent's memory safety check, completely. `internal/utils/podinfo/podinfo.go:102-118` returns `Limit: -1` when the file is missing, and logs it once per boot:

```json
{"error":"open /etc/podinfo/mem_limit: no such file or directory",
 "msg":"failed to load memory limit for podinfo, using default","level":"warning"}
```

That value goes straight into the watcher's throttle at `cmd/watcher/watcher.go:168`:

```go
system.StartMemoryStatusPeriodicRunner(podinfo.Get().Memory.Limit, memoryThresholdNotificationChan, &utils.MemoryReader{})
```

and `internal/system/periodic_memory_stats.go:78-80` bails on that value before doing anything useful:

```go
if m.limit == -1 {
    return nil
}
if err := m.checkMemoryThreshold(buffer, notificationChan); err != nil {
```

So `checkMemoryThreshold` — the 20%-remaining check — has never executed on any install. The second gate, `EnableMemoryThresholdSafetyCheck`, defaults to **true**, so the missing mount was the only thing stopping it; this change is sufficient to switch the mechanism on.

## Why unconditional rather than adding the values key

The volume is already unconditional, so the mount matching it is the smaller and more honest shape. `capabilities.events` is also the wrong home for a memory-limit toggle, which is plausibly why nobody noticed the key was never added. If a toggle is wanted later it should go somewhere that makes sense and come with a test.

## Blast radius

Every install gains one volumeMount. Render diff against master, both at chart defaults and under `profile=cost`, is exactly:

```
>           - name: podinfo
>             mountPath: /etc/podinfo
```

Nothing else moves. The downwardAPI falls back to node allocatable when a container has no memory limit, so this is safe for installs that set no limits.

**This turns on a safety mechanism that has never run**, so expect the watcher to start logging `bufferLeft` and, on a genuinely constrained agent, to begin reporting the memory-threshold notification it was always supposed to. That is the intent, but it is a behaviour change rather than a pure no-op.

## Tests

294 pass. Three new, in `values_components_test.py`:

- the watcher mounts `/etc/podinfo`, at chart defaults **and** under `profile=cost`
- the podinfo volume's `resourceFieldRef` names `limits.memory` on the `k8s-watcher` container specifically

Both mutation-checked. Restoring the dead guard fails the first; pointing `containerName` at `supervisor` fails the second — a wrong container renders perfectly well and yields nothing useful, which is why it is asserted rather than assumed.

## Follow-on

komodorio/planning#243 (HC-6) argues for lowering the watcher's 8Gi limit on the grounds that the agent does not protect itself until 6.4Gi, by which point the node has OOM-killed it. That reasoning assumes this mechanism runs. It has not, so #243's measurements should be re-taken after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeSiKPyLrDyKWabgQMDmsS
