### PR TITLE
CU-86cbfp653 - fix(komodor-agent): grant binpacking the reads its informers need under profile=cost

### DIFF
--- a/.buildkite/tests/values_profile_test.py
+++ b/.buildkite/tests/values_profile_test.py
@@ -65,13 +65,25 @@ ALLOWED_RESOURCES_ON = ["metrics"]
 # where cluster region and the node labels the backend derives the cloud provider from come from.
 # Lose that last one and a customer's enterprise discount silently becomes zero.
 COST_RBAC_FLOOR = [
-    ("", "nodes", {"get", "list"}),
-    ("", "pods", {"get", "list"}),
+    ("", "nodes", {"get", "list", "watch"}),
+    ("", "pods", {"get", "list", "watch"}),
     ("", "namespaces", {"get", "list"}),
     ("", "nodes/stats", {"get", "list"}),
     ("", "nodes/proxy", {"get", "list"}),
     ("metrics.k8s.io", "pods", {"get", "list"}),
     ("metrics.k8s.io", "nodes", {"get", "list"}),
+    ("autoscaling", "horizontalpodautoscalers", {"get", "list"}),
+    # komodor_binpacking_state informers. list+watch or the informer never syncs and the input
+    # produces no state at all, which is what happened for the first three cost releases.
+    ("", "persistentvolumes", {"get", "list", "watch"}),
+    ("", "persistentvolumeclaims", {"get", "list", "watch"}),
+    ("policy", "poddisruptionbudgets", {"get", "list", "watch"}),
+    ("apps", "deployments", {"list", "watch"}),
+    ("apps", "replicasets", {"list", "watch"}),
+    ("apps", "statefulsets", {"list", "watch"}),
+    ("apps", "daemonsets", {"list", "watch"}),
+    ("batch", "jobs", {"list", "watch"}),
+    ("batch", "cronjobs", {"list", "watch"}),
 ]
 
 ARGO_WORKFLOWS_OFF = ["workflows", "cronWorkflows", "workflowTemplates", "clusterWorkflowTemplates"]

--- a/.buildkite/tests/values_profile_test.py
+++ b/.buildkite/tests/values_profile_test.py
@@ -33,7 +33,6 @@ PROFILED_CAPABILITY_PATHS = [
     "capabilities.tunnel.kubeapiserver.enabled",
     "capabilities.kubectlProxy.enabled",
     "capabilities.klaudiaIntegrationSync.enabled",
-    "components.komodorDaemonWindows.enabled",
 ]
 
 ALLOWED_RESOURCES_OFF = [
@@ -401,7 +400,6 @@ class TestCostProfile:
 
     def test_cost_profile_drops_the_workloads_it_disables(self, cost_render, default_render):
         gone = [
-            ("DaemonSet", f"{FULLNAME}-daemon-windows"),
             ("ClusterRole", f"{FULLNAME}-node-enricher"),
             ("Service", f"{FULLNAME}-otel-collector"),
         ]
@@ -504,6 +502,23 @@ class TestCostProfile:
         assert ("Deployment", FULLNAME) in kinds
         assert ("Deployment", f"{FULLNAME}-metrics") in kinds
         assert ("Deployment", f"{FULLNAME}-admission-controller") in kinds
+
+    @pytest.mark.parametrize("name", [f"{FULLNAME}-daemon", f"{FULLNAME}-daemon-windows"])
+    def test_cost_profile_keeps_every_telegraf_daemonset(self, cost_render, name):
+        """The Windows daemonset is the only cost collection a Windows node gets."""
+        kinds = {(d["kind"], d["metadata"]["name"]) for d in cost_render}
+        assert ("DaemonSet", name) in kinds
+
+    def test_cost_profile_windows_daemonset_still_runs_telegraf(self, cost_render):
+        """A rendered DaemonSet proves nothing if the metrics container dropped out of it."""
+        daemon = next(
+            d for d in cost_render
+            if d["kind"] == "DaemonSet" and d["metadata"]["name"] == f"{FULLNAME}-daemon-windows"
+        )
+        metrics = next(
+            c for c in daemon["spec"]["template"]["spec"]["containers"] if c["name"] == "metrics"
+        )
+        assert any("telegraf" in part for part in metrics["command"])
 
     def test_cost_profile_grants_no_wildcard_or_empty_rules(self, cost_render):
         bound = {

--- a/charts/komodor-agent/README.md
+++ b/charts/komodor-agent/README.md
@@ -118,7 +118,7 @@ helm upgrade --install komodor-agent komodorio/komodor-agent \
 | Profile | What it does |
 | --- | --- |
 | `""` (default) | Nothing. Every value is exactly as documented below. |
-| `cost` | A read-only, cost-only agent. Keeps metrics collection, the admission controller and HPA right-sizing. Turns off actions, helm, RBAC management, pod logs, the node enricher, resource-info, agent telemetry and the OpenTelemetry collector, the WebSocket tunnel, the kubectl proxy, the Klaudia integration sync and the Windows daemonset, and narrows the agent's cluster read permissions to the resource kinds the cost flows actually read. |
+| `cost` | A read-only, cost-only agent. Keeps metrics collection, the admission controller and HPA right-sizing. Turns off actions, helm, RBAC management, pod logs, the node enricher, resource-info, agent telemetry and the OpenTelemetry collector, the WebSocket tunnel, the kubectl proxy, and the Klaudia integration sync, and narrows the agent's cluster read permissions to the resource kinds the cost flows actually read. |
 
 Two things to know before using one:
 

--- a/charts/komodor-agent/README.md.gotmpl
+++ b/charts/komodor-agent/README.md.gotmpl
@@ -117,7 +117,7 @@ helm upgrade --install komodor-agent komodorio/komodor-agent \
 | Profile | What it does |
 | --- | --- |
 | `""` (default) | Nothing. Every value is exactly as documented below. |
-| `cost` | A read-only, cost-only agent. Keeps metrics collection, the admission controller and HPA right-sizing. Turns off actions, helm, RBAC management, pod logs, the node enricher, resource-info, agent telemetry and the OpenTelemetry collector, the WebSocket tunnel, the kubectl proxy, the Klaudia integration sync and the Windows daemonset, and narrows the agent's cluster read permissions to the resource kinds the cost flows actually read. |
+| `cost` | A read-only, cost-only agent. Keeps metrics collection, the admission controller and HPA right-sizing. Turns off actions, helm, RBAC management, pod logs, the node enricher, resource-info, agent telemetry and the OpenTelemetry collector, the WebSocket tunnel, the kubectl proxy, and the Klaudia integration sync, and narrows the agent's cluster read permissions to the resource kinds the cost flows actually read. |
 
 Two things to know before using one:
 

--- a/charts/komodor-agent/templates/_profile.tpl
+++ b/charts/komodor-agent/templates/_profile.tpl
@@ -59,8 +59,6 @@ silently installing a full agent because someone typed it is the worst outcome h
 {{- $_ := set $caps.kubectlProxy "enabled" false -}}
 {{- $_ := set $caps.klaudiaIntegrationSync "enabled" false -}}
 
-{{/* components.komodorDaemonWindows stays on: it is the telegraf daemon for Windows nodes. */}}
-
 {{- $allowed := .Values.allowedResources -}}
 {{/*
 Kept on, and deliberately not pinned here: metrics — and customReadAPIGroups, which an operator

--- a/charts/komodor-agent/templates/_profile.tpl
+++ b/charts/komodor-agent/templates/_profile.tpl
@@ -59,12 +59,12 @@ silently installing a full agent because someone typed it is the worst outcome h
 {{- $_ := set $caps.kubectlProxy "enabled" false -}}
 {{- $_ := set $caps.klaudiaIntegrationSync "enabled" false -}}
 
-{{- $_ := set .Values.components.komodorDaemonWindows "enabled" false -}}
+{{/* components.komodorDaemonWindows stays on: it is the telegraf daemon for Windows nodes. */}}
 
 {{- $allowed := .Values.allowedResources -}}
 {{/*
-Kept on, and deliberately not pinned here: metrics, namespace, pod — and customReadAPIGroups,
-which an operator sets per cluster alongside the profile.
+Kept on, and deliberately not pinned here: metrics — and customReadAPIGroups, which an operator
+sets per cluster alongside the profile.
 
 node is off, and the thing that makes that safe is not obvious: three ClusterRoles bind the
 agent's single ServiceAccount, and the two metrics ones grant core nodes/pods/namespaces

--- a/charts/komodor-agent/templates/clusterrole-metrics-deployment.yaml
+++ b/charts/komodor-agent/templates/clusterrole-metrics-deployment.yaml
@@ -61,4 +61,43 @@ rules:
   - pods
   verbs:
   - watch
+# komodor_binpacking_state runs informers over the cluster's schedulable state, so it needs
+# list+watch where the rules above grant only get. Same set clusterrole-admission-controller.yaml
+# already grants, minus the writes.
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - persistentvolumes
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - replicasets
+  - statefulsets
+  - daemonsets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - list
+  - watch
 {{- end -}}


### PR DESCRIPTION
`komodor_binpacking_state` is the one telegraf input on the metrics Deployment that is genuinely
cost-related, and under `profile=cost` it is broken. It runs informers over the cluster's
schedulable state, and every one of them is refused.

Measured on a cost-profile cluster, one hour: 1,243 telegraf error lines, all permission denials.
About 870 of those are this input retrying informers that will never sync. Because they never sync,
the input produces no state at all. This is not log noise, it is a cost input returning nothing.

Effective verbs the agent ServiceAccount held on that cluster, from `kubectl auth can-i`:

```
nodes                                 get list        watch missing
poddisruptionbudgets                  -               all missing
persistentvolumes                     -               all missing
persistentvolumeclaims                -               all missing
jobs, cronjobs                        get             list, watch missing
deployments, daemonsets, statefulsets get             list, watch missing
pods, replicasets                     get list watch  fine
```

## The change

Adds the missing `list`/`watch` to `clusterrole-metrics-deployment.yaml`, which is the role bound to
the ServiceAccount the telegraf metrics pod runs as.

Nothing new is being sanctioned on these clusters. `clusterrole-admission-controller.yaml` already
grants this exact set, and renders in full under `profile=cost`. It is bound to the
`komodor-agent-admission-controller` ServiceAccount rather than `komodor-agent`, so the same reads
are already happening on the cluster, just by the other identity. This copies that rule block minus
the writes: no `patch`, no `create`, no `delete`.

Gating the input off instead would contradict the profile, which deliberately keeps
`capabilities.admissionController` and the binpacking and right-sizing webhooks on.

## Effective permission diff

Computed by rendering both profiles, collecting every ClusterRole bound to the agent
ServiceAccount, and unioning the verbs per (apiGroup, resource):

```
default:  no change at all

cost:     apps/daemonsets            [get]            -> [get, list, watch]
          apps/deployments           [get]            -> [get, list, watch]
          apps/statefulsets          [get]            -> [get, list, watch]
          batch/cronjobs             [get]            -> [get, list, watch]
          batch/jobs                 [get]            -> [get, list, watch]
          core/nodes                 [get, list]      -> [get, list, watch]
          core/persistentvolumeclaims                 -> [get, list, watch]
          core/persistentvolumes                      -> [get, list, watch]
          policy/poddisruptionbudgets                 -> [get, list, watch]
```

A default install is untouched because `clusterrole-k8s-watcher.yaml` already grants all of this
there through `allowedResources`. Only the cost profile changes, and it changes by exactly the nine
kinds the informers open.

## Tests

`COST_RBAC_FLOOR` in `values_profile_test.py` already asserts a floor on the ServiceAccount's
effective permissions rather than on any single role, which is the right shape for this. Extended it
with the nine kinds. Reverting the template fails 9 of those assertions.

`replicasets` is in the list and does not fail on revert, because the k8s-watcher role grants it
ungated. Left in as a floor anyway, since the informer needs it and nothing else states that.

145 passed.

## Two lines outside the strict scope

`core/pods` and `autoscaling/horizontalpodautoscalers` floors. Neither needs a chart change, both are
already granted, and both are invisible dependencies of a cost input: HPA survives the profile only
through `capabilities.cost.hpa` at `clusterrole-k8s-watcher.yaml:455`, and nothing pinned it. Say the
word and I will drop them to keep the diff to binpacking alone.


