### PR TITLE
CU-86cbfpxjg - feat(komodor-agent): ask Komodor for the cost telegraf input set under profile=cost

### DIFF
--- a/.buildkite/tests/values_profile_test.py
+++ b/.buildkite/tests/values_profile_test.py
@@ -532,6 +532,30 @@ class TestCostProfile:
         )
         assert any("telegraf" in part for part in metrics["command"])
 
+    def test_cost_profile_asks_komodor_for_the_reduced_input_set(self, cost_render, default_render):
+        """
+        Both the init container and the sidecar fetch the telegraf config, so both have to ask for
+        the same component. The name must match the config directory in
+        services/agents-service/pkg/remote_config_telegraf/configs, and agents-service must know it
+        before this ships: an unknown component is a 400, which telegraf_init panics on.
+        """
+        def components(docs, workload):
+            deployment = next(
+                d for d in docs if d["kind"] == "Deployment" and d["metadata"]["name"] == workload
+            )
+            spec = deployment["spec"]["template"]["spec"]
+            containers = spec["containers"] + spec.get("initContainers", [])
+            return [
+                e["value"]
+                for c in containers
+                for e in c.get("env") or []
+                if e["name"] == "KOMOKW_COMPONENT"
+            ]
+
+        metrics = f"{FULLNAME}-metrics"
+        assert components(cost_render, metrics) == ["komodor-agent-metrics-cost"] * 2
+        assert components(default_render, metrics) == ["komodor-agent-metrics"] * 2
+
     def test_cost_profile_grants_no_wildcard_or_empty_rules(self, cost_render):
         bound = {
             d["roleRef"]["name"]

--- a/charts/komodor-agent/templates/_helpers.tpl
+++ b/charts/komodor-agent/templates/_helpers.tpl
@@ -12,6 +12,19 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
+{{/*
+The remote-config component the metrics Deployment asks Komodor for. A cost install runs a reduced
+set of telegraf inputs, so it asks for a different one. Reads .Values.profile directly rather than a
+key applyProfile writes, so it has no ordering dependency on that helper.
+*/}}
+{{- define "komodorAgent.metricsRemoteConfigComponent" -}}
+{{- if eq (.Values.profile | toString) "cost" -}}
+komodor-agent-metrics-cost
+{{- else -}}
+komodor-agent-metrics
+{{- end -}}
+{{- end }}
+
 {{- define "komodorAgent.fullname" -}}
 {{- if .Values.fullnameOverride }} 
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}

--- a/charts/komodor-agent/templates/metrics/_containers_deployment.tpl
+++ b/charts/komodor-agent/templates/metrics/_containers_deployment.tpl
@@ -58,7 +58,7 @@
   - name: KOMOKW_RUNTIME_MODE
     value: sidecar
   - name: KOMOKW_COMPONENT
-    value: komodor-agent-metrics
+    value: {{ include "komodorAgent.metricsRemoteConfigComponent" . }}
   - name: NAMESPACE
     value: {{ .Release.Namespace }}
   - name: KOMOKW_API_KEY
@@ -90,7 +90,7 @@
   - name: KOMOKW_RUNTIME_MODE
     value: init
   - name: KOMOKW_COMPONENT
-    value: komodor-agent-metrics
+    value: {{ include "komodorAgent.metricsRemoteConfigComponent" . }}
   - name: NAMESPACE
     value: {{ .Release.Namespace }}
   - name: KOMOKW_API_KEY


### PR DESCRIPTION
Companion to komodorio/mono#30531. That PR adds a `komodor-agent-metrics-cost` remote-config
component with a reduced telegraf input set. This makes a `--set profile=cost` install ask for it.

Two literals become one helper:

```
templates/metrics/_containers_deployment.tpl   KOMOKW_COMPONENT on the init container
templates/metrics/_containers_deployment.tpl   KOMOKW_COMPONENT on the sidecar
```

Both fetch the telegraf config, so both have to ask for the same thing. The helper reads
`.Values.profile` directly rather than a key `applyProfile` writes, so it has no ordering dependency
on that include.

## MERGE ORDER MATTERS

`component` is a closed enum on the wire
(`services/agents-service/pkg/remote_config_telegraf/params.go`). Until mono#30531 is in production
in **both** regions, a request naming `komodor-agent-metrics-cost` is a 400. That is not the 403
`HandleConfigFetchError` special-cases, so `telegraf_init` panics in init mode and the metrics pod
CrashLoops.

So: mono#30531 merges and reaches production in US and EU, and only then does a chart carrying this
get released. Merging this PR is safe at any time, cutting a release is not.

## What a cost install stops collecting

Only the three `workload_replicas_*` inputs. `binpacking.conf` and `hpa.conf` stay, and so does
`plugin.conf`: its `external_dns` metrics feed the `EXTERNAL_DNS_NOT_SYNCED` reliability violation,
whose close path only runs on an explicit synced status, so dropping the input would strand any open
violation on that cluster.

## Below the telegraf floor

The cost config is authored against telegraf 2.0.32. An install pinned below that resolves nothing
for the cost component, and mono#30531 falls back to the full `komodor-agent-metrics` config rather
than returning an empty one. The chart default is `v2.0.81-alpine`, so this only affects a cluster
that has deliberately pinned an older telegraf.

## Tests

`test_cost_profile_asks_komodor_for_the_reduced_input_set` asserts both containers on the metrics
Deployment carry the cost component under the profile, and the stock one without it. Reverting
either literal fails it. 146 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeSiKPyLrDyKWabgQMDmsS
