### PR TITLE
CU-86cbfe87a - fix(komodor-agent): keep the Windows telegraf daemonset under profile=cost

### DIFF
--- a/.buildkite/tests/values_profile_test.py
+++ b/.buildkite/tests/values_profile_test.py
@@ -33,7 +33,6 @@ PROFILED_CAPABILITY_PATHS = [
     "capabilities.tunnel.kubeapiserver.enabled",
     "capabilities.kubectlProxy.enabled",
     "capabilities.klaudiaIntegrationSync.enabled",
-    "components.komodorDaemonWindows.enabled",
 ]
 
 ALLOWED_RESOURCES_OFF = [
@@ -401,7 +400,6 @@ class TestCostProfile:
 
     def test_cost_profile_drops_the_workloads_it_disables(self, cost_render, default_render):
         gone = [
-            ("DaemonSet", f"{FULLNAME}-daemon-windows"),
             ("ClusterRole", f"{FULLNAME}-node-enricher"),
             ("Service", f"{FULLNAME}-otel-collector"),
         ]
@@ -504,6 +502,23 @@ class TestCostProfile:
         assert ("Deployment", FULLNAME) in kinds
         assert ("Deployment", f"{FULLNAME}-metrics") in kinds
         assert ("Deployment", f"{FULLNAME}-admission-controller") in kinds
+
+    @pytest.mark.parametrize("name", [f"{FULLNAME}-daemon", f"{FULLNAME}-daemon-windows"])
+    def test_cost_profile_keeps_every_telegraf_daemonset(self, cost_render, name):
+        """The Windows daemonset is the only cost collection a Windows node gets."""
+        kinds = {(d["kind"], d["metadata"]["name"]) for d in cost_render}
+        assert ("DaemonSet", name) in kinds
+
+    def test_cost_profile_windows_daemonset_still_runs_telegraf(self, cost_render):
+        """A rendered DaemonSet proves nothing if the metrics container dropped out of it."""
+        daemon = next(
+            d for d in cost_render
+            if d["kind"] == "DaemonSet" and d["metadata"]["name"] == f"{FULLNAME}-daemon-windows"
+        )
+        metrics = next(
+            c for c in daemon["spec"]["template"]["spec"]["containers"] if c["name"] == "metrics"
+        )
+        assert any("telegraf" in part for part in metrics["command"])
 
     def test_cost_profile_grants_no_wildcard_or_empty_rules(self, cost_render):
         bound = {

--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -118,7 +118,7 @@ helm upgrade --install komodor-agent komodorio/komodor-agent \
 | Profile | What it does |
 | --- | --- |
 | `""` (default) | Nothing. Every value is exactly as documented below. |
-| `cost` | A read-only, cost-only agent. Keeps metrics collection, the admission controller and HPA right-sizing. Turns off actions, helm, RBAC management, pod logs, the node enricher, resource-info, agent telemetry and the OpenTelemetry collector, the WebSocket tunnel, the kubectl proxy, the Klaudia integration sync and the Windows daemonset, and narrows the agent's cluster read permissions to the resource kinds the cost flows actually read. |
+| `cost` | A read-only, cost-only agent. Keeps metrics collection, the admission controller and HPA right-sizing. Turns off actions, helm, RBAC management, pod logs, the node enricher, resource-info, agent telemetry and the OpenTelemetry collector, the WebSocket tunnel, the kubectl proxy, and the Klaudia integration sync, and narrows the agent's cluster read permissions to the resource kinds the cost flows actually read. |
 
 Two things to know before using one:
 

--- a/charts/komodor-agent/README.md.gotmpl
+++ b/charts/komodor-agent/README.md.gotmpl
@@ -117,7 +117,7 @@ helm upgrade --install komodor-agent komodorio/komodor-agent \
 | Profile | What it does |
 | --- | --- |
 | `""` (default) | Nothing. Every value is exactly as documented below. |
-| `cost` | A read-only, cost-only agent. Keeps metrics collection, the admission controller and HPA right-sizing. Turns off actions, helm, RBAC management, pod logs, the node enricher, resource-info, agent telemetry and the OpenTelemetry collector, the WebSocket tunnel, the kubectl proxy, the Klaudia integration sync and the Windows daemonset, and narrows the agent's cluster read permissions to the resource kinds the cost flows actually read. |
+| `cost` | A read-only, cost-only agent. Keeps metrics collection, the admission controller and HPA right-sizing. Turns off actions, helm, RBAC management, pod logs, the node enricher, resource-info, agent telemetry and the OpenTelemetry collector, the WebSocket tunnel, the kubectl proxy, and the Klaudia integration sync, and narrows the agent's cluster read permissions to the resource kinds the cost flows actually read. |
 
 Two things to know before using one:
 

--- a/charts/komodor-agent/templates/_profile.tpl
+++ b/charts/komodor-agent/templates/_profile.tpl
@@ -59,8 +59,6 @@ silently installing a full agent because someone typed it is the worst outcome h
 {{- $_ := set $caps.kubectlProxy "enabled" false -}}
 {{- $_ := set $caps.klaudiaIntegrationSync "enabled" false -}}
 
-{{/* components.komodorDaemonWindows stays on: it is the telegraf daemon for Windows nodes. */}}
-
 {{- $allowed := .Values.allowedResources -}}
 {{/*
 Kept on, and deliberately not pinned here: metrics — and customReadAPIGroups, which an operator

--- a/charts/komodor-agent/templates/_profile.tpl
+++ b/charts/komodor-agent/templates/_profile.tpl
@@ -59,12 +59,12 @@ silently installing a full agent because someone typed it is the worst outcome h
 {{- $_ := set $caps.kubectlProxy "enabled" false -}}
 {{- $_ := set $caps.klaudiaIntegrationSync "enabled" false -}}
 
-{{- $_ := set .Values.components.komodorDaemonWindows "enabled" false -}}
+{{/* components.komodorDaemonWindows stays on: it is the telegraf daemon for Windows nodes. */}}
 
 {{- $allowed := .Values.allowedResources -}}
 {{/*
-Kept on, and deliberately not pinned here: metrics, namespace, pod — and customReadAPIGroups,
-which an operator sets per cluster alongside the profile.
+Kept on, and deliberately not pinned here: metrics — and customReadAPIGroups, which an operator
+sets per cluster alongside the profile.
 
 node is off, and the thing that makes that safe is not obvious: three ClusterRoles bind the
 agent's single ServiceAccount, and the two metrics ones grant core nodes/pods/namespaces


### PR DESCRIPTION
The cost profile turned off the Windows daemonset. That daemonset is telegraf: the same binary and
the same telegraf.conf as the Linux one, just for Windows nodes.

```
metrics                C:/telegraf/telegraf.exe --config C:/telegraf/telegraf.conf
telegraf-init-sidecar
init container
```

There is no non-metrics container in it. So a `profile=cost` install on a mixed cluster collected
nothing from its Windows nodes, which is the one thing the profile exists to do.

It came in with the original profile PR (#645), in the same hunk as the tunnel and kubectl-proxy
lines, and was the only line in that block with no rationale next to it. It got grouped with
components a cost install does not need without anyone checking what it runs.

## The change

Stop pinning `components.komodorDaemonWindows.enabled`. Its chart default is already `true`, and an
operator on a Linux-only cluster can still set it false, which is what the key is documented for.
This follows rule 2 in the helper's own header: a profile only turns capabilities off, and anything
it depends on staying on is left at the chart default.

## Tests

`test_cost_profile_keeps_every_telegraf_daemonset` asserts both daemonsets render under
`profile=cost`. `test_cost_profile_windows_daemonset_still_runs_telegraf` asserts the metrics
container is still telegraf, since a rendered DaemonSet proves nothing if the container dropped out.
Both fail if the pinning line is put back.

`test_cost_profile_drops_the_workloads_it_disables` had the Windows daemonset in its `gone` list.
Removed, it was asserting the bug.

`values_profile_test.py` 135 passed. Ran the template and values suites locally: 307 passed. The two
failures there are `basic_test.py::test_get_deploy_event_from_resources_api`,
`values_capabilities_test.py::test_get_metrics` and
`values_base_test.py::test_use_existing_service_account`, all live-cluster tests that install into
kind and query the backend, so they need CI.

## Also in here

One stale comment in the same file. #648 added `pod` and `namespace` to the off-list but only
removed `node` from the sentence above it, so the comment claimed two kinds were kept on that the
code four lines below turns off. `values_profile_test.py` already had it right
(`ALLOWED_RESOURCES_ON = ["metrics"]`).

README says the profile turns off the Windows daemonset. Updated, in both `README.md` and
`README.md.gotmpl`.
